### PR TITLE
MPT-10181 Broken link(s) to an image in notification email from Adobe extension

### DIFF
--- a/adobe_vipm/templates/notification.html
+++ b/adobe_vipm/templates/notification.html
@@ -34,7 +34,7 @@ Order status update
 											<tr><td style="padding: 0; width: 60px; height: 60px; overflow: hidden; background: #F4F6F8">
 												
 <!-- LOGO -->
-<img src="{% if order.agreement.client.icon is not none %}{{ api_base_url }}{{ order.agreement.client.icon }}{% else %}#{% endif %}" style="max-width: 60px; max-height: 60px;" width="60" height="60"/>
+{% if order.agreement.client.icon is defined %}<img src="{{ api_base_url }}{{ order.agreement.client.icon }}" style="max-width: 60px; max-height: 60px;" width="60" height="60" alt="Client icon"/>{% endif %}
 
 											</td><td style="padding-left: 16px;">
 												<h1 style="margin: 0; font-weight: 400; font-size: 24px;">


### PR DESCRIPTION
When there is no icon property available for the Client email shows no icon but:
![image](https://github.com/user-attachments/assets/43e54c85-7a62-4910-8df3-ca331ee4ce19)

We want something more easthetically pleasing.

