### PR TITLE
MPT-3758, MPT-3759 Add new logic to the migration of already transfer…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ devmock/data/**/*.json
 
 .DS_Store
 .ruff_cache
+.idea

--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -189,11 +189,13 @@ FAKE_CUSTOMERS_IDS = {
     MARKET_SEGMENT_EDUCATION: "1234567890EDU",
 }
 
-ERR_INVALID_DOWNSIZE_QUANTITY =  ValidationError(
+ERR_INVALID_DOWNSIZE_QUANTITY = ValidationError(
     "VIPMV013", "Could not find suitable returnable orders for all items.\n{messages}"
 )
 
-ERR_INVALID_ITEM_DOWNSIZE_QUANTITY_ANY_COMBINATION = " or any combination of these values,"
+ERR_INVALID_ITEM_DOWNSIZE_QUANTITY_ANY_COMBINATION = (
+    " or any combination of these values,"
+)
 
 ERR_INVALID_ITEM_DOWNSIZE_QUANTITY = (
     "Cannot reduce item `{item}` quantity by {delta}. "
@@ -206,4 +208,9 @@ ERR_INVALID_ITEM_DOWNSIZE_FIRST_PO = (
     "is only one returnable order which would reduce the quantity to zero. "
     "Consider placing a Termination order for this subscription instead and "
     "place a new order for {quantity} licenses."
+)
+
+ERR_UPDATING_TRANSFER_ITEMS = (
+    "Do not add or remove items, and do not modify the quantities of any items. "
+    "You may make these changes using a Change order once this order completes."
 )

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -45,7 +45,6 @@ from adobe_vipm.flows.mpt import (
     complete_order,
     create_subscription,
     fail_order,
-    get_product_onetime_items_by_ids,
     get_product_template_or_default,
     get_rendered_template,
     get_subscription_by_external_id,
@@ -62,6 +61,7 @@ from adobe_vipm.flows.utils import (
     get_coterm_date,
     get_next_sync,
     get_notifications_recipient,
+    get_one_time_skus,
     get_order_line_by_sku,
     get_price_item_by_line_sku,
     get_retry_count,
@@ -518,27 +518,6 @@ def send_email_notification(client, order):
             "email",
             context,
         )
-
-
-def get_one_time_skus(client, order):
-    """
-    Get tge SKUs from the order lines that correspond
-    to One-Time items.
-
-    Args:
-        client (MPTClient): The client to consume the MPT API.
-        order (dict): The order from which the One-Time items SKUs
-        must be extracted.
-
-    Returns:
-        list: List of One-Time SKUs.
-    """
-    one_time_items = get_product_onetime_items_by_ids(
-        client,
-        order["agreement"]["product"]["id"],
-        [line["item"]["id"] for line in order["lines"]],
-    )
-    return [item["externalIds"]["vendor"] for item in one_time_items]
 
 
 def set_customer_coterm_date_if_null(client, adobe_client, order):

--- a/adobe_vipm/flows/fulfillment/transfer.py
+++ b/adobe_vipm/flows/fulfillment/transfer.py
@@ -35,7 +35,6 @@ from adobe_vipm.flows.constants import (
 from adobe_vipm.flows.fulfillment.shared import (
     add_subscription,
     check_processing_template,
-    get_one_time_skus,
     handle_retries,
     save_adobe_order_id,
     save_adobe_order_id_and_customer_data,
@@ -48,6 +47,7 @@ from adobe_vipm.flows.sync import sync_agreements_by_agreement_ids
 from adobe_vipm.flows.utils import (
     get_adobe_membership_id,
     get_adobe_order_id,
+    get_one_time_skus,
     get_ordering_parameter,
     set_ordering_parameter_error,
 )

--- a/adobe_vipm/flows/utils.py
+++ b/adobe_vipm/flows/utils.py
@@ -41,6 +41,7 @@ from adobe_vipm.flows.constants import (
     REQUIRED_CUSTOMER_ORDER_PARAMS,
     STATUS_MARKET_SEGMENT_PENDING,
 )
+from adobe_vipm.flows.mpt import get_product_onetime_items_by_ids
 from adobe_vipm.notifications import send_exception
 from adobe_vipm.utils import find_first
 
@@ -435,8 +436,12 @@ def split_downsizes_and_upsizes(order):
         tuple: (downsizes, upsizes)
     """
     return (
-        list(filter(lambda line: line["quantity"] < line["oldQuantity"], order["lines"])),
-        list(filter(lambda line: line["quantity"] > line["oldQuantity"], order["lines"])),
+        list(
+            filter(lambda line: line["quantity"] < line["oldQuantity"], order["lines"])
+        ),
+        list(
+            filter(lambda line: line["quantity"] > line["oldQuantity"], order["lines"])
+        ),
     )
 
 
@@ -626,6 +631,19 @@ def is_transferring_item_expired(item):
     return date.today() > renewal_date
 
 
+def are_all_transferring_items_expired(adobe_items):
+    """
+    Check if all Adobe subscriptions to be transferred are expired.
+    Args:
+        adobe_items (list): List of adobe items to be transferred.
+        must be extracted.
+
+    Returns:
+        bool: True if all Adobe subscriptions are expired, False otherwise.
+    """
+    return all(is_transferring_item_expired(item) for item in adobe_items)
+
+
 def get_transfer_item_sku_by_subscription(trf, sub_id):
     item = find_first(
         lambda x: x["subscriptionId"] == sub_id,
@@ -700,12 +718,15 @@ def is_renewal_window_open(order):
 
 def map_returnable_to_return_orders(returnable_orders, return_orders):
     mapped = []
+
     def filter_by_reference_order(reference_order_id, item):
         return item["referenceOrderId"] == reference_order_id
 
     for returnable_order in returnable_orders:
         return_order = find_first(
-            functools.partial(filter_by_reference_order, returnable_order.order["orderId"]),
+            functools.partial(
+                filter_by_reference_order, returnable_order.order["orderId"]
+            ),
             return_orders,
         )
         mapped.append((returnable_order, return_order))
@@ -717,3 +738,24 @@ def set_template(order, template):
     updated_order = copy.deepcopy(order)
     updated_order["template"] = template
     return updated_order
+
+
+def get_one_time_skus(client, order):
+    """
+    Get tge SKUs from the order lines that correspond
+    to One-Time items.
+
+    Args:
+        client (MPTClient): The client to consume the MPT API.
+        order (dict): The order from which the One-Time items SKUs
+        must be extracted.
+
+    Returns:
+        list: List of One-Time SKUs.
+    """
+    one_time_items = get_product_onetime_items_by_ids(
+        client,
+        order["agreement"]["product"]["id"],
+        [line["item"]["id"] for line in order["lines"]],
+    )
+    return [item["externalIds"]["vendor"] for item in one_time_items]

--- a/adobe_vipm/flows/validation/transfer.py
+++ b/adobe_vipm/flows/validation/transfer.py
@@ -22,15 +22,19 @@ from adobe_vipm.flows.constants import (
     ERR_ADOBE_MEMBERSHIP_ID_ITEM,
     ERR_ADOBE_MEMBERSHIP_NOT_FOUND,
     ERR_ADOBE_UNEXPECTED_ERROR,
+    ERR_UPDATING_TRANSFER_ITEMS,
     PARAM_MEMBERSHIP_ID,
 )
 from adobe_vipm.flows.mpt import get_product_items_by_skus
 from adobe_vipm.flows.utils import (
+    are_all_transferring_items_expired,
     get_adobe_membership_id,
+    get_one_time_skus,
     get_order_line_by_sku,
     get_ordering_parameter,
     get_transfer_item_sku_by_subscription,
     is_transferring_item_expired,
+    set_order_error,
     set_ordering_parameter_error,
 )
 from adobe_vipm.utils import get_partial_sku
@@ -69,37 +73,91 @@ def get_prices(order, commitment, adobe_skus):
         return get_prices_for_skus(product_id, currency, adobe_skus)
 
 
-
-def add_lines_to_order(mpt_client, order, adobe_object, commitment, quantity_field):
+def has_order_line_updated(order_lines, adobe_items, quantity_field):
     """
-    Add the lines that belongs to the provided Adobe VIP membership to the current order.
-    Updates the purchase price of each line according to the customer discount level/benefits.
-
-
+    Compare order lines and Adobe items to be transferred
     Args:
-        mpt_client (MPTClient): The client used to consume the MPT API.
-        order (dict): The order to validate.
-        adobe_object (dict): Either a transfer preview object or a list of subscriptions object.
-        commitment (dict): Either the customer 3y commitment data or None if the customer doesn't
-        have such benefit.
+        order_lines (list): List of order lines
+        adobe_items (list): List of adobe items to be transferred.
         quantity_field (str): The name of the field that contains the quantity depending on the
         provided `adobe_object` argument.
 
     Returns:
+        bool: True if order line is not equal to adobe items, False otherwise.
+
+    """
+    order_line_map = {
+        order_line["item"]["externalIds"]["vendor"]: order_line["quantity"]
+        for order_line in order_lines
+    }
+
+    adobe_items_map = {
+        get_partial_sku(adobe_item["offerId"]): adobe_item[quantity_field]
+        for adobe_item in adobe_items
+    }
+    return order_line_map != adobe_items_map
+
+
+def add_lines_to_order(
+    mpt_client, order, adobe_items, commitment, quantity_field, is_transferred=False
+):
+    """
+    Add the lines that belongs to the provided Adobe VIP membership to the current order.
+    Updates the purchase price of each line according to the customer discount level/benefits.
+
+    Args:
+        mpt_client (MPTClient): The client used to consume the MPT API.
+        order (dict): The order to validate.
+        adobe_items (list): List of Adobe subscriptions to be migrated.
+        commitment (dict): Either the customer 3y commitment data or None if the customer doesn't
+        have such benefit.
+        quantity_field (str): The name of the field that contains the quantity depending on the
+        provided `adobe_object` argument.
+        is_transferred (bool): True if the order has already been transferred, False otherwise.
+
+    Returns:
         tuple: (True, order) if there is an error adding the lines, (False, order) otherwise.
     """
-    returned_skus = [
-        get_partial_sku(item["offerId"])
-        for item in adobe_object["items"]
-        if not is_transferring_item_expired(item)
-    ]
-    returned_full_skus = [
-        item["offerId"]
-        for item in adobe_object["items"]
-        if not is_transferring_item_expired(item)
-    ]
 
-    if not returned_skus:
+    order_error = False
+
+    if is_transferred:
+        one_time_skus = get_one_time_skus(mpt_client, order)
+
+        adobe_items_without_one_time_offers = [
+            item
+            for item in adobe_items
+            if get_partial_sku(item["offerId"]) not in one_time_skus
+        ]
+
+        if are_all_transferring_items_expired(adobe_items_without_one_time_offers):
+
+            # If the order already has items and all the items on Adobe to be migrated are
+            # expired, the user can add, edit or delete the expired subscriptions
+            if len(order["lines"]):
+                return False, order
+
+            adobe_items = adobe_items_without_one_time_offers
+
+        else:
+            # remove expired items from adobe items
+            adobe_items = [
+                item for item in adobe_items if not is_transferring_item_expired(item)
+            ]
+
+            # If the order items has been updated, the validation order will fail
+            if len(order["lines"]) and has_order_line_updated(
+                order["lines"], adobe_items, quantity_field
+            ):
+                order_error = True
+                order = set_order_error(order, ERR_UPDATING_TRANSFER_ITEMS)
+    else:
+        # remove expired items from adobe items
+        adobe_items = [
+            item for item in adobe_items if not is_transferring_item_expired(item)
+        ]
+
+    if len(adobe_items) == 0:
         param = get_ordering_parameter(order, PARAM_MEMBERSHIP_ID)
         order = set_ordering_parameter_error(
             order,
@@ -108,6 +166,8 @@ def add_lines_to_order(mpt_client, order, adobe_object, commitment, quantity_fie
         )
         return True, order
 
+    returned_skus = [get_partial_sku(item["offerId"]) for item in adobe_items]
+    returned_full_skus = [item["offerId"] for item in adobe_items]
     prices = get_prices(order, commitment, returned_full_skus)
 
     items_map = {
@@ -116,10 +176,8 @@ def add_lines_to_order(mpt_client, order, adobe_object, commitment, quantity_fie
             mpt_client, order["agreement"]["product"]["id"], returned_skus
         )
     }
-    valid_adobe_lines = []
-    for adobe_line in adobe_object["items"]:
-        if is_transferring_item_expired(adobe_line):
-            continue
+
+    for adobe_line in adobe_items:
         item = items_map.get(get_partial_sku(adobe_line["offerId"]))
         if not item:
             param = get_ordering_parameter(order, PARAM_MEMBERSHIP_ID)
@@ -147,8 +205,6 @@ def add_lines_to_order(mpt_client, order, adobe_object, commitment, quantity_fie
             new_line["price"]["unitPP"] = prices.get(adobe_line["offerId"], 0)
             order["lines"].append(new_line)
 
-        valid_adobe_lines.append(adobe_line)
-
     lines = [
         line
         for line in order["lines"]
@@ -156,7 +212,7 @@ def add_lines_to_order(mpt_client, order, adobe_object, commitment, quantity_fie
     ]
     order["lines"] = lines
 
-    return False, order
+    return order_error, order
 
 
 def validate_transfer_not_migrated(mpt_client, adobe_client, order):
@@ -202,7 +258,9 @@ def validate_transfer_not_migrated(mpt_client, adobe_client, order):
         )
         return True, order
     commitment = get_3yc_commitment(transfer_preview)
-    return add_lines_to_order(mpt_client, order, transfer_preview, commitment, "quantity")
+    return add_lines_to_order(
+        mpt_client, order, transfer_preview["items"], commitment, "quantity"
+    )
 
 
 def validate_transfer(mpt_client, adobe_client, order):
@@ -282,4 +340,11 @@ def validate_transfer(mpt_client, adobe_client, order):
         subscription["offerId"] = correct_sku or subscription["offerId"]
     customer = adobe_client.get_customer(authorization_id, transfer.customer_id)
     commitment = get_3yc_commitment(customer)
-    return add_lines_to_order(mpt_client, order, subscriptions, commitment, "currentQuantity")
+
+    # If there is no subscription to transfer, the order is valid
+    if len(subscriptions["items"]) == 0:
+        return False, order
+
+    return add_lines_to_order(
+        mpt_client, order, subscriptions["items"], commitment, "currentQuantity", True
+    )

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -114,7 +114,7 @@ def test_transfer(
         return_value=subscription,
     )
     mocked_get_onetime = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.get_product_onetime_items_by_ids",
+        "adobe_vipm.flows.utils.get_product_onetime_items_by_ids",
         return_value=items_factory(item_id=2, external_vendor_id="99999999CA"),
     )
 
@@ -813,7 +813,7 @@ def test_fulfill_transfer_order_already_migrated(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.get_product_onetime_items_by_ids",
+        "adobe_vipm.flows.utils.get_product_onetime_items_by_ids",
         return_value=items_factory(item_id=2, external_vendor_id="99999999CA"),
     )
 
@@ -1010,7 +1010,7 @@ def test_fulfill_transfer_order_already_migrated_3yc(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.get_product_onetime_items_by_ids",
+        "adobe_vipm.flows.utils.get_product_onetime_items_by_ids",
         return_value=[],
     )
 
@@ -1304,7 +1304,7 @@ def test_transfer_3yc_customer(
         return_value=subscription,
     )
     mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.get_product_onetime_items_by_ids",
+        "adobe_vipm.flows.utils.get_product_onetime_items_by_ids",
         return_value=[],
     )
 


### PR DESCRIPTION
Migrating an already transferred Adobe account with an expired subscription will require additional validations to avoid manual processes.