### PR TITLE
MPT-12622: remove WPS300 code from ignore

### DIFF
--- a/adobe_vipm/apps.py
+++ b/adobe_vipm/apps.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from mpt_extension_sdk.runtime.djapp.apps import DjAppConfig
 
-from .extension import ext
+from adobe_vipm.extension import ext
 
 
 class ExtensionConfig(DjAppConfig):

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,6 @@ per-file-ignores =
   adobe_vipm/management/commands/process_transfers.py: WPS110
   adobe_vipm/management/commands/sync_3yc_enrollments.py: WPS110 WPS114
   adobe_vipm/management/commands/sync_agreements.py: WPS110 WPS204
-  adobe_vipm/apps.py: WPS300
   adobe_vipm/notifications.py: WPS110 WPS202 WPS211 WPS213
   adobe_vipm/utils.py: WPS100 WPS110 WPS114
   adobe_vipm/management/commands/sync_3yc_enrol.py: WPS114


### PR DESCRIPTION
Remove [WPS111](https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/consistency.html#wemake_python_styleguide.violations.consistency.LocalFolderImportViolation) code from per-file-ignores