### PR TITLE
MT-9318: authorization not found error cause running transfer check to stop

### DIFF
--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -295,7 +295,6 @@ def check_running_transfers_for_product(product_id):
         f"Found {len(transfers_to_check)} running transfers for product {product_id}"
     )
     for transfer in transfers_to_check:
-        adobe_transfer = None
         try:
             adobe_transfer = client.get_transfer(
                 transfer.authorization_uk,
@@ -340,8 +339,6 @@ def check_running_transfers_for_product(product_id):
 
         transfer.customer_id = adobe_transfer["customerId"]
 
-        customer = None
-        global_sales_enabled = False
         try:
             customer = client.get_customer(
                 transfer.authorization_uk, transfer.customer_id

--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -307,6 +307,12 @@ def check_running_transfers_for_product(product_id):
             transfer.adobe_error_description = str(api_err)
             check_retries(transfer)
             continue
+        except AuthorizationNotFoundError as error:
+            transfer.status = "failed"
+            transfer.migration_error_description = str(error)
+            transfer.updated_at = datetime.now()
+            transfer.save()
+            continue
 
         if adobe_transfer["status"] == STATUS_PENDING:
             check_retries(transfer)

--- a/adobe_vipm/management/commands/check_running_transfers.py
+++ b/adobe_vipm/management/commands/check_running_transfers.py
@@ -4,7 +4,7 @@ from adobe_vipm.flows.migration import check_running_transfers
 
 
 class Command(BaseCommand):
-    help = "Check running tranfers taking data from AirTable bases."
+    help = "Check running transfers taking data from AirTable bases."
 
     def success(self, message):
         self.stdout.write(self.style.SUCCESS(message), ending="\n")


### PR DESCRIPTION
Fix check_running_transfer_for_product command where the process stop if an AuthorizationNotFoundError was raised for a single transfer. 

Now, the affected transfer is marked  failed, the `migration_error_description` field is populated with the error message, and the process continues with the remaining transfers.

