### PR TITLE
MPT-9297: handle KeyError exception when 504 response from adobe api

### DIFF
--- a/adobe_vipm/adobe/errors.py
+++ b/adobe_vipm/adobe/errors.py
@@ -41,7 +41,9 @@ class AdobeAPIError(AdobeHttpError):
     def __init__(self, status_code: int, payload: dict) -> None:
         super().__init__(status_code, json.dumps(payload))
         self.payload: dict = payload
-        self.code: str = payload["code"]
+        # 504 error response doesn't follow the expected format -
+        # it uses "error_code" field instead of "code"
+        self.code: str = payload.get("code", payload.get("error_code"))
         self.message: str = payload["message"]
         self.details: list = payload.get("additionalDetails", [])
 

--- a/tests/adobe/test_errors.py
+++ b/tests/adobe/test_errors.py
@@ -51,6 +51,23 @@ def test_wrap_http_error(mocker, adobe_api_error_factory):
     assert str(cv.value) == "5678 - error message with details: detail1, detail2"
 
 
+def test_wrap_http_error_504_error_code(mocker):
+    @wrap_http_error
+    def func():
+        response = mocker.MagicMock()
+        response.status_code = 504
+        response.json.return_value = {"error_code": "504001", "message": "Gateway Timeout"}
+        raise HTTPError(response=response)
+
+    wrapped_func = wrap_http_error(func)
+
+    with pytest.raises(AdobeError) as cv:
+        wrapped_func()
+
+    assert cv.value.status_code == 504
+    assert str(cv.value) == "504001 - Gateway Timeout"
+
+
 def test_wrap_http_error_json_decode_error(mocker):
     def func():
         response = mocker.MagicMock()


### PR DESCRIPTION
The 504 error response doesn't follow the official documentation, as it uses a `error_code` field instead of `code`.

* 504 error response:
`{"error_code":"504001","message":"Gateway Timeout"}`

* [Documentation](https://developer.adobe.com/vipmp/docs/references/error_handling/#error-handling):
```
{
  "code": "1117",
  "message": "Some Fields are Invalid",
  "additionalDetails": [
    "companyProfile.companyName",
    "companyProfile.contacts[0].firstName"
  ]
}
```
However, a 500 error response does follow the expected structure. 
`{"code":"1124","message":"Internal Server Error","additionalDetails":[]}`

The AdobeAPIError has been updated to support both `code` and `error_code` fields.
