### PR TITLE
MPT-10186 revert global mpt client

### DIFF
--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -469,19 +469,19 @@ def save_next_sync_and_coterm_dates(client, order, coterm_date):
     return order
 
 
-def send_mpt_notification(client: MPTClient, order: dict) -> None:
+def send_mpt_notification(mpt_client: MPTClient, order: dict) -> None:
     """
     Send an MPT notification to the customer according to the
     current order status.
     It embeds the current order template into the body.
 
     Args:
-        client (MPTClient): The client used to consume the MPT API.
+        mpt_client (MPTClient): The client used to consume the MPT API.
         order (dict): The order for which the notification should be sent.
     """
     context = {
         "order": order,
-        "activation_template": md2html(get_rendered_template(client, order["id"])),
+        "activation_template": md2html(get_rendered_template(mpt_client, order["id"])),
         "api_base_url": settings.MPT_API_BASE_URL,
         "portal_base_url": settings.MPT_PORTAL_BASE_URL,
     }
@@ -495,6 +495,7 @@ def send_mpt_notification(client: MPTClient, order: dict) -> None:
             f"for {order['agreement']['buyer']['name']}"
         )
     mpt_notify(
+        mpt_client,
         order["agreement"]["licensee"]["account"]["id"],
         order["agreement"]["buyer"]["id"],
         subject,
@@ -528,6 +529,7 @@ def set_customer_coterm_date_if_null(client, adobe_client, order):
     order = set_coterm_date(order, coterm_date)
     update_order(client, order["id"], parameters=order["parameters"])
     return order
+
 
 def get_configuration_template_name(order):
     """
@@ -1019,7 +1021,7 @@ class ValidateDuplicateLines(Step):
         next_step(client, context)
 
 
-def send_gc_mpt_notification(order: dict, items_with_deployment: list) -> None:
+def send_gc_mpt_notification(mpt_client, order: dict, items_with_deployment: list) -> None:
     """Send MPT API notification to the subscribers according to the
     current order status.
     It embeds the current order template.
@@ -1050,6 +1052,7 @@ def send_gc_mpt_notification(order: dict, items_with_deployment: list) -> None:
     )
 
     mpt_notify(
+        mpt_client,
         order["agreement"]["licensee"]["account"]["id"],
         order["agreement"]["buyer"]["id"],
         subject,

--- a/adobe_vipm/flows/fulfillment/transfer.py
+++ b/adobe_vipm/flows/fulfillment/transfer.py
@@ -463,7 +463,7 @@ def _transfer_migrated(
     )
     if items_with_deployment_id:
         _manage_order_with_deployment_id(
-            order, adobe_transfer, gc_main_agreement, items_with_deployment_id
+            mpt_client, order, adobe_transfer, gc_main_agreement, items_with_deployment_id
         )
         return
 
@@ -983,7 +983,7 @@ def _get_order_line_items_with_deployment_id(adobe_transfer_order, order):
 
 
 def _manage_order_with_deployment_id(
-    order, adobe_transfer_order, gc_main_agreement, items_with_deployment
+    mpt_client, order, adobe_transfer_order, gc_main_agreement, items_with_deployment
 ):
     """
     Manages the order with items that contain deployment ID. A new notification is
@@ -997,10 +997,8 @@ def _manage_order_with_deployment_id(
     Returns:
         None
     """
-    logger.warning(
-        "Order contains items with deployment ID, keep in pending to be reviewed"
-    )
-    send_gc_mpt_notification(order, items_with_deployment)
+    logger.warning("Order contains items with deployment ID, keep in pending to be reviewed")
+    send_gc_mpt_notification(mpt_client, order, items_with_deployment)
     if gc_main_agreement:
         gc_main_agreement.status = STATUS_GC_ERROR
         gc_main_agreement.error_description = "Order contains items with deployment ID"
@@ -1131,7 +1129,7 @@ def fulfill_transfer_order(mpt_client, order):
     )
     if items_with_deployment_id:
         _manage_order_with_deployment_id(
-            order, adobe_transfer_order, gc_main_agreement, items_with_deployment_id
+            mpt_client, order, adobe_transfer_order, gc_main_agreement, items_with_deployment_id
         )
         return
 

--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from mpt_extension_sdk.core.utils import setup_client, setup_operations_client
 from mpt_extension_sdk.mpt_http.mpt import (
     create_agreement,
     create_agreement_subscription,
@@ -57,7 +58,6 @@ from adobe_vipm.flows.utils import (
     get_sku_with_discount_level,
     split_phone_number,
 )
-from adobe_vipm.shared import mpt_client, mpt_o_client
 from adobe_vipm.utils import get_partial_sku
 
 logger = logging.getLogger(__name__)
@@ -673,6 +673,8 @@ def check_gc_agreement_deployments():
         None
     """
     adobe_client = get_adobe_client()
+    mpt_client = setup_client()
+    mpt_o_client = setup_operations_client()
 
     for product_id in settings.MPT_PRODUCTS_IDS:
         if get_market_segment(product_id) != MARKET_SEGMENT_COMMERCIAL:

--- a/adobe_vipm/notifications.py
+++ b/adobe_vipm/notifications.py
@@ -6,17 +6,14 @@ from datetime import datetime
 import pymsteams
 from django.conf import settings
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.mpt import NotifyCategories, notify
-
-from adobe_vipm.shared import mpt_client
 
 logger = logging.getLogger(__name__)
 
 
 def dateformat(date_string):
-    return (
-        datetime.fromisoformat(date_string).strftime("%-d %B %Y") if date_string else ""
-    )
+    return datetime.fromisoformat(date_string).strftime("%-d %B %Y") if date_string else ""
 
 
 env = Environment(
@@ -116,7 +113,12 @@ def send_exception(
 
 
 def mpt_notify(
-    account_id: str, buyer_id: str, subject: str, template_name: str, context: dict
+    mpt_client: MPTClient,
+    account_id: str,
+    buyer_id: str,
+    subject: str,
+    template_name: str,
+    context: dict,
 ) -> None:
     """
     Sends a notification through the MPT API using a specified template and context.

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -62,7 +62,7 @@ from adobe_vipm.flows.utils.parameter import get_fulfillment_parameter
 
 @pytest.fixture(autouse=True)
 def mocked_send_mpt_notification(mocker):
-    return mocker.patch("adobe_vipm.flows.fulfillment.shared.send_mpt_notification")
+    return mocker.patch("adobe_vipm.flows.fulfillment.shared.send_mpt_notification", spec=True)
 
 
 @pytest.mark.parametrize(
@@ -86,9 +86,7 @@ def mocked_send_mpt_notification(mocker):
         ),
     ],
 )
-def test_send_mpt_notification(mocker, settings, order_factory, status, subject):
-    mocked_mpt_client = mocker.MagicMock()
-
+def test_send_mpt_notification(mocker, settings, order_factory, mock_mpt_client, status, subject):
     mocked_get_rendered_template = mocker.patch(
         "adobe_vipm.flows.fulfillment.shared.get_rendered_template",
         return_value="rendered-template",
@@ -98,10 +96,11 @@ def test_send_mpt_notification(mocker, settings, order_factory, status, subject)
 
     order = order_factory(order_id="ORD-1234", status=status)
 
-    send_mpt_notification(mocked_mpt_client, order)
-    mocked_get_rendered_template.assert_called_once_with(mocked_mpt_client, order["id"])
+    send_mpt_notification(mock_mpt_client, order)
+    mocked_get_rendered_template.assert_called_once_with(mock_mpt_client, order["id"])
 
     mocked_mpt_notify.assert_called_once_with(
+        mock_mpt_client,
         order["agreement"]["licensee"]["account"]["id"],
         order["agreement"]["buyer"]["id"],
         subject,
@@ -117,16 +116,13 @@ def test_send_mpt_notification(mocker, settings, order_factory, status, subject)
 
 @freeze_time("2025-01-01")
 def test_start_processing_attempt_first_attempt(
-    mocker, settings, order_factory, fulfillment_parameters_factory
+    mocker, settings, order_factory, fulfillment_parameters_factory, mocked_send_mpt_notification
 ):
     order = order_factory()
     updated_order = order_factory(
         fulfillment_parameters=fulfillment_parameters_factory(
             due_date="2025-01-31",
         ),
-    )
-    mocked_send_notification = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.send_mpt_notification"
     )
     mocked_update = mocker.patch(
         "adobe_vipm.flows.fulfillment.shared.update_order",
@@ -137,7 +133,7 @@ def test_start_processing_attempt_first_attempt(
 
     start_processing_attempt(mocked_client, order)
 
-    mocked_send_notification.assert_called_once_with(mocked_client, updated_order)
+    mocked_send_mpt_notification.assert_called_once_with(mocked_client, updated_order)
     mocked_update.assert_called_once_with(
         mocked_client,
         updated_order["id"],
@@ -147,12 +143,8 @@ def test_start_processing_attempt_first_attempt(
 
 @freeze_time("2025-01-01")
 def test_start_processing_attempt_other_attempts(
-    mocker, order_factory, fulfillment_parameters_factory
+    mocker, order_factory, fulfillment_parameters_factory, mocked_send_mpt_notification
 ):
-    mocked_send_notification = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.send_mpt_notification"
-    )
-
     mocked_client = mocker.MagicMock()
 
     order = order_factory(
@@ -163,7 +155,7 @@ def test_start_processing_attempt_other_attempts(
 
     start_processing_attempt(mocked_client, order)
 
-    mocked_send_notification.assert_not_called()
+    mocked_send_mpt_notification.assert_not_called()
 
 
 def test_set_customer_coterm_date_if_null(
@@ -331,7 +323,7 @@ def test_setup_due_date_when_parameter_is_missed(
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
-def test_start_order_processing_step(mocker, order_factory):
+def test_start_order_processing_step(mocker, order_factory, mocked_send_mpt_notification):
     """
     Tests that the template for the `Processing` status
     with the name provided during the instantiation of the step class
@@ -341,12 +333,7 @@ def test_start_order_processing_step(mocker, order_factory):
         "adobe_vipm.flows.fulfillment.shared.get_product_template_or_default",
         return_value={"id": "TPL-1234"},
     )
-    mocked_update_order = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.update_order"
-    )
-    mocked_send_notification = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.send_mpt_notification",
-    )
+    mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
     order = order_factory()
@@ -369,7 +356,7 @@ def test_start_order_processing_step(mocker, order_factory):
         context.order["id"],
         template={"id": "TPL-1234"},
     )
-    mocked_send_notification.assert_called_once_with(mocked_client, context.order)
+    mocked_send_mpt_notification.assert_called_once_with(mocked_client, context.order)
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
@@ -415,7 +402,7 @@ def test_configuration_start_order_processing_selects_template(
 
 
 def test_set_processing_template_step_already_set_not_first_attempt(
-    mocker, order_factory
+    mocker, order_factory, mocked_send_mpt_notification
 ):
     """
     Tests that the template for the `Processing` status
@@ -427,12 +414,7 @@ def test_set_processing_template_step_already_set_not_first_attempt(
         "adobe_vipm.flows.fulfillment.shared.get_product_template_or_default",
         return_value={"id": "TPL-1234"},
     )
-    mocked_update_order = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.update_order"
-    )
-    mocked_send_notification = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.send_mpt_notification",
-    )
+    mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
 
@@ -451,7 +433,7 @@ def test_set_processing_template_step_already_set_not_first_attempt(
         "my template",
     )
     mocked_update_order.assert_not_called()
-    mocked_send_notification.assert_not_called()
+    mocked_send_mpt_notification.assert_not_called()
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
@@ -1789,7 +1771,7 @@ def test_complete_order_step(mocker, order_factory):
     ],
 )
 def test_complete_configuration_order_selects_template(
-    mocker, order_factory, auto_renew, expected_template
+    mocker, order_factory, auto_renew, expected_template, mocked_send_mpt_notification
 ):
     order = order_factory(subscriptions=[{"autoRenew": auto_renew}])
     completed_order = order_factory(status="Completed")
@@ -1810,9 +1792,6 @@ def test_complete_configuration_order_selects_template(
         "adobe_vipm.flows.fulfillment.shared.complete_order",
         return_value=completed_order,
     )
-    mocked_send_email = mocker.patch(
-        "adobe_vipm.flows.fulfillment.shared.send_mpt_notification"
-    )
 
     step = CompleteOrder(expected_template)
     step(mocked_client, context, mocked_next_step)
@@ -1829,7 +1808,7 @@ def test_complete_configuration_order_selects_template(
         {"id": "TPL-0000"},
         parameters=order["parameters"],
     )
-    mocked_send_email.assert_called_once_with(mocked_client, completed_order)
+    mocked_send_mpt_notification.assert_called_once_with(mocked_client, completed_order)
     assert context.order == completed_order
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
@@ -2136,14 +2115,17 @@ def test_get_preview_order_step_adobe_error(
         )
     ],
 )
-def test_send_gc_mpt_notification(mocker, settings, order_factory, status, subject):
+def test_send_gc_mpt_notification(
+    mocker, settings, order_factory, mock_mpt_client, status, subject
+):
     mock_mpt_notify = mocker.patch("adobe_vipm.flows.fulfillment.shared.mpt_notify")
 
     order = order_factory(order_id="ORD-1234", status=status)
 
-    send_gc_mpt_notification(order, ["deployment 1"])
+    send_gc_mpt_notification(mock_mpt_client, order, ["deployment 1"])
 
     mock_mpt_notify.assert_called_once_with(
+        mock_mpt_client,
         order["agreement"]["licensee"]["account"]["id"],
         order["agreement"]["buyer"]["id"],
         subject,

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -55,14 +55,12 @@ pytestmark = pytest.mark.usefixtures("mock_adobe_config")
 
 @pytest.fixture(autouse=True)
 def mocked_send_mpt_notification(mocker):
-    return mocker.patch("adobe_vipm.flows.fulfillment.shared.send_mpt_notification")
+    return mocker.patch("adobe_vipm.flows.fulfillment.shared.send_mpt_notification", spec=True)
 
 
 @pytest.fixture(autouse=True)
 def send_gc_mpt_notification(mocker):
-    return mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.send_gc_mpt_notification"
-    )
+    return mocker.patch("adobe_vipm.flows.fulfillment.transfer.send_gc_mpt_notification", spec=True)
 
 
 @freeze_time("2024-01-01")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -14,7 +14,6 @@ from adobe_vipm.notifications import (
     send_notification,
     send_warning,
 )
-from adobe_vipm.shared import mpt_client
 
 
 def test_send_notification_full(mocker, settings):
@@ -136,7 +135,7 @@ def test_send_others(mocker, function, color, icon):
     )
 
 
-def test_mpt_notify(mocker):
+def test_mpt_notify(mocker, mock_mpt_client):
     mocked_template = mocker.MagicMock()
     mocked_template.render.return_value = "rendered-template"
     mocked_jinja_env = mocker.MagicMock()
@@ -145,13 +144,18 @@ def test_mpt_notify(mocker):
 
     mocked_notify = mocker.patch("adobe_vipm.notifications.notify", autospec=True)
     mpt_notify(
-        "account_id", "buyer_id", "email-subject", "template_name", {"test": "context"}
+        mock_mpt_client,
+        "account_id",
+        "buyer_id",
+        "email-subject",
+        "template_name",
+        {"test": "context"},
     )
 
     mocked_jinja_env.get_template.assert_called_once_with("template_name.html")
     mocked_template.render.assert_called_once_with({"test": "context"})
     mocked_notify.assert_called_once_with(
-        mpt_client,
+        mock_mpt_client,
         "NTC-0000-0006",
         "account_id",
         "buyer_id",
@@ -160,7 +164,7 @@ def test_mpt_notify(mocker):
     )
 
 
-def test_mpt_notify_exception(mocker, caplog):
+def test_mpt_notify_exception(mocker, mock_mpt_client, caplog):
     mocked_template = mocker.MagicMock()
     mocked_template.render.return_value = "rendered-template"
     mocked_jinja_env = mocker.MagicMock()
@@ -174,6 +178,7 @@ def test_mpt_notify_exception(mocker, caplog):
     )
     with caplog.at_level(logging.ERROR):
         mpt_notify(
+            mock_mpt_client,
             "account_id",
             "buyer_id",
             "email-subject",


### PR DESCRIPTION
This PR reverts changes implementing global MPTClient. Due to the number of posts and bug reports I found claiming that the Python Requests library, specifically the Session object we use in our client, is not being fully threadsafe. https://stackoverflow.com/questions/18188044/is-the-session-object-from-pythons-requests-library-thread-safe