### PR TITLE
MPT-13788: update order fulfillment event to use new Context attribute in t…

### DIFF
--- a/adobe_vipm/extension.py
+++ b/adobe_vipm/extension.py
@@ -39,7 +39,7 @@ def jwt_secret_callback(client: MPTClient, claims: Mapping[str, Any]) -> str:
 @ext.events.listener("orders")
 def process_order_fulfillment(client: MPTClient, event) -> None:
     """Hook to process fulfillment order."""
-    fulfill_order(client, event.data)
+    fulfill_order(client, event.data.order)
 
 
 @ext.api.post(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,6 +1,7 @@
 import json
 
 from mpt_extension_sdk.core.events.dataclasses import Event
+from mpt_extension_sdk.flows.context import Context
 from mpt_extension_sdk.runtime.djapp.conf import get_for_product
 
 from adobe_vipm.extension import ext, jwt_secret_callback, process_order_fulfillment
@@ -13,23 +14,17 @@ def test_listener_registered():
 
 
 def test_process_order_fulfillment(mocker):
-    mocked_fulfill_order = mocker.patch(
-        "adobe_vipm.extension.fulfill_order",
-    )
-
+    mocked_fulfill_order = mocker.patch("adobe_vipm.extension.fulfill_order")
     client = mocker.MagicMock()
-    event = Event("evt-id", "orders", {"id": "ORD-0792-5000-2253-4210"})
+    event = Event("evt-id", "orders", Context(order={"id": "ORD-0792-5000-2253-4210"}))
 
     process_order_fulfillment(client, event)
 
-    mocked_fulfill_order.assert_called_once_with(client, event.data)
+    mocked_fulfill_order.assert_called_once_with(client, event.data.order)
 
 
 def test_jwt_secret_callback(mocker, settings, mpt_client, webhook):
-    mocked_webhook = mocker.patch(
-        "adobe_vipm.extension.get_webhook",
-        return_value=webhook,
-    )
+    mocked_webhook = mocker.patch("adobe_vipm.extension.get_webhook", return_value=webhook)
     assert jwt_secret_callback(mpt_client, {"webhook_id": "WH-123-123"}) == get_for_product(
         settings, "WEBHOOKS_SECRETS", "PRD-1111-1111"
     )
@@ -61,13 +56,9 @@ def test_process_order_validation(client, mocker, mock_order, order_factory, jwt
 
 
 def test_process_order_validation_error(client, mocker, jwt_token, webhook):
+    mocker.patch("adobe_vipm.extension.get_webhook", return_value=webhook)
     mocker.patch(
-        "adobe_vipm.extension.get_webhook",
-        return_value=webhook,
-    )
-    mocker.patch(
-        "adobe_vipm.extension.validate_order",
-        side_effect=Exception("A super duper error"),
+        "adobe_vipm.extension.validate_order", side_effect=Exception("A super duper error")
     )
     resp = client.post(
         "/api/v1/orders/validate",


### PR DESCRIPTION
…he event

The SDK event structure was changed here -> https://github.com/softwareone-platform/mpt-extension-sdk/pull/65

The update to this version didn't include that change, which caused this error during the fulfillment proccess ->

```
                               ╭─ Traceback (most recent call la─╮            
                                 │ /opt/venv/lib/python3.12/site-p │            
                                 │ ackages/mpt_extension_sdk/runti │            
                                 │ me/events/utils.py:69 in        │            
                                 │ wrapper                         │            
                                 │                                 │            
                                 │   66 │   @wraps(func)           │            
                                 │   67 │   def wrapper(client, ev │            
                                 │   68 │   │   try:               │            
                                 │ ❱ 69 │   │   │   func(client, e │            
                                 │   70 │   │   except Exception:  │            
                                 │   71 │   │   │   logger.excepti │            
                                 │   72                            │            
                                 │                                 │            
                                 │ /opt/project/adobe_vipm/extensi │            
                                 │ on.py:42 in                     │            
                                 │ process_order_fulfillment       │            
                                 │                                 │            
                                 │   39 @ext.events.listener("orde │            
                                 │   40 def process_order_fulfillm │            
                                 │   41 │   """Hook to process ful │            
                                 │ ❱ 42 │   fulfill_order(client,  │            
                                 │   43                            │            
                                 │   44                            │            
                                 │   45 @ext.api.post(             │            
                                 │                                 │            
                                 │ /opt/project/adobe_vipm/flows/f │            
                                 │ ulfillment/base.py:36 in        │            
                                 │ fulfill_order                   │            
                                 │                                 │            
                                 │   33 │   Returns:               │            
                                 │   34 │   │   None               │            
                                 │   35 │   """                    │            
                                 │ ❱ 36 │   logger.info - logger Resources and Information.  ("Start pro │            
                                 │   37 │                          │            
                                 │   38 │   validators = {         │            
                                 │   39 │   │   constants.ORDER_TY │            
                                 ╰─────────────────────────────────╯            
                                 TypeError: 'Context' object is not             
                                 subscriptable    
```