### PR TITLE
MPT-12622: use mock-adobe-client fixture

### DIFF
--- a/tests/commands/test_create_resellers.py
+++ b/tests/commands/test_create_resellers.py
@@ -208,7 +208,9 @@ def test_reseller_exists(mocker, settings, adobe_authorizations_file, tmp_path):
     assert ws["P2"].value is None
 
 
-def test_reseller_create_ok(mocker, settings, adobe_authorizations_file, tmp_path, reseller_data):
+def test_reseller_create_ok(
+    mocker, mock_adobe_client, settings, adobe_authorizations_file, tmp_path, reseller_data
+):
     settings.EXTENSION_CONFIG = {"ADOBE_AUTHORIZATIONS_FILE": "/path/to/authorizations.json"}
     authorization = adobe_authorizations_file["authorizations"][0]
     authorization_uk = authorization["authorization_uk"]
@@ -255,13 +257,7 @@ def test_reseller_create_ok(mocker, settings, adobe_authorizations_file, tmp_pat
     )
     mocked_dump = mocker.patch("adobe_vipm.management.commands.create_resellers.json.dump")
 
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_reseller_account.return_value = {"resellerId": "adobe-reseller-id"}
-    mocker.patch(
-        "adobe_vipm.management.commands.create_resellers.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
-
+    mock_adobe_client.create_reseller_account.return_value = {"resellerId": "adobe-reseller-id"}
     out = StringIO()
 
     call_command(
@@ -284,7 +280,9 @@ def test_reseller_create_ok(mocker, settings, adobe_authorizations_file, tmp_pat
     mocked_open.assert_called_once_with("w", encoding="utf-8")
 
 
-def test_api_error(mocker, adobe_authorizations_file, tmp_path, adobe_api_error_factory):
+def test_api_error(
+    mocker, mock_adobe_client, adobe_authorizations_file, tmp_path, adobe_api_error_factory
+):
     authorization = adobe_authorizations_file["authorizations"][0]
     authorization_uk = authorization["authorization_uk"]
 
@@ -303,32 +301,13 @@ def test_api_error(mocker, adobe_authorizations_file, tmp_path, adobe_api_error_
             ws[f"{letter}2"].value = f"row_1_{column}"
 
     wb.save(tmp_path / "test.xlsx")
-
-    mocker.patch.object(
-        Command,
-        "load_authorizations_data",
-        return_value=adobe_authorizations_file,
-    )
-
-    mocker.patch.object(
-        Command,
-        "validate_reseller_data",
-        return_value=[],
-    )
-
+    mocker.patch.object(Command, "load_authorizations_data", return_value=adobe_authorizations_file)
+    mocker.patch.object(Command, "validate_reseller_data", return_value=[])
     api_error = AdobeAPIError(
         400,
         adobe_api_error_factory(code="7777", message="Test Api Error"),
     )
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_reseller_account.side_effect = api_error
-
-    mocker.patch(
-        "adobe_vipm.management.commands.create_resellers.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
-
+    mock_adobe_client.create_reseller_account.side_effect = api_error
     out = StringIO()
 
     call_command(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1351,6 +1351,33 @@ def webhook(settings):
 
 
 @pytest.fixture
+def mock_adobe_client(mocker):
+    adobe_client = mocker.MagicMock(spec=AdobeClient)
+    paths = [
+        "adobe_vipm.flows.benefits.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.change.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.purchase.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.shared.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.configuration.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.termination.get_adobe_client",
+        "adobe_vipm.flows.fulfillment.transfer.get_adobe_client",
+        "adobe_vipm.flows.global_customer.get_adobe_client",
+        "adobe_vipm.flows.helpers.get_adobe_client",
+        "adobe_vipm.flows.migration.get_adobe_client",
+        "adobe_vipm.flows.sync.get_adobe_client",
+        "adobe_vipm.flows.validation.termination.get_adobe_client",
+        "adobe_vipm.flows.validation.change.get_adobe_client",
+        "adobe_vipm.flows.validation.shared.get_adobe_client",
+        "adobe_vipm.flows.validation.transfer.get_adobe_client",
+        "adobe_vipm.management.commands.create_resellers.get_adobe_client",
+    ]
+    for path in paths:
+        mocker.patch(path, return_value=adobe_client)
+
+    return adobe_client
+
+
+@pytest.fixture
 def adobe_items_factory():  # noqa: C901
     def _items(
         line_number=1,
@@ -2121,14 +2148,6 @@ def mock_invalid_env_values(
 @pytest.fixture
 def mock_worker_initialize(mocker):
     return mocker.patch("mpt_extension_sdk.runtime.workers.initialize")
-
-
-@pytest.fixture
-def mock_adobe_client(mocker):
-    m = mocker.MagicMock(spec=AdobeClient)
-    mocker.patch("adobe_vipm.flows.benefits.get_adobe_client", return_value=m)
-    mocker.patch("adobe_vipm.flows.sync.get_adobe_client", return_value=m)
-    return m
 
 
 @pytest.fixture

--- a/tests/flows/test_global_customer.py
+++ b/tests/flows/test_global_customer.py
@@ -6,7 +6,9 @@ from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.airtable.models import get_sku_price
 from adobe_vipm.flows.errors import AirTableAPIError, MPTAPIError
-from adobe_vipm.flows.global_customer import check_gc_agreement_deployments
+from adobe_vipm.flows.global_customer import (
+    check_gc_agreement_deployments,
+)
 
 
 @pytest.fixture
@@ -62,18 +64,15 @@ def empty_3y_commitment():
     return None
 
 
-def test_check_gc_agreement_deployments_no_licensee(mocker, settings, gc_agreement_deployment):
+def test_check_gc_agreement_deployments_no_licensee(
+    mocker, mock_adobe_client, settings, gc_agreement_deployment
+):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
         "AIRTABLE_BASES": {"PRD-1111-1111": "base_id"},
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM", "PRD-2222-2222": "GOV"},
     }
     settings.MPT_PRODUCTS_IDS = ["PRD-1111-1111", "PRD-2222-2222"]
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
@@ -87,29 +86,20 @@ def test_check_gc_agreement_deployments_no_licensee(mocker, settings, gc_agreeme
     mocked_gc_agreement_deployments_model.all.assert_called_once()
 
 
-def test_check_gc_agreement_deployments_unexpected_error(mocker, settings, airtable_error_factory):
+def test_check_gc_agreement_deployments_unexpected_error(
+    mocker, mock_adobe_client, settings, airtable_error_factory
+):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
         "AIRTABLE_BASES": {"PRD-1111-1111": "base_id"},
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-    error = AirTableAPIError(
-        400,
-        airtable_error_factory(
-            "Bad Request",
-            "BAD_REQUEST",
-        ),
-    )
+    error = AirTableAPIError(400, airtable_error_factory("Bad Request", "BAD_REQUEST"))
     mocked_gc_agreement_deployments_model.all.side_effect = error
 
     check_gc_agreement_deployments()
@@ -118,6 +108,7 @@ def test_check_gc_agreement_deployments_unexpected_error(mocker, settings, airta
 
 def test_check_gc_agreement_deployments_no_authorization_id(
     mocker,
+    mock_adobe_client,
     settings,
     gc_agreement_deployment,
 ):
@@ -128,13 +119,7 @@ def test_check_gc_agreement_deployments_no_authorization_id(
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
 
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_authorizations_by_currency_and_seller_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_authorizations_by_currency_and_seller_id",
         return_value=[],
@@ -153,7 +138,7 @@ def test_check_gc_agreement_deployments_no_authorization_id(
 
 
 def test_check_gc_agreement_deployments_get_authorization_error(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -161,12 +146,6 @@ def test_check_gc_agreement_deployments_get_authorization_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     error_data = mpt_error_factory(
         400,
@@ -189,12 +168,13 @@ def test_check_gc_agreement_deployments_get_authorization_error(
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_authorizations_by_currency_and_seller_id.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_get_authorization_more_than_one(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -202,14 +182,7 @@ def test_check_gc_agreement_deployments_get_authorization_more_than_one(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_authorizations_by_currency_and_seller_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_authorizations_by_currency_and_seller_id",
         return_value=[mocker.MagicMock(), mocker.MagicMock()],
@@ -218,18 +191,18 @@ def test_check_gc_agreement_deployments_get_authorization_more_than_one(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.authorization_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_authorizations_by_currency_and_seller_id.assert_called_once()
     gc_agreement_deployment.save.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_get_price_list_error(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -237,11 +210,6 @@ def test_check_gc_agreement_deployments_get_price_list_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
     error_data = mpt_error_factory(
         400,
@@ -263,20 +231,19 @@ def test_check_gc_agreement_deployments_get_price_list_error(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.authorization_id = None
     gc_agreement_deployment.price_list_id = None
-
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_authorizations_by_currency_and_seller_id.assert_called_once()
     mocked_get_gc_price_list_by_currency.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_no_price_list(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -284,34 +251,26 @@ def test_check_gc_agreement_deployments_no_price_list(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_gc_price_list_by_currency = mocker.patch(
         "adobe_vipm.flows.global_customer.get_gc_price_list_by_currency",
         return_value=[],
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.price_list_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_gc_price_list_by_currency.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_get_price_more_than_one(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -319,34 +278,26 @@ def test_check_gc_agreement_deployments_get_price_more_than_one(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_gc_price_list_by_currency = mocker.patch(
         "adobe_vipm.flows.global_customer.get_gc_price_list_by_currency",
         return_value=[mocker.MagicMock(), mocker.MagicMock()],
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.price_list_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_gc_price_list_by_currency.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_get_listing_error(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -354,14 +305,7 @@ def test_check_gc_agreement_deployments_get_listing_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     price_list = mocker.MagicMock()
     price_list.externalIds = "price_list_global"
     mocked_get_gc_price_list_by_currency = mocker.patch(
@@ -380,17 +324,16 @@ def test_check_gc_agreement_deployments_get_listing_error(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         side_effect=error,
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.price_list_id = None
     gc_agreement_deployment.listing_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_gc_price_list_by_currency.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
@@ -398,6 +341,7 @@ def test_check_gc_agreement_deployments_get_listing_error(
 
 def test_check_gc_agreement_deployments_create_listing(
     mocker,
+    mock_adobe_client,
     settings,
     adobe_customer_factory,
     adobe_subscription_factory,
@@ -410,91 +354,67 @@ def test_check_gc_agreement_deployments_create_listing(
     template,
 ):
     agreement = agreement_factory()
-
     expected_created_agreement_arg = created_agreement_factory(
         deployments="", is_profile_address_exists=True
     )
-
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
         "AIRTABLE_BASES": {"PRD-1111-1111": "base_id"},
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[],
     )
-
     mocked_create_listing = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_listing",
-        return_value=listing,
+        "adobe_vipm.flows.global_customer.create_listing", return_value=listing
     )
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_get_product_template_or_default = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_product_template_or_default",
-        return_value=template,
+        "adobe_vipm.flows.global_customer.get_product_template_or_default", return_value=template
     )
-
     mocked_create_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_agreement",
-        return_value=agreement,
+        "adobe_vipm.flows.global_customer.create_agreement", return_value=agreement
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=agreement,
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=agreement
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     adobe_customer = adobe_customer_factory(company_profile_address_exists=True)
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
-
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
     gc_agreement_deployment.listing_id = None
     gc_agreement_deployment.agreement_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
     mocked_get_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_agreement",
-        return_value=provisioning_agreement,
+        "adobe_vipm.flows.global_customer.get_agreement", return_value=provisioning_agreement
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
     mocked_create_listing.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_get_product_template_or_default.assert_called_once()
-
     assert mocked_create_agreement.call_args_list[0].args[1] == expected_created_agreement_arg
-
     mocked_get_agreement.assert_called_once()
-
     mocked_update_agreement.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_create_listing_with_no_address(
     mocker,
+    mock_adobe_client,
     settings,
     adobe_customer_factory,
     adobe_subscription_factory,
@@ -509,68 +429,45 @@ def test_check_gc_agreement_deployments_create_listing_with_no_address(
     template,
 ):
     agreement = agreement_factory()
-
     expected_created_agreement_arg = created_agreement_factory(
-        deployments=mock_adobe_customer_deployments_external_ids,
-        is_profile_address_exists=False,
+        deployments=mock_adobe_customer_deployments_external_ids, is_profile_address_exists=False
     )
-
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
         "AIRTABLE_BASES": {"PRD-1111-1111": "base_id"},
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[],
     )
-
     mocked_create_listing = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_listing",
-        return_value=listing,
+        "adobe_vipm.flows.global_customer.create_listing", return_value=listing
     )
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_get_product_template_or_default = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_product_template_or_default",
-        return_value=template,
+        "adobe_vipm.flows.global_customer.get_product_template_or_default", return_value=template
     )
-
     mocked_create_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_agreement",
-        return_value=agreement,
+        "adobe_vipm.flows.global_customer.create_agreement", return_value=agreement
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=agreement,
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=agreement
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     adobe_customer = adobe_customer_factory(company_profile_address_exists=False)
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = (
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = (
         mock_adobe_customer_deployments_items
     )
-    mocked_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
-
+    mock_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
     gc_agreement_deployment.listing_id = None
     gc_agreement_deployment.agreement_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
@@ -580,12 +477,13 @@ def test_check_gc_agreement_deployments_create_listing_with_no_address(
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
     mocked_create_listing.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_get_product_template_or_default.assert_called_once()
 
     assert mocked_create_agreement.call_args_list[0].args[1] == expected_created_agreement_arg
@@ -596,7 +494,7 @@ def test_check_gc_agreement_deployments_create_listing_with_no_address(
 
 
 def test_check_gc_agreement_deployments_get_listing_more_than_one(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -604,13 +502,7 @@ def test_check_gc_agreement_deployments_get_listing_more_than_one(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[mocker.MagicMock(), mocker.MagicMock()],
@@ -619,17 +511,17 @@ def test_check_gc_agreement_deployments_get_listing_more_than_one(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     gc_agreement_deployment.listing_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_create_listing_error(
-    mocker, settings, mpt_error_factory, gc_agreement_deployment
+    mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -637,14 +529,7 @@ def test_check_gc_agreement_deployments_create_listing_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[],
@@ -662,14 +547,13 @@ def test_check_gc_agreement_deployments_create_listing_error(
     )
     error = MPTAPIError(400, error_data)
     mocked_create_listing = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_listing",
-        side_effect=error,
+        "adobe_vipm.flows.global_customer.create_listing", side_effect=error
     )
-
     gc_agreement_deployment.listing_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
     mocked_create_listing.assert_called_once()
@@ -677,6 +561,7 @@ def test_check_gc_agreement_deployments_create_listing_error(
 
 def test_check_gc_agreement_deployments_create_agreement_error(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -693,27 +578,16 @@ def test_check_gc_agreement_deployments_create_agreement_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[mocker.MagicMock()],
     )
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_get_product_template_or_default = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_product_template_or_default",
-        return_value=template,
+        "adobe_vipm.flows.global_customer.get_product_template_or_default", return_value=template
     )
     error_data = mpt_error_factory(
         400,
@@ -724,20 +598,17 @@ def test_check_gc_agreement_deployments_create_agreement_error(
     )
     error = MPTAPIError(400, error_data)
     mocked_create_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_agreement",
-        side_effect=error,
+        "adobe_vipm.flows.global_customer.create_agreement", side_effect=error
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
 
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
-
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
     gc_agreement_deployment.listing_id = None
     gc_agreement_deployment.agreement_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
@@ -747,11 +618,12 @@ def test_check_gc_agreement_deployments_create_agreement_error(
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_get_product_template_or_default.assert_called_once()
     mocked_create_agreement.assert_called_once()
     mocked_get_agreement.assert_called_once()
@@ -759,6 +631,7 @@ def test_check_gc_agreement_deployments_create_agreement_error(
 
 def test_check_gc_agreement_deployments_get_adobe_subscriptions_error(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -777,65 +650,40 @@ def test_check_gc_agreement_deployments_get_adobe_subscriptions_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_listings_by_price_list_and_seller_and_authorization = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
         return_value=[],
     )
-
     mocked_create_listing = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_listing",
-        return_value=listing,
+        "adobe_vipm.flows.global_customer.create_listing", return_value=listing
     )
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_get_product_template_or_default = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_product_template_or_default",
-        return_value=template,
+        "adobe_vipm.flows.global_customer.get_product_template_or_default", return_value=template
     )
-
     mocked_create_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.create_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.create_agreement", return_value=mocker.MagicMock()
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=mocker.MagicMock()
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
     )
-
     mocked_get_agreement = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement",
         return_value=provisioning_agreement,
     )
-
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.side_effect = AdobeAPIError(
-        400,
-        adobe_api_error_factory(
-            "1000",
-            "Error updating autorenewal quantity",
-        ),
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("1000", "Error updating autorenewal quantity")
     )
-
     gc_agreement_deployment.listing_id = None
     gc_agreement_deployment.agreement_id = None
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
@@ -845,17 +693,17 @@ def test_check_gc_agreement_deployments_get_adobe_subscriptions_error(
     mocked_get_listings_by_price_list_and_seller_and_authorization.assert_called_once()
     mocked_create_listing.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_get_product_template_or_default.assert_called_once()
     mocked_create_agreement.assert_called_once()
     mocked_get_agreement.assert_called_once()
-
     mocked_update_agreement.assert_called_once()
 
 
 def test_check_gc_agreement_deployments_create_agreement_subscription(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -872,43 +720,28 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=mocker.MagicMock()
     )
-
     mocked_get_listing_by_id = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_listing_by_id",
-        return_value=listing,
+        "adobe_vipm.flows.global_customer.get_listing_by_id", return_value=listing
     )
     mocked_get_subscription_by_external_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement_subscription_by_external_id",
         return_value=[],
     )
-
     mocked_create_agreement_subscription = mocker.patch(
         "adobe_vipm.flows.global_customer.create_agreement_subscription",
         return_value=mocker.MagicMock(),
     )
-
     mocked_get_sku_price = mocker.patch(
         "adobe_vipm.flows.global_customer.get_sku_price",
         return_value={"65304578CA01A12": 100.0},
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
@@ -919,9 +752,9 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
         return_value=product_items,
     )
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [
             adobe_subscription_factory(deployment_id="deployment_id"),
             adobe_subscription_factory(deployment_id=""),
@@ -930,19 +763,18 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
             ),
         ]
     }
-
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
-
     mocked_get_agreement = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement",
         return_value=provisioning_agreement,
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
 
     mocked_update_agreement.assert_called_once()
     mocked_get_product_items_by_skus.assert_called()
@@ -955,6 +787,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
 
 def test_check_gc_agreement_deployments_create_agreement_subscription_already_created(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -971,27 +804,15 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_already_cr
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=licensee,
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=licensee
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=mocker.MagicMock()
     )
-
     mocked_get_listing_by_id = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_listing_by_id",
-        return_value=listing,
+        "adobe_vipm.flows.global_customer.get_listing_by_id", return_value=listing
     )
     mocked_get_subscription_by_external_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement_subscription_by_external_id",
@@ -1001,7 +822,6 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_already_cr
         "adobe_vipm.flows.global_customer.create_agreement_subscription",
         return_value=mocker.MagicMock(),
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
@@ -1012,25 +832,23 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_already_cr
         return_value=product_items,
     )
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [adobe_subscription_factory(deployment_id="deployment_id")]
     }
-
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
-
     mocked_get_agreement = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement",
         return_value=provisioning_agreement,
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
-
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_update_agreement.assert_called_once()
     mocked_get_product_items_by_skus.assert_called()
     mocked_get_listing_by_id.assert_called_once()
@@ -1041,6 +859,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_already_cr
 
 def test_check_gc_agreement_deployments_create_agreement_subscription_error(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -1055,24 +874,13 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=mocker.MagicMock()
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=mocker.MagicMock()
     )
-
     mocked_get_listing_by_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_listing_by_id",
         return_value=mocker.MagicMock(),
@@ -1093,12 +901,10 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
         "adobe_vipm.flows.global_customer.create_agreement_subscription",
         side_effect=error,
     )
-
     mocked_get_sku_price = mocker.patch(
         "adobe_vipm.flows.global_customer.get_sku_price",
         return_value={"65304578CA01A12": 100.0},
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
@@ -1109,12 +915,11 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
         return_value=product_items,
     )
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [adobe_subscription_factory(deployment_id="deployment_id")]
     }
-
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
 
     mocked_get_agreement = mocker.patch(
@@ -1125,9 +930,8 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
     check_gc_agreement_deployments()
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
-
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
     mocked_update_agreement.assert_called_once()
     mocked_get_product_items_by_skus.assert_called()
     mocked_get_listing_by_id.assert_called_once()
@@ -1139,6 +943,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_error(
 
 def test_check_gc_agreement_deployments_create_agreement_subscription_enable_auto_renew(
     mocker,
+    mock_adobe_client,
     settings,
     mpt_error_factory,
     adobe_customer_factory,
@@ -1153,45 +958,30 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_enable_aut
         "PRODUCT_SEGMENT": {"PRD-1111-1111": "COM"},
     }
     settings.MPT_API_TOKEN_OPERATIONS = "operations_api_key"
-
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.global_customer.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-
     mocked_get_licensee = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_licensee",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.get_licensee", return_value=mocker.MagicMock()
     )
-
     mocked_update_agreement = mocker.patch(
-        "adobe_vipm.flows.global_customer.update_agreement",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.update_agreement", return_value=mocker.MagicMock()
     )
-
     mocked_get_listing_by_id = mocker.patch(
-        "adobe_vipm.flows.global_customer.get_listing_by_id",
-        return_value=mocker.MagicMock(),
+        "adobe_vipm.flows.global_customer.get_listing_by_id", return_value=mocker.MagicMock()
     )
     mocked_get_subscription_by_external_id = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement_subscription_by_external_id",
         return_value=[],
     )
-
     mocked_create_agreement_subscription = mocker.patch(
         "adobe_vipm.flows.global_customer.create_agreement_subscription",
         return_value=mocker.MagicMock(),
     )
-
     mocked_get_sku_price = mocker.patch(
         "adobe_vipm.airtable.models.get_prices_for_skus",
         side_effect=[
             {"65304578CA01A12": 1234.55, "77777777CA01A12": 100},
         ],
     )
-
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
         return_value=mocked_gc_agreement_deployments_model,
@@ -1202,14 +992,13 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_enable_aut
         return_value=product_items,
     )
     adobe_customer = adobe_customer_factory()
-    mocked_adobe_client.get_customer.return_value = adobe_customer
-    mocked_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = mocker.MagicMock()
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [
             adobe_subscription_factory(deployment_id="deployment_id", autorenewal_enabled=False)
         ]
     }
-
     mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
     mocked_get_agreement = mocker.patch(
         "adobe_vipm.flows.global_customer.get_agreement",
@@ -1217,12 +1006,12 @@ def test_check_gc_agreement_deployments_create_agreement_subscription_enable_aut
     )
 
     check_gc_agreement_deployments()
+
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_licensee.assert_called_once()
-    mocked_adobe_client.get_customer.assert_called_once()
-    mocked_adobe_client.get_customer_deployments_active_status.assert_called_once()
-    mocked_adobe_client.update_subscription.assert_called_once()
-
+    mock_adobe_client.get_customer.assert_called_once()
+    mock_adobe_client.get_customer_deployments_active_status.assert_called_once()
+    mock_adobe_client.update_subscription.assert_called_once()
     mocked_update_agreement.assert_called_once()
     mocked_get_product_items_by_skus.assert_called()
     mocked_get_listing_by_id.assert_called_once()

--- a/tests/flows/validation/test_shared.py
+++ b/tests/flows/validation/test_shared.py
@@ -83,20 +83,13 @@ def test_validate_duplicate_lines_step_no_lines(mocker, order_factory):
     "segment",
     [MARKET_SEGMENT_GOVERNMENT, MARKET_SEGMENT_EDUCATION, MARKET_SEGMENT_COMMERCIAL],
 )
-def test_get_preview_order_step(mocker, order_factory, adobe_order_factory, segment):
+def test_get_preview_order_step(
+    mocker, mock_adobe_client, order_factory, adobe_order_factory, segment
+):
     deployment_id = "deployment-id"
     adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_preview_order.return_value = adobe_preview_order
-    mocker.patch(
-        "adobe_vipm.flows.validation.shared.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
-
-    order = order_factory(
-        deployment_id=deployment_id,
-    )
-
+    mock_adobe_client.create_preview_order.return_value = adobe_preview_order
+    order = order_factory(deployment_id=deployment_id)
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
     context = Context(
@@ -114,8 +107,7 @@ def test_get_preview_order_step(mocker, order_factory, adobe_order_factory, segm
 
     assert context.validation_succeeded is True
     assert context.adobe_preview_order == adobe_preview_order
-
-    mocked_adobe_client.create_preview_order.assert_called_once_with(
+    mock_adobe_client.create_preview_order.assert_called_once_with(
         context.authorization_id,
         FAKE_CUSTOMERS_IDS[segment],
         context.order_id,
@@ -130,20 +122,13 @@ def test_get_preview_order_step(mocker, order_factory, adobe_order_factory, segm
     "segment",
     [MARKET_SEGMENT_GOVERNMENT, MARKET_SEGMENT_EDUCATION, MARKET_SEGMENT_COMMERCIAL],
 )
-def test_get_preview_order_step_no_deployment(mocker, order_factory, adobe_order_factory, segment):
+def test_get_preview_order_step_no_deployment(
+    mocker, mock_adobe_client, order_factory, adobe_order_factory, segment
+):
     deployment_id = None
     adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_preview_order.return_value = adobe_preview_order
-    mocker.patch(
-        "adobe_vipm.flows.validation.shared.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
-
-    order = order_factory(
-        deployment_id=deployment_id,
-    )
-
+    mock_adobe_client.create_preview_order.return_value = adobe_preview_order
+    order = order_factory(deployment_id=deployment_id)
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
     context = Context(
@@ -161,8 +146,7 @@ def test_get_preview_order_step_no_deployment(mocker, order_factory, adobe_order
 
     assert context.validation_succeeded is True
     assert context.adobe_preview_order == adobe_preview_order
-
-    mocked_adobe_client.create_preview_order.assert_called_once_with(
+    mock_adobe_client.create_preview_order.assert_called_once_with(
         context.authorization_id,
         FAKE_CUSTOMERS_IDS[segment],
         context.order_id,
@@ -173,18 +157,11 @@ def test_get_preview_order_step_no_deployment(mocker, order_factory, adobe_order
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
-def test_get_preview_order_step_no_lines(mocker, order_factory):
-    mocked_adobe_client = mocker.MagicMock()
-    mocker.patch(
-        "adobe_vipm.flows.validation.shared.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
+def test_get_preview_order_step_no_lines(mocker, mock_adobe_client, order_factory):
     order = order_factory()
     order["lines"] = []
-
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         upsize_lines=order["lines"],
@@ -196,24 +173,18 @@ def test_get_preview_order_step_no_lines(mocker, order_factory):
 
     assert context.validation_succeeded is True
     assert context.adobe_preview_order is None
-
-    mocked_adobe_client.create_preview_order.assert_not_called()
+    mock_adobe_client.create_preview_order.assert_not_called()
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
-def test_get_preview_order_step_api_error(mocker, order_factory, adobe_api_error_factory):
+def test_get_preview_order_step_api_error(
+    mocker, mock_adobe_client, order_factory, adobe_api_error_factory
+):
     error = AdobeAPIError(400, adobe_api_error_factory("9999", "unexpected"))
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_preview_order.side_effect = error
-    mocker.patch(
-        "adobe_vipm.flows.validation.shared.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
+    mock_adobe_client.create_preview_order.side_effect = error
     order = order_factory()
-
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         upsize_lines=order["lines"],
@@ -231,19 +202,12 @@ def test_get_preview_order_step_api_error(mocker, order_factory, adobe_api_error
     mocked_next_step.assert_not_called()
 
 
-def test_get_preview_order_step_product_not_found_error(mocker, order_factory):
+def test_get_preview_order_step_product_not_found_error(mocker, mock_adobe_client, order_factory):
     error = AdobeProductNotFoundError("Product not found")
-    mocked_adobe_client = mocker.MagicMock()
-    mocked_adobe_client.create_preview_order.side_effect = error
-    mocker.patch(
-        "adobe_vipm.flows.validation.shared.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
+    mock_adobe_client.create_preview_order.side_effect = error
     order = order_factory()
-
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         upsize_lines=order["lines"],
@@ -257,5 +221,4 @@ def test_get_preview_order_step_product_not_found_error(mocker, order_factory):
     assert context.validation_succeeded is False
     assert context.order["error"] == ERR_ADOBE_ERROR.to_dict(details=str(error))
     assert context.adobe_preview_order is None
-
     mocked_next_step.assert_not_called()

--- a/tests/flows/validation/test_termination.py
+++ b/tests/flows/validation/test_termination.py
@@ -1,6 +1,5 @@
 from freezegun import freeze_time
 
-from adobe_vipm.adobe.client import AdobeClient
 from adobe_vipm.adobe.dataclasses import ReturnableOrderInfo
 from adobe_vipm.flows.constants import ERR_INVALID_TERMINATION_ORDER_QUANTITY
 from adobe_vipm.flows.context import Context
@@ -19,6 +18,7 @@ from adobe_vipm.flows.validation.termination import (
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsizes_step_success(
     mocker,
+    mock_adobe_client,
     order_factory,
     lines_factory,
     adobe_customer_factory,
@@ -53,42 +53,27 @@ def test_validate_downsizes_step_success(
             subscription_id="6158e1cf0e4414a9b3a06d123969fdNA",
         ),
     )
-
     ret_info_1 = ReturnableOrderInfo(
-        adobe_order_1,
-        adobe_order_1["lineItems"][0],
-        adobe_order_1["lineItems"][0]["quantity"],
+        adobe_order_1, adobe_order_1["lineItems"][0], adobe_order_1["lineItems"][0]["quantity"]
     )
     ret_info_2 = ReturnableOrderInfo(
-        adobe_order_2,
-        adobe_order_2["lineItems"][0],
-        adobe_order_2["lineItems"][0]["quantity"],
+        adobe_order_2, adobe_order_2["lineItems"][0], adobe_order_2["lineItems"][0]["quantity"]
     )
     ret_info_3 = ReturnableOrderInfo(
-        adobe_order_3,
-        adobe_order_3["lineItems"][0],
-        adobe_order_3["lineItems"][0]["quantity"],
+        adobe_order_3, adobe_order_3["lineItems"][0], adobe_order_3["lineItems"][0]["quantity"]
     )
 
     sku = order["lines"][0]["item"]["externalIds"]["vendor"]
-
-    mocked_adobe_client = mocker.MagicMock(spec=AdobeClient)
-    mocked_adobe_client.get_returnable_orders_by_subscription_id.return_value = [
+    mock_adobe_client.get_returnable_orders_by_subscription_id.return_value = [
         ret_info_1,
         ret_info_2,
         ret_info_3,
     ]
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [{"status": "1000", "offerId": sku}]
     }
-
-    mocker.patch(
-        "adobe_vipm.flows.validation.termination.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         authorization_id=order["authorization"]["id"],
@@ -100,11 +85,11 @@ def test_validate_downsizes_step_success(
     step = ValidateDownsizes()
     step(mocked_client, context, mocked_next_step)
 
-    mocked_adobe_client.get_subscriptions.assert_called_once_with(
+    mock_adobe_client.get_subscriptions.assert_called_once_with(
         context.authorization_id,
         context.adobe_customer_id,
     )
-    mocked_adobe_client.get_returnable_orders_by_subscription_id.assert_called_once_with(
+    mock_adobe_client.get_returnable_orders_by_subscription_id.assert_called_once_with(
         context.authorization_id,
         context.adobe_customer_id,
         "6158e1cf0e4414a9b3a06d123969fdNA",
@@ -117,6 +102,8 @@ def test_validate_downsizes_step_success(
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsizes_step_no_returnable_orders(
     mocker,
+    mock_adobe_client,
+    mock_mpt_client,
     order_factory,
     lines_factory,
     adobe_customer_factory,
@@ -128,23 +115,12 @@ def test_validate_downsizes_step_no_returnable_orders(
         )
     )
     adobe_customer = adobe_customer_factory(coterm_date="2025-10-09")
-
-    mocked_adobe_client = mocker.MagicMock(spec=AdobeClient)
-    mocked_adobe_client.get_returnable_orders_by_subscription_id.return_value = []
-
     sku = order["lines"][0]["item"]["externalIds"]["vendor"]
-
-    mocker.patch(
-        "adobe_vipm.flows.validation.termination.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
-    mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_returnable_orders_by_subscription_id.return_value = []
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [{"status": "1000", "offerId": sku}]
     }
-
     context = Context(
         order=order,
         authorization_id=order["authorization"]["id"],
@@ -154,9 +130,9 @@ def test_validate_downsizes_step_no_returnable_orders(
     )
 
     step = ValidateDownsizes()
-    step(mocked_client, context, mocked_next_step)
+    step(mock_mpt_client, context, mocked_next_step)
 
-    mocked_adobe_client.get_subscriptions.assert_called_once_with(
+    mock_adobe_client.get_subscriptions.assert_called_once_with(
         context.authorization_id,
         context.adobe_customer_id,
     )
@@ -169,64 +145,39 @@ def test_validate_downsizes_step_no_returnable_orders(
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsizes_step_quantity_mismatch(
     mocker,
+    mock_adobe_client,
     order_factory,
     lines_factory,
     adobe_customer_factory,
     adobe_order_factory,
     adobe_items_factory,
 ):
-    order = order_factory(
-        lines=lines_factory(
-            quantity=3,
-            old_quantity=7,
-        )
-    )
+    order = order_factory(lines=lines_factory(quantity=3, old_quantity=7))
     adobe_customer = adobe_customer_factory(coterm_date="2025-10-09")
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
-        items=adobe_items_factory(
-            quantity=1,
-            subscription_id="6158e1cf0e4414a9b3a06d123969fdNA",
-        ),
+        items=adobe_items_factory(quantity=1, subscription_id="6158e1cf0e4414a9b3a06d123969fdNA"),
     )
     adobe_order_2 = adobe_order_factory(
         order_type="NEW",
-        items=adobe_items_factory(
-            quantity=2,
-            subscription_id="6158e1cf0e4414a9b3a06d123969fdNA",
-        ),
+        items=adobe_items_factory(quantity=2, subscription_id="6158e1cf0e4414a9b3a06d123969fdNA"),
     )
-
     ret_info_1 = ReturnableOrderInfo(
-        adobe_order_1,
-        adobe_order_1["lineItems"][0],
-        adobe_order_1["lineItems"][0]["quantity"],
+        adobe_order_1, adobe_order_1["lineItems"][0], adobe_order_1["lineItems"][0]["quantity"]
     )
     ret_info_2 = ReturnableOrderInfo(
-        adobe_order_2,
-        adobe_order_2["lineItems"][0],
-        adobe_order_2["lineItems"][0]["quantity"],
+        adobe_order_2, adobe_order_2["lineItems"][0], adobe_order_2["lineItems"][0]["quantity"]
     )
-
     sku = order["lines"][0]["item"]["externalIds"]["vendor"]
-
-    mocked_adobe_client = mocker.MagicMock(spec=AdobeClient)
-    mocked_adobe_client.get_returnable_orders_by_subscription_id.return_value = [
+    mock_adobe_client.get_returnable_orders_by_subscription_id.return_value = [
         ret_info_1,
         ret_info_2,
     ]
-
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [{"status": "1000", "offerId": sku}]
     }
-
-    mocker.patch(
-        "adobe_vipm.flows.validation.termination.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         authorization_id=order["authorization"]["id"],
@@ -238,9 +189,8 @@ def test_validate_downsizes_step_quantity_mismatch(
     step = ValidateDownsizes()
     step(mocked_client, context, mocked_next_step)
 
-    mocked_adobe_client.get_subscriptions.assert_called_once_with(
-        context.authorization_id,
-        context.adobe_customer_id,
+    mock_adobe_client.get_subscriptions.assert_called_once_with(
+        context.authorization_id, context.adobe_customer_id
     )
     assert not context.validation_succeeded
     assert context.order["error"] == ERR_INVALID_TERMINATION_ORDER_QUANTITY.to_dict()
@@ -250,31 +200,19 @@ def test_validate_downsizes_step_quantity_mismatch(
 @freeze_time("2024-11-09 12:30:00")
 def test_validate_downsizes_step_inactive_subscription(
     mocker,
+    mock_adobe_client,
     order_factory,
     lines_factory,
     adobe_customer_factory,
 ):
-    order = order_factory(
-        lines=lines_factory(
-            quantity=3,
-            old_quantity=7,
-        )
-    )
+    order = order_factory(lines=lines_factory(quantity=3, old_quantity=7))
     adobe_customer = adobe_customer_factory(coterm_date="2025-10-09")
     sku = order["lines"][0]["item"]["externalIds"]["vendor"]
-
-    mocked_adobe_client = mocker.MagicMock(spec=AdobeClient)
-    mocked_adobe_client.get_subscriptions.return_value = {
+    mock_adobe_client.get_subscriptions.return_value = {
         "items": [{"status": "1004", "offerId": sku}]
     }
-
-    mocker.patch(
-        "adobe_vipm.flows.validation.termination.get_adobe_client",
-        return_value=mocked_adobe_client,
-    )
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
-
     context = Context(
         order=order,
         authorization_id=order["authorization"]["id"],
@@ -285,18 +223,16 @@ def test_validate_downsizes_step_inactive_subscription(
 
     step = ValidateDownsizes()
     step(mocked_client, context, mocked_next_step)
-    mocked_adobe_client.get_subscriptions.assert_called_once_with(
-        context.authorization_id,
-        context.adobe_customer_id,
-    )
 
-    mocked_adobe_client.get_returnable_orders_by_subscription_id.assert_not_called()
+    mock_adobe_client.get_subscriptions.assert_called_once_with(
+        context.authorization_id, context.adobe_customer_id
+    )
+    mock_adobe_client.get_returnable_orders_by_subscription_id.assert_not_called()
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
 def test_validate_termination_order(mocker):
     mocked_pipeline_instance = mocker.MagicMock()
-
     mocked_pipeline_ctor = mocker.patch(
         "adobe_vipm.flows.validation.termination.Pipeline",
         return_value=mocked_pipeline_instance,
@@ -311,7 +247,6 @@ def test_validate_termination_order(mocker):
     validate_termination_order(mocked_client, mocked_order)
 
     assert len(mocked_pipeline_ctor.mock_calls[0].args) == 6
-
     expected_steps = [
         SetupContext,
         ValidateDuplicateLines,
@@ -320,12 +255,8 @@ def test_validate_termination_order(mocker):
         ValidateDownsizes,
         Validate3YCCommitment,
     ]
-
     actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args]
     assert actual_steps == expected_steps
 
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
-    mocked_pipeline_instance.run.assert_called_once_with(
-        mocked_client,
-        mocked_context,
-    )
+    mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)


### PR DESCRIPTION
Small refactor replacing the adobe client mock with the mock_adobe_client fixture