### PR TITLE
MPT-20023 handle errors when processing transfer lines

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -248,6 +248,10 @@ ERR_ADOBE_GOVERNMENT_VALIDATE_IS_NOT_LGA = ValidationError(
     ),
 )
 
+ERR_PROCESSING_TRANSFER_LINES = ValidationError(
+    "VIPM0042", "Errors processing transfer lines: {details}"
+)
+
 ERR_ADOBE_MEMBERSHIP_NOT_FOUND = "Membership not found"
 ERR_ADOBE_UNEXPECTED_ERROR = "Adobe returned an unexpected error"
 

--- a/adobe_vipm/flows/validation/transfer.py
+++ b/adobe_vipm/flows/validation/transfer.py
@@ -26,15 +26,12 @@ from adobe_vipm.flows.constants import (
     ERR_ADOBE_RESSELLER_CHANGE_LINES,
     ERR_ADOBE_UNEXPECTED_ERROR,
     ERR_NO_SUBSCRIPTIONS_WITHOUT_DEPLOYMENT,
+    ERR_PROCESSING_TRANSFER_LINES,
     ERR_UPDATING_TRANSFER_ITEMS,
     Param,
 )
 from adobe_vipm.flows.context import Context
-from adobe_vipm.flows.errors import (
-    GovernmentLGANotValidOrderError,
-    GovernmentNotValidOrderError,
-    MPTError,
-)
+from adobe_vipm.flows.errors import GovernmentLGANotValidOrderError, GovernmentNotValidOrderError
 from adobe_vipm.flows.helpers import (
     FetchResellerChangeData,
     UpdatePrices,
@@ -542,8 +539,15 @@ class AddResellerChangeLinesToOrder(Step):
 
     def __call__(self, mpt_client, context, next_step):
         """Add lines from reseller change back to the MPT order."""
-        order_lines_from_transfer = self._get_order_lines_from_transfer(context, mpt_client)
-
+        order_lines_from_transfer, errors = self._get_order_lines_from_transfer(context, mpt_client)
+        if errors:
+            logger.warning("Errors found while processing transfer lines: %s", errors)
+            context.order = set_order_error(
+                context.order,
+                ERR_PROCESSING_TRANSFER_LINES.to_dict(details="; ".join(errors)),
+            )
+            context.validation_succeeded = False
+            return
         if order_lines_from_transfer:
             if not context.order["lines"]:
                 logger.info("No existing order lines, proceeding with transfer lines")
@@ -584,13 +588,16 @@ class AddResellerChangeLinesToOrder(Step):
         )
         next_step(mpt_client, context)
 
-    def _get_order_lines_from_transfer(self, context: Context, mpt_client) -> list[Any]:
+    def _get_order_lines_from_transfer(
+        self, context: Context, mpt_client
+    ) -> tuple[list[Any], list[str]]:
+        errors = []
         no_deployment_transfer_items = [
             item for item in context.adobe_transfer["lineItems"] if not item.get("deploymentId", "")
         ]
         if not no_deployment_transfer_items:
             logger.info("No transfer items without deployment ID")
-            return []
+            return [], []
         logger.info(
             "Processing %d transfer items without deployment ID", len(no_deployment_transfer_items)
         )
@@ -615,11 +622,11 @@ class AddResellerChangeLinesToOrder(Step):
                 error_msg = f"No reseller item found for partial SKU '{partial_sku}'"
                 logger.error(error_msg)
                 send_error("Transfer Validation - Missing reseller item", error_msg)
-                raise MPTError(error_msg)
+                errors.append(error_msg)
             order_lines_from_transfer.append({"item": mapped_item, "quantity": item["quantity"]})
 
         logger.info("Created %d order lines from transfer items", len(order_lines_from_transfer))
-        return order_lines_from_transfer
+        return order_lines_from_transfer, errors
 
     @staticmethod
     def _transfer_order_lines_match(order_lines: list[dict], transfer_lines: list[dict]) -> bool:

--- a/tests/flows/validation/test_reseller_change.py
+++ b/tests/flows/validation/test_reseller_change.py
@@ -5,8 +5,7 @@ import pytest
 
 from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW
 from adobe_vipm.adobe.errors import AdobeAPIError
-from adobe_vipm.flows.constants import Param
-from adobe_vipm.flows.errors import MPTError
+from adobe_vipm.flows.constants import ERR_PROCESSING_TRANSFER_LINES, Param
 from adobe_vipm.flows.utils import get_ordering_parameter
 from adobe_vipm.flows.validation.transfer import validate_reseller_change
 
@@ -487,7 +486,7 @@ def test_validate_reseller_change_lines_different_line_count(
 
 
 @pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
-def test_validate_reseller_change_missing_reseller_item_raises_error(
+def test_validate_reseller_change_missing_reseller_item_sets_order_error(
     mock_adobe_client,
     mock_mpt_client,
     order_factory,
@@ -496,7 +495,7 @@ def test_validate_reseller_change_missing_reseller_item_raises_error(
     mock_get_product_items_by_skus,
     mock_send_error,
 ):
-    """Test that missing reseller item raises MPTError during validation."""
+    """Test that missing reseller item sets order validation error."""
     order = order_factory(
         order_parameters=reseller_change_order_parameters_factory(),
         lines=[],
@@ -515,11 +514,69 @@ def test_validate_reseller_change_missing_reseller_item_raises_error(
     )
     mock_get_product_items_by_skus.return_value = []
 
-    with pytest.raises(MPTError) as exc_info:
-        validate_reseller_change(mock_mpt_client, order)  # Act
+    has_errors, validated_order = validate_reseller_change(mock_mpt_client, order)  # Act
 
-    assert "No reseller item found for partial SKU '65304578CA'" in str(exc_info.value)
+    assert has_errors is True
+    assert validated_order["error"] == ERR_PROCESSING_TRANSFER_LINES.to_dict(
+        details="No reseller item found for partial SKU '65304578CA'"
+    )
     mock_send_error.assert_called_once_with(
         "Transfer Validation - Missing reseller item",
         "No reseller item found for partial SKU '65304578CA'",
+    )
+
+
+@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+def test_validate_reseller_change_multiple_missing_reseller_items_sets_aggregated_error(
+    mock_adobe_client,
+    mock_mpt_client,
+    order_factory,
+    reseller_change_order_parameters_factory,
+    adobe_reseller_change_preview_factory,
+    mock_get_product_items_by_skus,
+    mock_send_error,
+):
+    order = order_factory(
+        order_parameters=reseller_change_order_parameters_factory(),
+        lines=[],
+    )
+    mock_adobe_client.reseller_change_request.return_value = adobe_reseller_change_preview_factory(
+        items=[
+            {
+                "lineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "quantity": 10,
+                "subscriptionId": "sub-id-1",
+                "deploymentId": "",
+                "currencyCode": "USD",
+            },
+            {
+                "lineItemNumber": 2,
+                "offerId": "65304579CA01A12",
+                "quantity": 20,
+                "subscriptionId": "sub-id-2",
+                "deploymentId": "",
+                "currencyCode": "USD",
+            },
+        ]
+    )
+    mock_get_product_items_by_skus.return_value = []
+
+    has_errors, validated_order = validate_reseller_change(mock_mpt_client, order)  # Act
+
+    assert has_errors is True
+    assert validated_order["error"] == ERR_PROCESSING_TRANSFER_LINES.to_dict(
+        details=(
+            "No reseller item found for partial SKU '65304578CA'; "
+            "No reseller item found for partial SKU '65304579CA'"
+        )
+    )
+    assert mock_send_error.call_count == 2
+    mock_send_error.assert_any_call(
+        "Transfer Validation - Missing reseller item",
+        "No reseller item found for partial SKU '65304578CA'",
+    )
+    mock_send_error.assert_any_call(
+        "Transfer Validation - Missing reseller item",
+        "No reseller item found for partial SKU '65304579CA'",
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20023](https://softwareone.atlassian.net/browse/MPT-20023)

## Release Notes

- Added new validation error constant ERR_PROCESSING_TRANSFER_LINES (code: VIPM0042, message: "Errors processing transfer lines: {details}").
- Transfer-line generation now returns (order_lines, errors) and accumulates missing/mapped-item errors instead of raising MPTError.
- AddResellerChangeLinesToOrder.__call__ logs warnings when transfer-line errors exist, sets order-level error using ERR_PROCESSING_TRANSFER_LINES.to_dict(details="; ".join(errors")), marks validation as failed (validation_succeeded = False), and aborts further pipeline steps.
- _get_order_lines_from_transfer updated to return tuple[list, list[str]]; missing reseller-item cases append a line with item=None and record an error message rather than raising.
- Tests updated to reflect error-aggregation behavior: validate_reseller_change returns (has_errors, validated_order); tests assert has_errors is True and validated_order["error"] equals ERR_PROCESSING_TRANSFER_LINES.to_dict(...) and cover aggregated multiple-missing-item errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20023]: https://softwareone.atlassian.net/browse/MPT-20023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ