### PR TITLE
MPT-8743 Fix membershipId is not found in Airtable due to case sensitivity

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -10,6 +10,7 @@ from pyairtable.formulas import (
     FIELD,
     GREATER,
     LESS_EQUAL,
+    LOWER,
     NOT_EQUAL,
     OR,
     STR_VALUE,
@@ -91,7 +92,7 @@ def get_transfer_model(base_info):
         base_info (AirTableBaseInfo): The base info instance.
 
     Returns:
-        Transfer: The AirTable Tranfer model.
+        Transfer: The AirTable Transfer model.
     """
 
     class Transfer(Model):
@@ -360,7 +361,7 @@ def get_transfer_by_authorization_membership_or_customer(
         formula=AND(
             EQUAL(FIELD("authorization_uk"), STR_VALUE(authorization_uk)),
             OR(
-                EQUAL(FIELD("membership_id"), STR_VALUE(membership_or_customer_id)),
+                EQUAL(LOWER(FIELD("membership_id")), LOWER(STR_VALUE(membership_or_customer_id))),
                 EQUAL(FIELD("customer_id"), STR_VALUE(membership_or_customer_id)),
             ),
             NOT_EQUAL(FIELD("status"), STR_VALUE(STATUS_DUPLICATED)),

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -184,7 +184,7 @@ def test_get_transfer_by_authorization_membership_or_customer(mocker, settings):
     mocked_transfer_model.all.assert_called_once_with(
         formula=(
             "AND({authorization_uk}='authorization_uk',"
-            "OR({membership_id}='membership_id',{customer_id}='membership_id'),"
+            "OR(LOWER({membership_id})=LOWER('membership_id'),{customer_id}='membership_id'),"
             "{status}!='duplicated')"
         ),
     )


### PR DESCRIPTION
The validation process is failing to retrive the transfer object from Airtable due to case sensitivity in the memershipId field. 

Following the [pyAirtable documentation](https://pyairtable.readthedocs.io/en/2.3.6/api.html#pyairtable.formulas.LOWER), we added the LOWER formula to the query to convert both IDs to lowercase.