### PR TITLE
[BACKPORT] #MPT-6939 Remove hardcoded SKU from config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,7 @@ EXT_ADOBE_AUTH_ENDPOINT_URL=https://authenticate.adobe
 EXT_WEBHOOKS_SECRETS={"PRD-1111-1111": "<super-jwt-secret>"}
 EXT_AIRTABLE_API_TOKEN=<super-secret-at-token>
 EXT_AIRTABLE_BASES="{\"PRD-1111-1111\": \"appunZZ4VRFI2DPkk\"}"
+EXT_AIRTABLE_SKU_MAPPING_BASE=appXyZxYzXyZxYzXy
 EXT_NAV_API_BASE_URL=https://api.nav
 EXT_NAV_AUTH_ENDPOINT_URL=https://authenticate.nav
 EXT_NAV_AUTH_CLIENT_ID=<client-id>

--- a/README.md
+++ b/README.md
@@ -172,25 +172,28 @@ Find generated data in the `devmock/data` folder. Extension automatically retrie
 # Configuration
 
 ## Application
-| Environment Variable | Default | Example | Description |
-| --- | --- | --- | --- |
-| `EXT_ADOBE_CREDENTIALS_FILE` | - | /extension/adobe_secrets.json | Path to Adobe credentials file |
-| `EXT_ADOBE_AUTHORIZATIONS_FILE` | - | /extension/adobe_authorizations.json | Path to Adobe authorizations file |
-| `EXT_ADOBE_API_BASE_URL` | - | https://partner-example.adobe.io | Path to Adobe VIPM API |
-| `EXT_ADOBE_AUTH_ENDPOINT_URL` | - | https://auth.partner-example.adobe.io | Path to Adobe VIPM authentication API |
-| `EXT_WEBHOOKS_SECRETS` | - |  {"PRD-1111-1111": "123qweasd3432234"} | Webhook secret of the Draft validation Webhook in SoftwareONE Marketplace for the product |
-| `MPT_PRODUCTS_IDS` | PRD-1111-1111 | PRD-1234-1234,PRD-4321-4321 | Comma-separated list of SoftwareONE Marketplace Product ID |
-| `MPT_API_BASE_URL` | http://localhost:8000 | https://portal.softwareone.com/mpt | SoftwareONE Marketplace API URL |
-| `MPT_API_TOKEN` | - | eyJhbGciOiJSUzI1N... | SoftwareONE Marketplace API Token |
+| Environment Variable            | Default               | Example                               | Description                                                                               |
+|---------------------------------|-----------------------|---------------------------------------|-------------------------------------------------------------------------------------------|
+| `EXT_ADOBE_CREDENTIALS_FILE`    | -                     | /extension/adobe_secrets.json         | Path to Adobe credentials file                                                            |
+| `EXT_ADOBE_AUTHORIZATIONS_FILE` | -                     | /extension/adobe_authorizations.json  | Path to Adobe authorizations file                                                         |
+| `EXT_ADOBE_API_BASE_URL`        | -                     | https://partner-example.adobe.io      | Path to Adobe VIPM API                                                                    |
+| `EXT_ADOBE_AUTH_ENDPOINT_URL`   | -                     | https://auth.partner-example.adobe.io | Path to Adobe VIPM authentication API                                                     |
+| `EXT_AIRTABLE_SKU_MAPPING_BASE` | -                     | appXXXXXXXXXXXXXXXX                   | Airtable base ID for the SKU mapping                                                      |
+| `EXT_WEBHOOKS_SECRETS`          | -                     | {"PRD-1111-1111": "123qweasd3432234"} | Webhook secret of the Draft validation Webhook in SoftwareONE Marketplace for the product |
+| `MPT_PRODUCTS_IDS`              | PRD-1111-1111         | PRD-1234-1234,PRD-4321-4321           | Comma-separated list of SoftwareONE Marketplace Product ID                                |
+| `MPT_API_BASE_URL`              | http://localhost:8000 | https://portal.softwareone.com/mpt    | SoftwareONE Marketplace API URL                                                           |
+| `MPT_API_TOKEN`                 | -                     | eyJhbGciOiJSUzI1N...                  | SoftwareONE Marketplace API Token                                                         |
+    
+    
 
 ## Azure AppInsights
-| Environment Variable | Default | Example | Description |
-| --- | --- | --- | --- |
-| `SERVICE_NAME` | Swo.Extensions.AdobeVIPM | Swo.Extensions.AdobeVIPM | Service name that is visible in the AppInsights logs |
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | - | InstrumentationKey=cf280af3-b686-40fd-8183-ec87468c12ba;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/ | Azure Application Insights connection string |
-| `LOGGING_ATTEMPT_GETTER` | adobe_vipm.utils.get_attempt_count | adobe_vipm.utils.get_attempt_count | Path to python function that retrieves order processing attempt to put it into the Azure Application Insights |
+| Environment Variable                    | Default                            | Example                                                                                                                                                                                             | Description                                                                                                   |
+|-----------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `SERVICE_NAME`                          | Swo.Extensions.AdobeVIPM           | Swo.Extensions.AdobeVIPM                                                                                                                                                                            | Service name that is visible in the AppInsights logs                                                          |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | -                                  | InstrumentationKey=cf280af3-b686-40fd-8183-ec87468c12ba;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/ | Azure Application Insights connection string                                                                  |
+| `LOGGING_ATTEMPT_GETTER`                | adobe_vipm.utils.get_attempt_count | adobe_vipm.utils.get_attempt_count                                                                                                                                                                  | Path to python function that retrieves order processing attempt to put it into the Azure Application Insights |
 
 ## Other
-| Environment Variable | Default | Example | Description |
-| --- | --- | --- | --- |
-| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | 120| 60 | Orders polling interval from the Software Marketplace API in seconds |
+| Environment Variable                   | Default | Example | Description                                                          |
+|----------------------------------------|---------|---------|----------------------------------------------------------------------|
+| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | 120     | 60      | Orders polling interval from the Software Marketplace API in seconds |

--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -23,7 +23,6 @@ from adobe_vipm.adobe.constants import (
     STATUS_PROCESSED,
 )
 from adobe_vipm.adobe.dataclasses import (
-    AdobeProduct,
     APIToken,
     Authorization,
     Reseller,
@@ -36,6 +35,7 @@ from adobe_vipm.adobe.utils import (
     join_phone_number,
     to_adobe_line_id,
 )
+from adobe_vipm.airtable.models import get_adobe_product_by_marketplace_sku
 from adobe_vipm.utils import get_partial_sku
 
 logger = logging.getLogger(__name__)
@@ -433,9 +433,9 @@ class AdobeClient:
         if not deployment_id:
             payload["currencyCode"] = authorization.currency
         for line in lines:
-            product: AdobeProduct = self._config.get_adobe_product(
+            product_sku = get_adobe_product_by_marketplace_sku(
                 line["item"]["externalIds"]["vendor"]
-            )
+            ).sku
             quantity = line["quantity"]
             old_quantity = line["oldQuantity"]
 
@@ -449,7 +449,7 @@ class AdobeClient:
                 quantity = quantity - old_quantity
             line_item = {
                 "extLineItemNumber": to_adobe_line_id(line["id"]),
-                "offerId": product.sku,
+                "offerId": product_sku,
                 "quantity": quantity,
             }
             if deployment_id:
@@ -948,7 +948,6 @@ class AdobeClient:
 
         response.raise_for_status()
         return response.json()
-
 
 
 _ADOBE_CLIENT = None

--- a/adobe_vipm/adobe/dataclasses.py
+++ b/adobe_vipm/adobe/dataclasses.py
@@ -43,13 +43,6 @@ class APIToken:
 
 
 @dataclass(frozen=True)
-class AdobeProduct:
-    sku: str
-    name: str
-    type: str
-
-
-@dataclass(frozen=True)
 class Country:
     code: str
     name: str

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -24,7 +24,7 @@ from adobe_vipm.adobe.utils import (
     sanitize_company_name,
     sanitize_first_last_name,
 )
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     get_prices_for_3yc_skus,
     get_prices_for_skus,
 )

--- a/adobe_vipm/flows/fulfillment/transfer.py
+++ b/adobe_vipm/flows/fulfillment/transfer.py
@@ -21,7 +21,7 @@ from adobe_vipm.adobe.constants import (
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeHttpError
 from adobe_vipm.adobe.utils import get_3yc_commitment
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_GC_CREATED,
     STATUS_GC_ERROR,
     STATUS_GC_PENDING,

--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -6,7 +6,7 @@ from swo.mpt.extensions.core.utils import setup_client
 
 from adobe_vipm.adobe.client import get_adobe_client
 from adobe_vipm.adobe.utils import sanitize_company_name, sanitize_first_last_name
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_GC_CREATED,
     STATUS_GC_ERROR,
     get_gc_agreement_deployments_to_check,

--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -16,7 +16,7 @@ from adobe_vipm.adobe.errors import (
     ResellerNotFoundError,
 )
 from adobe_vipm.adobe.utils import get_3yc_commitment
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_GC_PENDING,
     create_gc_main_agreement,
     create_offers,

--- a/adobe_vipm/flows/sync.py
+++ b/adobe_vipm/flows/sync.py
@@ -3,10 +3,13 @@ import sys
 from datetime import date, datetime, timedelta
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.config import get_config
 from adobe_vipm.adobe.constants import STATUS_3YC_ACTIVE, STATUS_3YC_COMMITTED
 from adobe_vipm.adobe.utils import get_3yc_commitment
-from adobe_vipm.flows.airtable import get_prices_for_3yc_skus, get_prices_for_skus
+from adobe_vipm.airtable.models import (
+    get_adobe_product_by_marketplace_sku,
+    get_prices_for_3yc_skus,
+    get_prices_for_skus,
+)
 from adobe_vipm.flows.constants import (
     PARAM_ADOBE_SKU,
     PARAM_CURRENT_QUANTITY,
@@ -53,7 +56,6 @@ def sync_agreement_prices(mpt_client, agreement, dry_run, adobe_client, customer
     agreement_id = agreement["id"]
 
     try:
-        adobe_config = get_config()
         authorization_id = agreement["authorization"]["id"]
         customer_id = get_adobe_customer_id(agreement)
         currency = agreement["listing"]["priceList"]["currency"]
@@ -167,7 +169,7 @@ def sync_agreement_prices(mpt_client, agreement, dry_run, adobe_client, customer
 
         to_update = []
         for line in agreement["lines"]:
-            actual_sku = adobe_config.get_adobe_product(
+            actual_sku = get_adobe_product_by_marketplace_sku(
                 line["item"]["externalIds"]["vendor"]
             ).sku
             discount_level = (

--- a/adobe_vipm/flows/validation/purchase.py
+++ b/adobe_vipm/flows/validation/purchase.py
@@ -19,7 +19,7 @@ from adobe_vipm.adobe.validation import (
     is_valid_postal_code_length,
     is_valid_state_or_province,
 )
-from adobe_vipm.flows.airtable import get_prices_for_skus
+from adobe_vipm.airtable.models import get_prices_for_skus
 from adobe_vipm.flows.constants import (
     ERR_3YC_NO_MINIMUMS,
     ERR_3YC_QUANTITY_CONSUMABLES,

--- a/adobe_vipm/flows/validation/transfer.py
+++ b/adobe_vipm/flows/validation/transfer.py
@@ -8,7 +8,7 @@ from adobe_vipm.adobe.constants import (
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeHttpError
 from adobe_vipm.adobe.utils import get_3yc_commitment
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_RUNNING,
     STATUS_SYNCHRONIZED,
     get_prices_for_3yc_skus,

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -269,10 +269,17 @@ def test_create_preview_order(
     quantity,
     old_quantity,
     expected_quantity,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     """
     Test the call to Adobe API to create a preview order.
     """
+
+    mocker.patch(
+        "adobe_vipm.adobe.client.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
+    )
+
     mocker.patch(
         "adobe_vipm.adobe.client.uuid4",
         side_effect=["uuid-1", "uuid-2"],
@@ -363,6 +370,7 @@ def test_create_preview_order_no_deployment(
     quantity,
     old_quantity,
     expected_quantity,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     """
     Test the call to Adobe API to create a preview order.
@@ -370,6 +378,11 @@ def test_create_preview_order_no_deployment(
     mocker.patch(
         "adobe_vipm.adobe.client.uuid4",
         side_effect=["uuid-1", "uuid-2"],
+    )
+
+    mocker.patch(
+        "adobe_vipm.adobe.client.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
     authorization_uk = adobe_authorizations_file["authorizations"][0][
         "authorization_uk"
@@ -437,16 +450,24 @@ def test_create_preview_order_no_deployment(
 
 
 def test_create_preview_order_bad_request(
+    mocker,
     requests_mocker,
     settings,
     adobe_authorizations_file,
     adobe_api_error_factory,
     adobe_client_factory,
     order,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     """
     Test the call to Adobe API to create a preview order when the response is 400 bad request.
     """
+
+    mocker.patch(
+        "adobe_vipm.adobe.client.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
+    )
+
     order["lines"][0]["item"]["externalIds"] = {"vendor": "65304578CA"}
     authorization_uk = adobe_authorizations_file["authorizations"][0][
         "authorization_uk"
@@ -504,9 +525,7 @@ def test_create_new_order(
     client, authorization, api_token = adobe_client_factory()
 
     adobe_order = adobe_order_factory(
-        ORDER_TYPE_NEW,
-        external_id="mpt-order-id",
-        deployment_id=deployment_id
+        ORDER_TYPE_NEW, external_id="mpt-order-id", deployment_id=deployment_id
     )
 
     requests_mocker.post(
@@ -569,9 +588,7 @@ def test_create_new_order_no_deployment(
     client, authorization, api_token = adobe_client_factory()
 
     adobe_order = adobe_order_factory(
-        ORDER_TYPE_NEW,
-        external_id="mpt-order-id",
-        deployment_id=deployment_id
+        ORDER_TYPE_NEW, external_id="mpt-order-id", deployment_id=deployment_id
     )
 
     requests_mocker.post(
@@ -928,8 +945,7 @@ def test_create_return_order(
         reference_order_id=returning_order["orderId"],
         external_id=expected_external_id,
         items=adobe_items_factory(
-            deployment_id=deployment_id,
-            deployment_currency_code="USD"
+            deployment_id=deployment_id, deployment_currency_code="USD"
         ),
         deployment_id=deployment_id,
     )

--- a/tests/adobe/test_config.py
+++ b/tests/adobe/test_config.py
@@ -4,13 +4,11 @@ import pytest
 
 from adobe_vipm.adobe.config import Config
 from adobe_vipm.adobe.dataclasses import (
-    AdobeProduct,
     Authorization,
     Country,
     Reseller,
 )
 from adobe_vipm.adobe.errors import (
-    AdobeProductNotFoundError,
     AuthorizationNotFoundError,
     CountryNotFoundError,
     ResellerNotFoundError,
@@ -113,35 +111,6 @@ def test_get_authorization_not_found(mock_adobe_config):
         assert c.get_authorization("does-not-exist")
 
     assert str(cv.value) == "Authorization with uk/id does-not-exist not found."
-
-
-def test_get_adobe_product(mock_adobe_config, adobe_config_file):
-    """
-    Test the lookup the Product object by product item identifier.
-    """
-    vendor_external_id = adobe_config_file["skus_mapping"][0]["vendor_external_id"]
-    name = adobe_config_file["skus_mapping"][0]["name"]
-    sku = adobe_config_file["skus_mapping"][0]["sku"]
-    type = adobe_config_file["skus_mapping"][0]["type"]
-
-    c = Config()
-    product = c.get_adobe_product(vendor_external_id)
-    assert isinstance(product, AdobeProduct)
-    assert product.sku == sku
-    assert product.name == name
-    assert product.type == type
-
-
-def test_get_adobe_product_not_found(mock_adobe_config):
-    """
-    Check that the lookup of the product raises `ProductNotFound`
-    if there is no product for a given product item id.
-    """
-    c = Config()
-    with pytest.raises(AdobeProductNotFoundError) as cv:
-        assert c.get_adobe_product("not-found")
-
-    assert str(cv.value) == "AdobeProduct with id not-found not found."
 
 
 def test_get_country(mock_adobe_config, adobe_config_file):

--- a/tests/commands/test_check_gc_agreement_delployment.py
+++ b/tests/commands/test_check_gc_agreement_delployment.py
@@ -2,7 +2,9 @@ from django.core.management import call_command
 
 
 def test_process_transfers(mocker):
-    mocked = mocker.patch("adobe_vipm.flows.global_customer.check_gc_agreement_deployments")
+    mocked = mocker.patch(
+        "adobe_vipm.flows.global_customer.check_gc_agreement_deployments"
+    )
 
     call_command("check_gc_agreement_deployments")
 

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -627,7 +627,11 @@ def test_set_or_update_coterm_next_sync_dates_step_are_in_sync(
 
 
 def test_submit_return_orders_step(
-    mocker, order_factory, adobe_order_factory, adobe_items_factory, settings,
+    mocker,
+    order_factory,
+    adobe_order_factory,
+    adobe_items_factory,
+    settings,
 ):
     """
     Tests the creation of a return order for a returnable order.
@@ -689,7 +693,11 @@ def test_submit_return_orders_step(
 
 
 def test_submit_return_orders_step_with_deployment_id(
-    mocker, order_factory, adobe_order_factory, adobe_items_factory, settings,
+    mocker,
+    order_factory,
+    adobe_order_factory,
+    adobe_items_factory,
+    settings,
 ):
     """
     Tests the creation of a return order for a returnable order.
@@ -761,7 +769,11 @@ def test_submit_return_orders_step_with_deployment_id(
 
 
 def test_submit_return_orders_step_with_only_main_deployment_id(
-    mocker, order_factory, adobe_order_factory, adobe_items_factory, settings,
+    mocker,
+    order_factory,
+    adobe_order_factory,
+    adobe_items_factory,
+    settings,
 ):
     """
     Tests the creation of a return order for a returnable order.
@@ -819,7 +831,11 @@ def test_submit_return_orders_step_with_only_main_deployment_id(
 
 
 def test_submit_return_orders_step_order_processed(
-    mocker, order_factory, adobe_order_factory, adobe_items_factory, settings,
+    mocker,
+    order_factory,
+    adobe_order_factory,
+    adobe_items_factory,
+    settings,
 ):
     """
     Tests that all return orders previously created have been processed
@@ -928,10 +944,7 @@ def test_submit_new_order_step(mocker, order_factory, adobe_order_factory):
 
 
 def test_submit_new_order_step_with_deployment_id(
-    mocker,
-    order_factory,
-    adobe_order_factory,
-    settings
+    mocker, order_factory, adobe_order_factory, settings
 ):
     """
     Test the creation of an Adobe new order.
@@ -941,7 +954,9 @@ def test_submit_new_order_step_with_deployment_id(
     deployment_id = "deployment-id"
 
     order = order_factory(deployment_id=deployment_id)
-    preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
+    preview_order = adobe_order_factory(
+        order_type=ORDER_TYPE_PREVIEW, deployment_id=deployment_id
+    )
     new_order = adobe_order_factory(
         order_type=ORDER_TYPE_NEW,
         status=STATUS_PENDING,
@@ -1639,6 +1654,7 @@ def test_update_prices_step(
         ],
     )
 
+
 @freeze_time("2024-11-09 12:30:00")
 def test_update_prices_step_3yc(
     mocker,
@@ -1878,7 +1894,9 @@ def test_get_preview_order_step(mocker, order_factory, adobe_order_factory):
     deployment_id = "deployment-id"
 
     order = order_factory(deployment_id=deployment_id)
-    preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
+    preview_order = adobe_order_factory(
+        order_type=ORDER_TYPE_PREVIEW, deployment_id=deployment_id
+    )
 
     mocked_adobe_client = mocker.MagicMock()
     mocked_adobe_client.create_preview_order.return_value = preview_order

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -16,7 +16,7 @@ from adobe_vipm.adobe.constants import (
     UNRECOVERABLE_TRANSFER_STATUSES,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeHttpError
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_GC_CREATED,
     STATUS_GC_ERROR,
     STATUS_GC_PENDING,
@@ -4036,7 +4036,6 @@ def test_fulfill_transfer_gc_order_already_migrated_no_items_without_deployment(
     adobe_subscription_factory,
     items_factory,
 ):
-
     order_params = transfer_order_parameters_factory()
     order = order_factory(order_parameters=order_params, lines=[])
 
@@ -4248,7 +4247,6 @@ def test_transfer_gc_account_items_with_deployment_main_agreement(
     items_factory,
     subscriptions_factory,
 ):
-
     mocker.patch(
         "adobe_vipm.flows.fulfillment.shared.get_product_template_or_default",
         side_effect=[{"id": "TPL-0000"}, {"id": "TPL-1111"}],

--- a/tests/flows/test_global_customer.py
+++ b/tests/flows/test_global_customer.py
@@ -17,7 +17,7 @@ def test_check_gc_agreement_deployments_no_licensee(mocker, mpt_client, settings
     )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -44,7 +44,7 @@ def test_check_gc_agreement_deployments_unexpected_error(
     )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     error = AirTableAPIError(
@@ -82,7 +82,7 @@ def test_check_gc_agreement_deployments_no_authorization_id(
         return_value=[],
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -126,7 +126,7 @@ def test_check_gc_agreement_deployments_get_authorization_error(
         side_effect=error,
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -163,7 +163,7 @@ def test_check_gc_agreement_deployments_get_authorization_more_than_one(
         return_value=[mocker.MagicMock(), mocker.MagicMock()],
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -211,7 +211,7 @@ def test_check_gc_agreement_deployments_get_price_list_error(
         return_value=[mocker.MagicMock()],
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -251,7 +251,7 @@ def test_check_gc_agreement_deployments_no_price_list(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -290,7 +290,7 @@ def test_check_gc_agreement_deployments_get_price_more_than_one(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -343,7 +343,7 @@ def test_check_gc_agreement_deployments_get_listing_error(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -415,7 +415,7 @@ def test_check_gc_agreement_deployments_create_listing(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -469,7 +469,7 @@ def test_check_gc_agreement_deployments_get_listing_more_than_one(
         return_value=[mocker.MagicMock(), mocker.MagicMock()],
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -508,7 +508,7 @@ def test_check_gc_agreement_deployments_create_listing_error(
         return_value=[],
     )
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     error_data = mpt_error_factory(
@@ -589,7 +589,7 @@ def test_check_gc_agreement_deployments_create_agreement_error(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -674,7 +674,7 @@ def test_check_gc_agreement_deployments_get_adobe_subscriptions_error(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
@@ -759,7 +759,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     product_items = items_factory()
@@ -844,7 +844,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_already_cr
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     product_items = items_factory()
@@ -937,7 +937,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     product_items = items_factory()
@@ -1023,7 +1023,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_enable_aut
     )
 
     mocker.patch(
-        "adobe_vipm.flows.airtable.get_gc_agreement_deployment_model",
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
     product_items = items_factory()

--- a/tests/flows/test_migration.py
+++ b/tests/flows/test_migration.py
@@ -15,7 +15,7 @@ from adobe_vipm.adobe.errors import (
     AuthorizationNotFoundError,
     ResellerNotFoundError,
 )
-from adobe_vipm.flows.airtable import (
+from adobe_vipm.airtable.models import (
     STATUS_GC_PENDING,
 )
 from adobe_vipm.flows.errors import AirTableAPIError

--- a/tests/flows/test_mpt.py
+++ b/tests/flows/test_mpt.py
@@ -1073,10 +1073,10 @@ def test_get_listings_by_currency_and_by_seller_id(mpt_client, requests_mocker):
     )
 
     assert (
-            get_listings_by_price_list_and_seller_and_authorization(
+        get_listings_by_price_list_and_seller_and_authorization(
             mpt_client, product_id, price_list_id, seller_id, authorization_id
         )
-            == []
+        == []
     )
 
 
@@ -1149,7 +1149,6 @@ def test_create_listing(mpt_client, requests_mocker):
 
 
 def test_create_agreement(mpt_client, requests_mocker, agreement):
-
     requests_mocker.post(
         urljoin(mpt_client.base_url, "commerce/agreements"),
         json=agreement,

--- a/tests/flows/test_sync.py
+++ b/tests/flows/test_sync.py
@@ -22,7 +22,13 @@ def test_sync_agreement_prices(
     lines_factory,
     adobe_subscription_factory,
     adobe_customer_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
+    )
+
     agreement = agreement_factory(
         lines=lines_factory(
             external_vendor_id="77777777CA",
@@ -78,6 +84,11 @@ def test_sync_agreement_prices(
     ]
     mocked_adobe_client.get_customer.return_value = adobe_customer_factory(
         coterm_date="2025-04-04"
+    )
+
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
 
     mocker.patch(
@@ -214,6 +225,7 @@ def test_sync_agreement_prices_dry_run(
     lines_factory,
     adobe_subscription_factory,
     adobe_customer_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     agreement = agreement_factory(
         lines=lines_factory(
@@ -238,6 +250,11 @@ def test_sync_agreement_prices_dry_run(
     mocker.patch(
         "adobe_vipm.flows.sync.get_adobe_client",
         return_value=mocked_adobe_client,
+    )
+
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
 
     mocked_get_agreement_subscription = mocker.patch(
@@ -437,6 +454,7 @@ def test_sync_agreement_prices_with_3yc(
     adobe_subscription_factory,
     adobe_customer_factory,
     adobe_commitment_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     agreement = agreement_factory(
         lines=lines_factory(
@@ -480,6 +498,11 @@ def test_sync_agreement_prices_with_3yc(
 
     mocked_update_agreement = mocker.patch(
         "adobe_vipm.flows.sync.update_agreement",
+    )
+
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
 
     sync_agreement(mocked_mpt_client, agreement, False)
@@ -539,6 +562,7 @@ def test_sync_global_customer_parameter(
     lines_factory,
     adobe_subscription_factory,
     adobe_customer_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     agreement = agreement_factory(
         lines=lines_factory(
@@ -632,6 +656,11 @@ def test_sync_global_customer_parameter(
 
     mocked_update_agreement = mocker.patch(
         "adobe_vipm.flows.sync.update_agreement",
+    )
+
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
 
     sync_agreement(mocked_mpt_client, agreement, False)
@@ -751,6 +780,7 @@ def test_sync_global_customer_update_not_required(
     lines_factory,
     adobe_subscription_factory,
     adobe_customer_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     agreement = agreement_factory(
         lines=lines_factory(
@@ -809,6 +839,12 @@ def test_sync_global_customer_update_not_required(
         adobe_subscription,
         another_adobe_subscription,
     ]
+
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
+    )
+
     mocked_adobe_client.get_customer_deployments.return_value = {
         "totalCount": 1,
         "items": [
@@ -959,6 +995,7 @@ def test_sync_global_customer_update_adobe_error(
     adobe_subscription_factory,
     adobe_customer_factory,
     adobe_api_error_factory,
+    mock_get_adobe_product_by_marketplace_sku,
 ):
     agreement = agreement_factory(
         lines=lines_factory(
@@ -1054,6 +1091,11 @@ def test_sync_global_customer_update_adobe_error(
 
     mocked_update_agreement = mocker.patch(
         "adobe_vipm.flows.sync.update_agreement",
+    )
+
+    mocker.patch(
+        "adobe_vipm.flows.sync.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_adobe_product_by_marketplace_sku,
     )
 
     sync_agreement(mocked_mpt_client, agreement, False)

--- a/tests/flows/validation/test_change.py
+++ b/tests/flows/validation/test_change.py
@@ -415,6 +415,7 @@ def test_validate_change_order(mocker):
         mocked_context,
     )
 
+
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsize_3yc_orders_step_error_minimum_license_quantity(
     mocker,
@@ -488,6 +489,7 @@ def test_validate_downsize_3yc_orders_step_error_minimum_license_quantity(
     ] == ERR_DOWNSIZE_MINIMUM_3YC_LICENSES.format(minimum_licenses=25)
     mocked_next_step.assert_not_called()
 
+
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsize_3yc_orders_step_error_minimum_license_consumables(
     mocker,
@@ -555,6 +557,7 @@ def test_validate_downsize_3yc_orders_step_error_minimum_license_consumables(
         "message"
     ] == ERR_DOWNSIZE_MINIMUM_3YC_CONSUMABLES.format(minimum_consumables=37)
     mocked_next_step.assert_not_called()
+
 
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsize_3yc_orders_step_error_minimum_quantity_generic(

--- a/tests/flows/validation/test_shared.py
+++ b/tests/flows/validation/test_shared.py
@@ -87,7 +87,9 @@ def test_validate_duplicate_lines_step_no_lines(mocker, order_factory):
 )
 def test_get_preview_order_step(mocker, order_factory, adobe_order_factory, segment):
     deployment_id = "deployment-id"
-    adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
+    adobe_preview_order = adobe_order_factory(
+        ORDER_TYPE_PREVIEW, deployment_id=deployment_id
+    )
     mocked_adobe_client = mocker.MagicMock()
     mocked_adobe_client.create_preview_order.return_value = adobe_preview_order
     mocker.patch(
@@ -131,9 +133,13 @@ def test_get_preview_order_step(mocker, order_factory, adobe_order_factory, segm
     "segment",
     [MARKET_SEGMENT_GOVERNMENT, MARKET_SEGMENT_EDUCATION, MARKET_SEGMENT_COMMERCIAL],
 )
-def test_get_preview_order_step_no_deployment(mocker, order_factory, adobe_order_factory, segment):
+def test_get_preview_order_step_no_deployment(
+    mocker, order_factory, adobe_order_factory, segment
+):
     deployment_id = None
-    adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
+    adobe_preview_order = adobe_order_factory(
+        ORDER_TYPE_PREVIEW, deployment_id=deployment_id
+    )
     mocked_adobe_client = mocker.MagicMock()
     mocked_adobe_client.create_preview_order.return_value = adobe_preview_order
     mocker.patch(


### PR DESCRIPTION
- Moved adobe/flow/airtable to adobe/airtable/models
- Removed AdobeProduct dataclass
- Added AdobeProductMapping that replace AdobeProduct
- Removed sku mapping from plugin configuration and adobe client