### PR TITLE
MPT-20097 add repository documentation structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,43 +1,8 @@
 ---
-description: 'Python coding conventions and guidelines'
-applyTo: '**/*.py'
+description: 'Repository entry point for Copilot'
+applyTo: '**'
 ---
 
-# Python Coding Conventions
+# Copilot Instructions
 
-## General Instructions
-- All configuration **must be provided via environment variables**.
-- Do not hardcode configuration values.
-- Write maintainable, readable, and predictable code.
-- In `pyproject.toml`:
-  - Use `*` for **minor versions only**
-    ✅ `django==4.2.*`
-    ❌ `django==^4.2.2`
-
-- Use consistent naming conventions and follow language-specific best practices.
-
-## Python Instructions
-- Use type annotations (PEP 484) - except in the `tests/` folder.
-- All public functions, methods, and classes **must include [Google-style docstrings](https://google.github.io/styleguide/pyguide.html)**.
-- **Do not add inline comments**; rely on clear code and docstrings instead.
-- Function and variable names must be explicit and intention-revealing.
-- `pyproject.toml` is the source of truth for code quality rules. Generated code must not violate any configured rules.
-- **ruff** is the primary linter for general Python style and best practices.
-- **flake8** is used exclusively to run:
-  - `wemake-python-styleguide` - Enforces strict Python coding standards ([docs](https://wemake-python-styleguide.readthedocs.io/en/latest/))
-  - `flake8-aaa` - Validates the AAA pattern in tests
-- Follow PEP 8 unless explicitly overridden by ruff.
-- Prefer simple, explicit code over clever or compact implementations.
-
-## Testing
-- Use pytest only.
-- Tests must be written as **functions**, not classes.
-- Test files and functions must use the `test_` prefix.
-- Follow ***AAA(Arrange - Act - Assert)*** strictly. See the [flake8-aaa documentation](https://flake8-aaa.readthedocs.io/en/stable/index.html).
-- Do **not** use `if` statements or branching logic inside tests.
-- Prefer fixtures over mocks whenever possible.
-- Avoid duplicating test logic; extract shared setup into fixtures.
-- Use `mocker` only when mocking is unavoidable.
-- Never use `unittest.mock` directly.
-- Always use `spec` or `autospec` when mocking.
-- Use `@pytest.mark.parametrize` tests when testing permutations of the same behavior.
+Read [AGENTS.md](../AGENTS.md) first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+Read this repository in the following order:
+
+1. [README.md](README.md) for the repository purpose, quick start, and documentation map.
+2. [docs/deployment.md](docs/deployment.md) for runtime configuration and deployment-facing settings.
+3. [docs/contributing.md](docs/contributing.md) for repository-specific workflow expectations.
+4. [docs/testing.md](docs/testing.md) before changing code or tests.
+5. [docs/migrations.md](docs/migrations.md) when a task mentions schema, data migrations, or transfer-processing migration logic.
+6. [docs/documentation.md](docs/documentation.md) when changing repository documentation.
+
+Then inspect the code paths relevant to the task:
+
+- [`adobe_vipm/extension.py`](adobe_vipm/extension.py): extension hooks, API entry point, and event listener registration
+- [`adobe_vipm/apps.py`](adobe_vipm/apps.py): Django app setup and startup-time configuration validation
+- [`adobe_vipm/flows/fulfillment/`](adobe_vipm/flows/fulfillment): fulfillment workflows by order action
+- [`adobe_vipm/flows/validation/`](adobe_vipm/flows/validation): validation workflows by order action
+- [`adobe_vipm/flows/sync/`](adobe_vipm/flows/sync): agreement, asset, subscription, and pricing synchronization flows
+- [`adobe_vipm/management/commands/`](adobe_vipm/management/commands): operational and scheduled commands
+- [`adobe_vipm/adobe/`](adobe_vipm/adobe) and [`adobe_vipm/airtable/`](adobe_vipm/airtable): integration-specific clients and models
+- [`tests/`](tests/): pytest coverage by domain area
+- [`make/`](make/): canonical local commands
+- [`helm/swo-extension-adobe/`](helm/swo-extension-adobe): deployment manifests for API and worker workloads
+
+Operational guidance:
+
+- Prefer documented `make` targets over ad hoc Docker commands.
+- Treat Docker Compose as the default local execution model.
+- Keep repository policy in `docs/` and keep `.github/copilot-instructions.md` thin.
+- Do not expand `README.md` into a full manual. Update the topic-specific file under `docs/`.
+- Do not infer undocumented deployment or migration behavior. If the code does not make it explicit, document the current constraint instead of inventing rules.

--- a/README.md
+++ b/README.md
@@ -1,270 +1,61 @@
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=softwareone-platform_swo-adobe-vipm-extension&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=softwareone-platform_swo-adobe-vipm-extension) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=softwareone-platform_swo-adobe-vipm-extension&metric=coverage)](https://sonarcloud.io/summary/new_code?id=softwareone-platform_swo-adobe-vipm-extension)
-
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-
 # SoftwareONE Adobe VIP Marketplace Extension
-Extension integrates Adobe VIP Marketplace Extension with the SoftwareONE Marketplace
 
-## Getting started
+`swo-adobe-vipm-extension` is a SoftwareOne Marketplace extension for Adobe VIP Marketplace.
 
-### Prerequisites
+The repository contains:
 
-- Docker and Docker Compose plugin (`docker compose` CLI)
+- a Django-based extension runtime
+- Marketplace order validation and fulfillment flows
+- Adobe synchronization and transfer-processing logic
+- operational commands for workers and scheduled jobs
+- Helm deployment charts for API and worker workloads
+
+## Documentation
+
+Start here:
+
+- [AGENTS.md](AGENTS.md): entry point for AI agents
+- [docs/deployment.md](docs/deployment.md): runtime configuration and deployment model
+- [docs/contributing.md](docs/contributing.md): repository-specific development workflow
+- [docs/testing.md](docs/testing.md): testing strategy and commands
+- [docs/migrations.md](docs/migrations.md): migration workflow and migration-specific constraints
+- [docs/documentation.md](docs/documentation.md): repository documentation rules
+
+## Quick Start
+
+Prerequisites:
+
+- Docker with the `docker compose` plugin
 - `make`
-- [CodeRabbit CLI](https://www.coderabbit.ai/cli) (optional. Used for running review check locally)
 
-
-### Make targets overview
-
-Common development workflows are wrapped in the `Makefile`. Run `make help` to see the list of available commands.
-
-### How the Makefile works
-
-The project uses a modular Makefile structure that organizes commands into logical groups:
-
-- **Main Makefile** (`Makefile`): Entry point that automatically includes all `.mk` files from the `make/` directory
-- **Modular includes** (`make/*.mk`): Commands are organized by category:
-  - `common.mk` - Core development commands (build, test, format, etc.)
-  - `repo.mk` - Repository management and dependency commands
-  - `migrations.mk` - Database migration commands (Only available in extension repositories)
-  - `external_tools.mk` - Integration with external tools
-
-
-You can extend the Makefile with your own custom commands creating a `local.mk` file inside make folder. This file is
-automatically ignored by git, so your personal commands won't affect other developers or appear in version control.
-
-
-### Setup
-
-Follow these steps to set up the development environment:
-
-#### 1. Clone the repository
-
-```bash
-git clone <repository-url>
-```
-```bash
-cd swo-adobe-vipm-extension
-```
-
-#### 2. Create environment configuration
-
-Copy the sample environment file and update it with your values:
+Recommended setup:
 
 ```bash
 cp .env.sample .env
-```
-
-Edit the `.env` file with your actual configuration values. See the [Configuration](#configuration) section for details on available variables.
-
-In the project root, create and configure the following files.
-
-#### Adobe secrets file
-
-Create `adobe_credentials.json`:
-
-```bash
-touch adobe_credentials.json
-```
-
-Fill it with your Adobe credentials:
-
-```json
-[
-    {
-        "authorization_uk": "<authorization-uk>",
-        "authorization_id": "<authorization-id>",
-        "name": "<name>",
-        "client_id": "<client-id>",
-        "client_secret": "<client-secret>"
-    },
-    {"...": "..."}
-]
-```
-
-Example:
-
-```json
-[
-    {
-        "authorization_uk": "auth-adobe-us-01",
-        "authorization_id": "AUT-1111-1111",
-        "name": "Credentials for US",
-        "client_id": "cc7fce0d-f2e8-45c2-a61e-452b31d096c7",
-        "client_secret": "cltn3c1eo0001m5pxkdcmd8cl"
-    }
-]
-```
-
-#### Adobe authorizations file
-
-Create `adobe_authorizations.json`:
-
-```bash
-touch adobe_authorizations.json
-```
-
-Fill it with your Adobe authorizations:
-
-```json
-{
-    "authorizations": [
-        {
-            "authorization_uk": "<authorization-uk>",
-            "authorization_id": "<authorization-id>",
-            "distributor_id": "<distributor-id>",
-            "currency": "USD",
-            "resellers": [
-                {
-                    "id": "<adobe-reseller-id>",
-                    "seller_id": "<seller-id>",
-                    "seller_uk": "<seller-uk>"
-                }
-            ]
-        }
-    ]
-}
-```
-
-Example:
-
-```json
-{
-    "authorizations": [
-        {
-            "authorization_uk": "auth-adobe-us-01",
-            "authorization_id": "AUT-1111-1111",
-            "distributor_id": "db5a6d9c-9eb5-492e-a000-ab4b8c29fc63",
-            "currency": "USD",
-            "resellers": [
-                {
-                    "id": "P1000041107",
-                    "seller_id": "SEL-1111-1111",
-                    "seller_uk": "SWO_US"
-                }
-            ]
-        }
-    ]
-}
-```
-
-#### 3. Build the Docker images
-
-Build the development environment:
-
-```bash
 make build
-```
-
-This will create the Docker images with all required dependencies and the virtualenv.
-
-#### 4. Verify the setup
-
-Run the test suite to ensure everything is configured correctly:
-
-```bash
 make test
-```
-
-You're now ready to start developing! See [Running the service](#running-the-service) for next steps.
-
-
-## Running the service
-
-Before running, ensure your `.env` file is populated with real endpoints and tokens.
-
-Start the app:
-
-```bash
 make run
 ```
 
-The service will be available at `http://localhost:8080`.
+The application runs on `http://localhost:8080`.
 
-Example `.env` snippet for real services:
+See [docs/deployment.md](docs/deployment.md) for runtime parameters and the Docker-based local execution context.
 
-```env
-EXT_ADOBE_API_BASE_URL=<adobe-vipm-api>
-EXT_ADOBE_AUTH_ENDPOINT_URL=<adobe-vipm-authentication-url>
-EXT_ADOBE_CREDENTIALS_FILE=/extension/adobe_credentials.json
-EXT_WEBHOOKS_SECRETS={"PRD-1111-1111": "<webhook-secret-for-product>", "PRD-2222-2222": "<webhook-secret-for-product>"}
-MPT_API_BASE_URL=https://api.s1.show/public
-MPT_API_TOKEN=c0fdafd7-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-MPT_PORTAL_BASE_URL=https://portal.s1.show
-MPT_PRODUCTS_IDS=PRD-1111-1111,PRD-2222-2222
-MPT_TOOL_STORAGE_TYPE=airtable
-MPT_TOOL_STORAGE_AIRTABLE_API_KEY=<fake-airtable-api-key>
-MPT_TOOL_STORAGE_AIRTABLE_BASE_ID=<fake-storage-airtable-base-id>
-MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME=<fake-storage-airtable-table-name>
-```
+## Repository Layout
 
-`MPT_PRODUCTS_IDS` is a comma-separated list of SWO Marketplace Product identifiers.
-For each product ID in the `MPT_PRODUCTS_IDS` list, define the corresponding entry in the `EXT_WEBHOOKS_SECRETS` JSON using the product ID as the key.
+- [`adobe_vipm/`](adobe_vipm): extension package and business flows
+- [`tests/`](tests): pytest suite
+- [`make/`](make): modular make targets
+- [`migrations/`](migrations): `mpt-service-cli` migration scripts
+- [`helm/swo-extension-adobe/`](helm/swo-extension-adobe): Helm charts for deployment
 
-
-
-## Developer utilities
-
-Useful helper targets during development:
+## Common Commands
 
 ```bash
-make bash      # open a bash shell in the app container
-make check     # run ruff, flake8, and lockfile checks
-make check-all # run checks and tests
-make format    # auto-format code and imports
-make review    # check the code in the cli by running CodeRabbit
-make shell     # open a Django shell in the app container
+make build
+make run
+make test
+make check
+make check-all
+make shell
 ```
-
-### Migration commands
-
-The mpt-tool provides commands for managing database migrations:
-
-```bash
-make migrate-check                           # check migration status
-make migrate-data                            # run data migrations
-make migrate-schema                          # run schema migrations
-make migrate-list                            # list available migrations
-make migrate-new-data name=migration_id      # create a new data migration
-make migrate-new-schema name=migration_id    # create a new schema migration
-```
-
-
-# Configuration
-
-The following environment variables are typically set in `.env`. Docker Compose reads them when using the Make targets described above.
-
-## Application
-
-| Environment Variable                   | Default                 | Example                                 | Description                                                                               |
-|----------------------------------------|-------------------------|-----------------------------------------|-------------------------------------------------------------------------------------------|
-| `EXT_ADOBE_API_BASE_URL`               | -                       | `https://partner-example.adobe.io`      | Path to Adobe VIPM API                                                                    |
-| `EXT_ADOBE_AUTHORIZATIONS_FILE`        | -                       | /extension/adobe_authorizations.json    | Path to Adobe authorizations file                                                         |
-| `EXT_ADOBE_AUTH_ENDPOINT_URL`          | -                       | `https://auth.partner-example.adobe.io` | Path to Adobe VIPM authentication API                                                     |
-| `EXT_ADOBE_CREDENTIALS_FILE`           | -                       | /extension/adobe_credentials.json       | Path to Adobe credentials file                                                            |
-| `EXT_AIRTABLE_SKU_MAPPING_BASE`        | -                       | appXXXXXXXXXXXXXXXX                     | Airtable base ID for the SKU mapping                                                      |
-| `EXT_NAV_AUTH_AUDIENCE`                | -                       | `api://default`                         | Audience/identifier string used by the NAV auth provider for JWT validation               |
-| `EXT_WEBHOOKS_SECRETS`                 | -                       | {"PRD-1111-1111": "123qweasd3432234"}   | Webhook secret of the Draft validation Webhook in SoftwareONE Marketplace for the product |
-| `MPT_API_BASE_URL`                     | `http://localhost:8000` | `https://api.s1.show`                   | SoftwareONE Marketplace API URL                                                           |
-| `MPT_API_TOKEN`                        | -                       | eyJhbGciOiJSUzI1N...                    | SoftwareONE Marketplace API Token                                                         |
-| `MPT_NOTIFY_CATEGORIES`                | -                       | {"ORDERS": "NTC-0000-0006"}             | SoftwareONE Marketplace Notification Categories                                           |
-| `MPT_PORTAL_BASE_URL`                  | `http://localhost:8000` | `https://portal.softwareone.com`        | Base URL for the Marketplace Portal used to construct portal links and API endpoints      |
-| `MPT_PRODUCTS_IDS`                     | PRD-1111-1111           | PRD-1234-1234,PRD-4321-4321             | Comma-separated list of SoftwareONE Marketplace Product ID                                |
-| `MPT_TOOL_STORAGE_TYPE`                | `local`                 | `airtable`                              | Storage type for MPT tools (local or airtable)                                            |
-| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY`    | -                       | patXXXXXXXXXXXXXX                       | Airtable API key for MPT tool storage (required when storage type is airtable)            |
-| `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID`    | -                       | appXXXXXXXXXXXXXX                       | Airtable base ID for MPT tool storage (required when storage type is airtable)            |
-| `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` | -                       | MigrationTracking                       | Airtable table name for MPT tool storage (required when storage type is airtable)         |
-
-### Azure AppInsights
-
-| Environment Variable                    | Default                            | Example                                                                                                                                                                                               | Description                                                                                                   |
-|-----------------------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| `APPLICATIONINSIGHTS_CONNECTION_STRING` | -                                  | `InstrumentationKey=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;IngestionEndpoint=https://westeurope-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/` | Azure Application Insights connection string                                                                  |
-| `LOGGING_ATTEMPT_GETTER`                | adobe_vipm.utils.get_attempt_count | adobe_vipm.utils.get_attempt_count                                                                                                                                                                    | Path to python function that retrieves order processing attempt to put it into the Azure Application Insights |
-| `OTEL_SERVICE_NAME`                     | -                                  | Swo.Extensions.AdobeVIPM                                                                                                                                                                              | Service name that is visible in the AppInsights logs                                                          |
-
-### Other
-
-| Environment Variable                   | Default | Example | Description                                                          |
-|----------------------------------------|---------|---------|----------------------------------------------------------------------|
-| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | 120     | 60      | Orders polling interval from the Software Marketplace API in seconds |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,55 @@
+# Contributing
+
+This document captures repository-specific contribution guidance.
+
+Shared engineering rules live in `mpt-extension-skills` and should not be duplicated here:
+
+- documentation standard: [documentation.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/documentation.md)
+- makefile structure: [makefiles.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/makefiles.md)
+- commit message rules: [commit-messages.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/commit-messages.md)
+- dependency management: [packages-and-dependencies.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/packages-and-dependencies.md)
+- extension design guidance: [extensions-best-practices.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/extensions-best-practices.md)
+- pull request rules: [pull-requests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/pull-requests.md)
+- Python coding conventions: [python-coding.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/python-coding.md)
+
+Shared operational knowledge also applies:
+
+- build and validation flow: [knowledge/build-and-checks.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/build-and-checks.md)
+- common make target meanings: [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+## Development Model
+
+The default development model for this repository is Docker-based.
+
+- Use `make build` to build the local image and install dependencies.
+- Use `make run` to start the service through Docker Compose.
+- Use `make bash` or `make shell` when you need an interactive container session.
+
+## Code Organization Expectations
+
+Repository-specific expectations:
+
+- keep extension entry-point changes close to [`adobe_vipm/extension.py`](../adobe_vipm/extension.py) and [`adobe_vipm/apps.py`](../adobe_vipm/apps.py)
+- keep business behavior under the relevant domain directory in [`adobe_vipm/flows/`](../adobe_vipm/flows)
+- keep operational command logic in [`adobe_vipm/management/commands/`](../adobe_vipm/management/commands)
+- keep tests under [`tests/`](../tests), mirroring production structure where practical
+- update documentation in the matching file under [`docs/`](.) when runtime, testing, or setup behavior changes
+
+## Validation Before Review
+
+Use the repository command entry points before review:
+
+```bash
+make check
+make test
+```
+
+Use `make check-all` when you want the combined workflow.
+
+See [testing.md](testing.md) for repository-specific testing expectations.
+
+## Documentation Changes
+
+Documentation rules live in [documentation.md](documentation.md).
+
+When changing docs, update the smallest relevant file instead of duplicating policy across multiple documents.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,160 @@
+# Deployment
+
+This document is the source of truth for runtime configuration referenced by local development and deployment flows.
+
+## Deployment Model
+
+The repository deploys more than one workload shape from [`helm/swo-extension-adobe/`](../helm/swo-extension-adobe):
+
+- an API workload
+- a worker workload
+- cron-style worker jobs for commands such as `process_transfers`, `check_running_transfers`, `sync_agreements`, `process_3yc`, `check_gc_agreement_deployments`, and `sync_3yc_enrol`
+
+## Configuration Source
+
+Local Docker Compose reads `.env`.
+
+Deployed workloads receive configuration through Helm config maps, secrets, and mounted JSON files. The deployed templates map the same runtime variables used locally.
+
+## Core Marketplace Settings
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `MPT_API_BASE_URL` | `http://localhost:8000` | `https://api.s1.show` | SoftwareOne Marketplace API base URL |
+| `MPT_API_TOKEN` | - | `eyJhbGciOiJSUzI1N...` | Marketplace API token |
+| `MPT_PORTAL_BASE_URL` | `http://localhost:8000` | `https://portal.softwareone.com` | Marketplace portal base URL |
+| `MPT_PRODUCTS_IDS` | `PRD-1111-1111` | `PRD-1111-1111,PRD-2222-2222` | Comma-separated Marketplace product ids |
+| `MPT_NOTIFY_CATEGORIES` | `{"ORDERS": "NTC-0000-0006"}` | `{"ORDERS": "NTC-0000-0006"}` | Marketplace notification category mapping |
+| `MPT_ORDERS_API_POLLING_INTERVAL_SECS` | `120` | `60` | Order polling interval |
+
+## Adobe Integration Settings
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `EXT_ADOBE_API_BASE_URL` | - | `https://partner-example.adobe.io` | Adobe VIPM API base URL |
+| `EXT_ADOBE_AUTH_ENDPOINT_URL` | - | `https://auth.partner-example.adobe.io` | Adobe authentication endpoint |
+| `EXT_ADOBE_AUTHORIZATIONS_FILE` | - | `/extension/adobe_authorizations.json` | Path to Adobe authorizations JSON |
+| `EXT_ADOBE_CREDENTIALS_FILE` | - | `/extension/adobe_credentials.json` | Path to Adobe credentials JSON |
+| `EXT_WEBHOOKS_SECRETS` | - | `{"PRD-1111-1111":"secret"}` | Per-product webhook secret mapping |
+| `EXT_PRODUCT_SEGMENT` | - | `{"PRD-1111-1111":"COM"}` | Per-product segment mapping |
+| `EXT_ORDER_CREATION_WINDOW_HOURS` | `24` | `24` | Window used by order-creation logic |
+
+## Airtable And Tool Storage Settings
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `MPT_TOOL_STORAGE_TYPE` | `local` | `airtable` | `mpt-tool` storage backend |
+| `MPT_TOOL_STORAGE_AIRTABLE_API_KEY` | - | `patXXXXXXXX` | Airtable API key for `mpt-tool` storage |
+| `MPT_TOOL_STORAGE_AIRTABLE_BASE_ID` | - | `appXXXXXXXX` | Airtable base id for `mpt-tool` storage |
+| `MPT_TOOL_STORAGE_AIRTABLE_TABLE_NAME` | - | `MigrationTracking` | Airtable table for `mpt-tool` storage |
+| `EXT_AIRTABLE_API_TOKEN` | - | `patXXXXXXXX` | Airtable API token used by repository-specific flows |
+| `EXT_AIRTABLE_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for migration and transfer data |
+| `EXT_AIRTABLE_PRICING_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for pricing data |
+| `EXT_AIRTABLE_SKU_MAPPING_BASE` | - | `appXXXXXXXX` | Airtable base id for SKU mapping |
+| `EXT_MIGRATION_RUNNING_MAX_RETRIES` | `10` | `10` | Retry limit for migration-running logic |
+
+## NAV Settings
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `EXT_NAV_API_BASE_URL` | - | `https://api.nav` | NAV API base URL |
+| `EXT_NAV_AUTH_ENDPOINT_URL` | - | `https://authenticate.nav` | NAV auth endpoint |
+| `EXT_NAV_AUTH_AUDIENCE` | - | `api://default` | NAV auth audience |
+| `EXT_NAV_AUTH_CLIENT_ID` | - | `<client-id>` | NAV auth client id |
+| `EXT_NAV_AUTH_CLIENT_SECRET` | - | `<client-secret>` | NAV auth client secret |
+
+## Notifications And Observability
+
+| Environment Variable | Default | Example | Description |
+| --- | --- | --- | --- |
+| `EXT_MSTEAMS_WEBHOOK_URL` | - | `https://...office.com/...` | Microsoft Teams webhook used by notification helpers |
+| `EXT_EMAIL_NOTIFICATIONS_ENABLED` | - | `true` | Enables email notification flows where configured |
+| `EXT_EMAIL_NOTIFICATIONS_SENDER` | - | `noreply@example.com` | Sender address for email notifications |
+| `EXT_AWS_SES_REGION` | - | `eu-west-1` | AWS SES region |
+| `EXT_AWS_SES_CREDENTIALS` | - | `<json-or-secret-ref>` | AWS SES credentials |
+| `EXT_GC_EMAIL_NOTIFICATIONS_RECIPIENT` | - | `ops@example.com` | Recipient list for global-customer notification flows |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | - | `InstrumentationKey=...` | Azure Application Insights connection string |
+| `OTEL_SERVICE_NAME` | - | `Swo.Extensions.AdobeVIPM` | Telemetry service name |
+
+## File-Based Secrets
+
+The runtime reads Adobe authorizations and credentials from the file paths provided by:
+
+- `EXT_ADOBE_AUTHORIZATIONS_FILE`
+- `EXT_ADOBE_CREDENTIALS_FILE`
+
+In local Docker Compose runs, these usually point to files in the repository root because the repository is mounted at `/extension`.
+
+In deployed environments, the same paths are expected to exist inside the container through mounted secrets or equivalent file injection.
+
+## Adobe JSON File Formats
+
+### `EXT_ADOBE_CREDENTIALS_FILE`
+
+The credentials file must be a JSON array. Each item represents one Adobe authorization credential set.
+
+Expected fields:
+
+- `authorization_uk`
+- `authorization_id`
+- `name`
+- `client_id`
+- `client_secret`
+
+Example:
+
+```json
+[
+  {
+    "authorization_uk": "pl-adobe-auth-us",
+    "authorization_id": "AUT-5774-7413",
+    "name": "Credentials for US",
+    "client_id": "<client-id>",
+    "client_secret": "<client-secret>"
+  }
+]
+```
+
+The `authorization_uk` value must match the corresponding authorization entry in `EXT_ADOBE_AUTHORIZATIONS_FILE`.
+
+### `EXT_ADOBE_AUTHORIZATIONS_FILE`
+
+The authorizations file must be a JSON object with an `authorizations` array.
+
+Each authorization entry is expected to contain:
+
+- `authorization_uk`
+- `authorization_id`
+- `distributor_id`
+- `currency`
+- `resellers`
+
+Each reseller entry is expected to contain:
+
+- `id`
+- `seller_uk`
+- optionally `seller_id`
+
+Example:
+
+```json
+{
+  "authorizations": [
+    {
+      "authorization_uk": "pl-adobe-auth-us",
+      "authorization_id": "AUT-5774-7413",
+      "distributor_id": "db5a6d9c-9eb5-492e-a000-ab4b8c29fc63",
+      "currency": "USD",
+      "resellers": [
+        {
+          "id": "P1000050972",
+          "seller_id": "SEL-7282-9889",
+          "seller_uk": "SWO_US"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The repository loads credentials by `authorization_uk` and augments reseller data from the authorization file, so the two files must stay consistent.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,28 @@
+# Documentation
+
+This repository follows the shared documentation standard:
+
+- [standards/documentation.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/documentation.md)
+
+This file documents repository-specific documentation rules only.
+
+## Repository Rules
+
+- `README.md` must stay short and act as the main human entry point.
+- `AGENTS.md` must stay operational and tell AI agents which files to read first.
+- Topic-specific behavior must live in the matching file under [`docs/`](.).
+- `.github/copilot-instructions.md` must remain a thin adapter that points back to [`AGENTS.md`](../AGENTS.md).
+- When runtime, testing, migration, or setup behavior changes, update the corresponding document in the same change.
+
+## Current Documentation Map
+
+- [`README.md`](../README.md): human entry point, overview, quick start, and documentation map
+- [`AGENTS.md`](../AGENTS.md): AI entry point and reading order
+- [`deployment.md`](deployment.md): runtime configuration and deployment model
+- [`contributing.md`](contributing.md): repository-specific development workflow
+- [`testing.md`](testing.md): testing strategy and command mapping
+- [`migrations.md`](migrations.md): migration workflow and migration-specific constraints
+
+## Documentation Change Rule
+
+When documentation changes, prefer updating the smallest relevant document instead of creating overlapping summary files.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,32 @@
+# Migrations
+
+Shared migration knowledge lives in:
+
+- [knowledge/migrations.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/migrations.md)
+- [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+This file documents repository-specific migration behavior only.
+
+## Migration Files
+
+Repository migration scripts live in [`migrations/`](../migrations).
+
+This repository uses the standard migration workflow and standard make-based command wiring used across related repositories. Use the shared migration knowledge above as the primary reference.
+
+## Repository-Specific Constraint
+
+Do not confuse two different concepts in this repository:
+
+- [`migrations/`](../migrations) contains `mpt-service-cli` migration scripts
+- [`adobe_vipm/flows/migration.py`](../adobe_vipm/flows/migration.py) contains business logic for transfer-processing and related operational flows
+
+Changing transfer-processing logic does not automatically mean a new `mpt-service-cli` migration is required.
+
+## When To Update This Document
+
+Update this file when the repository changes:
+
+- migration file locations
+- migration command entry points
+- required execution order
+- rollout or safety constraints specific to this repository

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,72 @@
+# Testing
+
+Shared unit-test rules live in [unittests.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/standards/unittests.md).
+
+Shared build and target knowledge also applies:
+
+- [knowledge/build-and-checks.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/build-and-checks.md)
+- [knowledge/make-targets.md](https://github.com/softwareone-platform/mpt-extension-skills/blob/main/knowledge/make-targets.md)
+
+This file documents repository-specific testing behavior.
+
+## Test Scope
+
+The repository currently has stable coverage in these areas:
+
+- extension registration and startup checks in [`tests/test_apps.py`](../tests/test_apps.py) and [`tests/test_extension.py`](../tests/test_extension.py)
+- Adobe client and configuration behavior in [`tests/adobe/`](../tests/adobe)
+- Airtable model behavior in [`tests/airtable/`](../tests/airtable)
+- fulfillment, validation, sync, migration, Marketplace, NAV, and helper flows in [`tests/flows/`](../tests/flows)
+- management commands in [`tests/management/commands/`](../tests/management/commands)
+- notification and utility helpers in [`tests/test_notifications.py`](../tests/test_notifications.py) and [`tests/test_utils.py`](../tests/test_utils.py)
+
+## Commands
+
+Use the repository make targets:
+
+```bash
+make test
+make check
+make check-all
+```
+
+Repository command mapping:
+
+- `make test` runs `pytest`
+- `make check` runs `ruff format --check`, `ruff check`, `flake8`, and `uv lock --check`
+- `make check-all` runs both checks and tests
+
+The CI workflow in [`.github/workflows/pr-build-merge.yml`](../.github/workflows/pr-build-merge.yml) uses the same `make build` and `make check-all` flow.
+
+## Pytest Configuration
+
+Repository-specific test settings come from [`pyproject.toml`](../pyproject.toml):
+
+- tests are discovered under `tests`
+- `pythonpath` includes the repository root
+- coverage is collected for `adobe_vipm`
+- `DJANGO_SETTINGS_MODULE` is `tests.django.settings`
+- tests run with `--import-mode=importlib`
+
+## Writing Tests
+
+Repository-specific guidance:
+
+- prefer existing fixtures from [`tests/conftest.py`](../tests/conftest.py) and domain-specific `conftest.py` files under `tests/`
+- add or update tests next to the affected domain area instead of creating catch-all test files
+- keep external service calls mocked; do not make live Adobe, Marketplace, Airtable, NAV, or notification calls in tests
+- cover action-specific behavior in the matching fulfillment or validation test module when changing those flows
+- cover command behavior in [`tests/management/commands/`](../tests/management/commands) when changing scheduled or operational commands
+
+## When Tests Are Required
+
+Add or update tests when a change modifies:
+
+- extension startup or webhook handling
+- validation behavior
+- fulfillment behavior
+- synchronization behavior
+- management command behavior
+- Airtable, NAV, or notification integration logic
+
+If a change only affects documentation, tests are not required.


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary
- align repository documentation with the shared documentation standard
- add AGENTS.md and focused docs for deployment, contributing, testing, migrations, and documentation rules
- reduce README.md to a concise navigation entry point and keep Copilot instructions as a thin adapter

## Testing
- not run (documentation-only changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20097](https://softwareone.atlassian.net/browse/MPT-20097)

- Added `AGENTS.md` as the AI-focused repository entry point, defining documentation reading sequence and primary code-path locations for common tasks
- Simplified `.github/copilot-instructions.md` to a minimal adapter that directs to `AGENTS.md`, removing Python-specific conventions and tooling details
- Refactored `README.md` to a concise human-focused navigation entry point, removing badges, detailed configuration tables, and developer utility targets while adding a "Documentation" section linking to focused docs
- Added `docs/contributing.md` documenting contribution guidelines, Makefile command mappings, code organization expectations, and validation steps
- Added `docs/deployment.md` specifying runtime configuration for Docker Compose and Helm deployments, including required environment variables and JSON file structures for Adobe credentials and authorizations
- Added `docs/documentation.md` establishing repository-specific documentation rules and maintaining a documentation map for the repository
- Added `docs/migrations.md` scoping repository-specific migration behavior and distinguishing between migration scripts and business logic
- Added `docs/testing.md` defining test scope, how to run tests using `make` targets, pytest configuration settings, and test placement guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20097]: https://softwareone.atlassian.net/browse/MPT-20097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ