### PR TITLE
Change order updated to support global customers

### DIFF
--- a/adobe_vipm/flows/context.py
+++ b/adobe_vipm/flows/context.py
@@ -25,6 +25,7 @@ class Context:
     adobe_new_order: dict | None = None
     adobe_returnable_orders: dict = field(default_factory=dict)
     adobe_return_orders: dict = field(default_factory=dict)
+    deployment_id: str | None = None
 
     def __str__(self):
         due_date = self.due_date.strftime("%Y-%m-%d") if self.due_date else "-"

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -24,7 +24,10 @@ from adobe_vipm.adobe.utils import (
     sanitize_company_name,
     sanitize_first_last_name,
 )
-from adobe_vipm.flows.airtable import get_prices_for_3yc_skus, get_prices_for_skus
+from adobe_vipm.flows.airtable import (
+    get_prices_for_3yc_skus,
+    get_prices_for_skus,
+)
 from adobe_vipm.flows.constants import (
     MPT_ORDER_STATUS_COMPLETED,
     MPT_ORDER_STATUS_PROCESSING,
@@ -59,6 +62,7 @@ from adobe_vipm.flows.sync import sync_agreements_by_agreement_ids
 from adobe_vipm.flows.utils import (
     get_adobe_customer_id,
     get_coterm_date,
+    get_deployment_id,
     get_due_date,
     get_next_sync,
     get_notifications_recipient,
@@ -660,24 +664,31 @@ class SubmitReturnOrders(Step):
     def __call__(self, client, context, next_step):
         adobe_client = get_adobe_client()
         all_return_orders = []
+        deployment_id = get_deployment_id(context.order)
+        is_returnable = False
         for sku, returnable_orders in context.adobe_returnable_orders.items():
             return_orders = context.adobe_return_orders.get(sku, [])
             for returnable_order, return_order in map_returnable_to_return_orders(
                 returnable_orders or [], return_orders
             ):
-                if return_order:
-                    all_return_orders.append(return_order)
-                    continue
-
-                all_return_orders.append(
-                    adobe_client.create_return_order(
-                        context.authorization_id,
-                        context.adobe_customer_id,
-                        returnable_order.order,
-                        returnable_order.line,
-                        context.order_id,
-                    )
+                returnable_order_deployment_id = returnable_order.line.get("deploymentId", None)
+                is_returnable = (
+                    (deployment_id == returnable_order_deployment_id) if deployment_id else True
                 )
+                if is_returnable:
+                    if return_order:
+                        all_return_orders.append(return_order)
+                        continue
+                    all_return_orders.append(
+                        adobe_client.create_return_order(
+                            context.authorization_id,
+                            context.adobe_customer_id,
+                            returnable_order.order,
+                            returnable_order.line,
+                            context.order_id,
+                            deployment_id,
+                        )
+                    )
         pending_orders = [
             return_order["orderId"]
             for return_order in all_return_orders
@@ -706,11 +717,13 @@ class GetPreviewOrder(Step):
         adobe_client = get_adobe_client()
         if context.upsize_lines and not context.adobe_new_order_id:
             try:
+                deployment_id = get_deployment_id(context.order)
                 context.adobe_preview_order = adobe_client.create_preview_order(
                     context.authorization_id,
                     context.adobe_customer_id,
                     context.order_id,
                     context.upsize_lines,
+                    deployment_id=deployment_id,
                 )
             except AdobeError as e:
                 switch_order_to_failed(client, context.order, str(e))
@@ -733,10 +746,12 @@ class SubmitNewOrder(Step):
         adobe_client = get_adobe_client()
         adobe_order = None
         if not context.adobe_new_order_id:
+            deployment_id = get_deployment_id(context.order)
             adobe_order = adobe_client.create_new_order(
                 context.authorization_id,
                 context.adobe_customer_id,
                 context.adobe_preview_order,
+                deployment_id=deployment_id,
             )
             logger.info(f'{context}: new adobe order created: {adobe_order["orderId"]}')
             context.order = set_adobe_order_id(context.order, adobe_order["orderId"])

--- a/adobe_vipm/flows/utils.py
+++ b/adobe_vipm/flows/utils.py
@@ -928,3 +928,19 @@ def exclude_subscriptions_with_deployment_id(adobe_subscriptions):
     ]
     adobe_subscriptions["items"] = items
     return adobe_subscriptions
+
+
+def get_deployment_id(source):
+    """
+    Get the deploymentId parameter from the source.
+    Args:
+        source (dict): The order to update.
+
+    Returns:
+        string: The value of the deploymentId parameter.
+    """
+    param = get_fulfillment_parameter(
+        source,
+        "deploymentId",
+    )
+    return param.get("value")

--- a/adobe_vipm/flows/validation/shared.py
+++ b/adobe_vipm/flows/validation/shared.py
@@ -10,7 +10,7 @@ from adobe_vipm.flows.constants import (
     FAKE_CUSTOMERS_IDS,
 )
 from adobe_vipm.flows.pipeline import Step
-from adobe_vipm.flows.utils import set_order_error
+from adobe_vipm.flows.utils import get_deployment_id, set_order_error
 
 logger = logging.getLogger(__name__)
 
@@ -75,12 +75,14 @@ class GetPreviewOrder(Step):
         customer_id = (
             context.adobe_customer_id or FAKE_CUSTOMERS_IDS[context.market_segment]
         )
+        deployment_id = get_deployment_id(context.order)
         try:
             context.adobe_preview_order = adobe_client.create_preview_order(
                 context.authorization_id,
                 customer_id,
                 context.order_id,
                 context.upsize_lines,
+                deployment_id=deployment_id,
             )
         except AdobeAPIError as e:
             context.validation_succeeded = False

--- a/tests/flows/fulfillment/test_change.py
+++ b/tests/flows/fulfillment/test_change.py
@@ -528,6 +528,7 @@ def test_validate_downsize_3yc_orders_step_error_minimum_quantity_generic(
         adobe_customer_id=adobe_customer["customerId"],
         adobe_customer=adobe_customer,
         adobe_return_orders={},
+        deployment_id="",
     )
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -3665,6 +3665,7 @@ def test_transfer_gc_account_some_deployments_not_created(
             deployment_id="deployment-id",
             currencyCode="EUR",
             offer_id="653045798CA01A12",
+            deployment_currency_code="EUR",
         )
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
         + adobe_items_factory(
@@ -3673,6 +3674,7 @@ def test_transfer_gc_account_some_deployments_not_created(
             subscription_id="one-time-sub-id",
             deployment_id="deployment-id-2",
             currencyCode="EUR",
+            deployment_currency_code="EUR",
         )
         + adobe_items_factory(
             line_number=4,
@@ -3680,6 +3682,7 @@ def test_transfer_gc_account_some_deployments_not_created(
             deployment_id="deployment-id",
             currencyCode="USD",
             offer_id="65304579CA01A12",
+            deployment_currency_code="USD",
         ),
     )
 
@@ -3710,11 +3713,13 @@ def test_transfer_gc_account_some_deployments_not_created(
                 "deploymentId": "deployment-id",
                 "status": "1000",
                 "companyProfile": {"address": {"country": "DE"}},
+                "currencyCode": "EUR",
             },
             {
                 "deploymentId": "deployment-id-2",
                 "status": "1000",
                 "companyProfile": {"address": {"country": "ES"}},
+                "currencyCode": "EUR",
             },
         ],
     }


### PR DESCRIPTION
If the agreement belongs to an Adobe deployment, a new logic will be added to manage only the Adobe orders for this deployment:

New Adobe orders will be created for the selected deployment

Upsize/Downsize orders will include the deployment ID

New logic will be added to manage return orders only for the selected deployment ID

If a Upsize/Downsize order is created in the main order for an item with deployment ID the change order will fail 

New logic added to manage return orders applied to termination.

Deployment id added to line item and if deployment id exists, currency code is moved to line item.

https://softwareone.atlassian.net/browse/MPT-5142
https://softwareone.atlassian.net/browse/MPT-5143