### PR TITLE
MPT-12512 Updated pre-renewal window timeframe.

### DIFF
--- a/adobe_vipm/flows/utils/date.py
+++ b/adobe_vipm/flows/utils/date.py
@@ -122,4 +122,4 @@ def is_coterm_date_within_order_creation_window(order: dict) -> bool:
     # this is for the business logic to be consistent with the Adobe order creation window
     pacific_tz = ZoneInfo("America/Los_Angeles")
     today = dt.datetime.now(pacific_tz).date()
-    return today >= coterm_date - dt.timedelta(hours=int(hours))
+    return coterm_date - dt.timedelta(hours=int(hours)) <= today <= coterm_date

--- a/tests/flows/test_utils.py
+++ b/tests/flows/test_utils.py
@@ -1,12 +1,14 @@
 import datetime as dt
 
 import pytest
+from freezegun import freeze_time
 
 from adobe_vipm.adobe.constants import AdobeStatus
 from adobe_vipm.flows.utils import (
     get_customer_consumables_discount_level,
     get_customer_licenses_discount_level,
     get_transfer_item_sku_by_subscription,
+    is_coterm_date_within_order_creation_window,
     is_transferring_item_expired,
     notify_agreement_unhandled_exception_in_teams,
     notify_missing_prices,
@@ -263,3 +265,36 @@ def test_get_customer_consumables_discount_level(adobe_customer_factory):
         )
         == "T2"
     )
+
+
+@freeze_time("2024-05-06")
+def test_is_coterm_date_within_order_creation_window_before_window(
+    order_factory, fulfillment_parameters_factory
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(coterm_date="2024-04-06")
+    )
+
+    assert not is_coterm_date_within_order_creation_window(order)
+
+
+@freeze_time("2024-05-06")
+def test_is_coterm_date_within_order_creation_window_during_window(
+    order_factory, fulfillment_parameters_factory
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(coterm_date="2024-05-05")
+    )
+
+    assert is_coterm_date_within_order_creation_window(order)
+
+
+@freeze_time("2024-05-06")
+def test_is_coterm_date_within_order_creation_window_after_window(
+    order_factory, fulfillment_parameters_factory
+):
+    order = order_factory(
+        fulfillment_parameters=fulfillment_parameters_factory(coterm_date="2024-06-06")
+    )
+
+    assert not is_coterm_date_within_order_creation_window(order)


### PR DESCRIPTION
Allows customers with Assets only, who have coterm dates that don't update to place orders. For customers without recurring subscriptions, their coterm date never moves forward, but they should still be able to place orders. This change allows those customers who may have co term dates quite far in the past to continue ordering.