### PR TITLE
MPT-18381 Implement the changes to store the Adobe order ids in chang…

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -66,6 +66,7 @@ class Param(StrEnum):
     LINKED_MEMBERSHIP_TYPE = "lmType"
     LINKED_MEMBERSHIP_ROLE = "lmRole"
     LINKED_MEMBERSHIP_CREATED = "lmCreated"
+    ADOBE_ORDER_IDS = "adobeOrderIds"
 
 
 PARAM_REQUIRED_CUSTOMER_ORDER = (

--- a/adobe_vipm/flows/fulfillment/reseller_transfer.py
+++ b/adobe_vipm/flows/fulfillment/reseller_transfer.py
@@ -23,6 +23,7 @@ from adobe_vipm.flows.utils.order import set_adobe_order_id, split_downsizes_ups
 from adobe_vipm.flows.utils.parameter import (
     get_change_reseller_admin_email,
     get_change_reseller_code,
+    set_adobe_order_ids_created_parameter,
 )
 
 logger = logging.getLogger(__name__)
@@ -158,6 +159,10 @@ class CommitResellerChange(Step):
                 ),
             )
             return
+
+        context.order = set_adobe_order_ids_created_parameter(
+            context, [context.adobe_transfer_order.get("transferId")]
+        )
 
         context.order = set_adobe_order_id(
             context.order, context.adobe_transfer_order.get("transferId")

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1,7 +1,6 @@
 """This module contains shared functions used by the different fulfillment flows."""
 
 import datetime as dt
-import json
 import logging
 from collections import Counter
 
@@ -85,6 +84,9 @@ from adobe_vipm.flows.utils import (
 )
 from adobe_vipm.flows.utils.customer import has_coterm_date, set_agency_type
 from adobe_vipm.flows.utils.parameter import (
+    get_ordering_parameter,
+    set_adobe_order_ids_created_parameter,
+    set_flex_discounts_parameter,
     set_ordering_parameter_error,
     update_agreement_params_visibility,
 )
@@ -832,6 +834,15 @@ class SubmitReturnOrders(Step):
                 return_order_created = self._create_return_order(
                     adobe_client, context, returnable_order, deployment_id
                 )
+                context.order = set_adobe_order_ids_created_parameter(
+                    context,
+                    [return_order_created.get("orderId")],
+                )
+                update_order(
+                    client,
+                    context.order_id,
+                    parameters=context.order["parameters"],
+                )
 
                 all_return_orders.append(return_order_created)
 
@@ -925,19 +936,13 @@ class SubmitNewOrder(Step):
             )
             logger.info("%s: new adobe order created: %s", context, adobe_order["orderId"])
             context.order = set_adobe_order_id(context.order, adobe_order["orderId"])
-            flex_discounts = _get_flex_discounts(adobe_order)
+            context.order = set_adobe_order_ids_created_parameter(context, [adobe_order["orderId"]])
+            context.order = set_flex_discounts_parameter(context.order, adobe_order)
             update_order(
                 client,
                 context.order_id,
                 externalIds=context.order["externalIds"],
-                parameters={
-                    Param.PHASE_FULFILLMENT.value: [
-                        {
-                            "externalId": Param.FLEXIBLE_DISCOUNTS,
-                            "value": flex_discounts,
-                        },
-                    ]
-                },
+                parameters=context.order["parameters"],
             )
         elif not context.adobe_new_order_id and not context.adobe_preview_order:
             logger.info(
@@ -976,20 +981,6 @@ class SubmitNewOrder(Step):
             logger.warning("%s: the order has been failed due to %s.", context, error["message"])
             return
         next_step(client, context)
-
-
-def _get_flex_discounts(adobe_order: dict) -> str | None:
-    flex_discounts = [
-        {
-            "extLineItemNumber": line.get("extLineItemNumber"),
-            "offerId": line.get("offerId"),
-            "subscriptionId": line.get("subscriptionId"),
-            "flexDiscountCode": [flex_discount["code"] for flex_discount in line["flexDiscounts"]],
-        }
-        for line in adobe_order["lineItems"]
-        if line.get("flexDiscounts")
-    ]
-    return json.dumps(flex_discounts) if flex_discounts else None
 
 
 class CreateOrUpdateAssets(Step):
@@ -1196,11 +1187,16 @@ class CompleteOrder(Step):
             MPT_ORDER_STATUS_COMPLETED,
             self.template_name,
         )
+        list_adobe_order_ids = get_ordering_parameter(context.order, Param.ADOBE_ORDER_IDS.value)
+        adobe_order_ids = (list_adobe_order_ids.get("value") or "").strip()
+        if adobe_order_ids:
+            context.order = set_adobe_order_id(context.order, adobe_order_ids)
         agreement = context.order["agreement"]
         context.order = complete_order(
             client,
             context.order_id,
             template,
+            externalIds=context.order.get("externalIds", {}),
             parameters=context.order["parameters"],
         )
         context.order["agreement"] = agreement

--- a/adobe_vipm/flows/utils/parameter.py
+++ b/adobe_vipm/flows/utils/parameter.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+import json
 from typing import Any
 
 from django.conf import settings
@@ -183,7 +184,7 @@ def get_coterm_date(order: dict) -> str | None:
     ).get("value")
 
 
-def update_ordering_parameter_value(order: dict, param_external_id: str, value: str) -> dict:
+def update_ordering_parameter_value(order: dict, param_external_id: str, value: Any) -> dict:
     """
     Update ordering parameter value in MPT order.
 
@@ -197,6 +198,28 @@ def update_ordering_parameter_value(order: dict, param_external_id: str, value: 
     """
     updated_order = copy.deepcopy(order)
     param = get_ordering_parameter(
+        updated_order,
+        param_external_id,
+    )
+    param["value"] = value
+
+    return updated_order
+
+
+def update_fulfillment_parameter_value(order: dict, param_external_id: str, value: Any) -> dict:
+    """
+    Update fulfillment parameter value in MPT order.
+
+    Args:
+        order: MPT order.
+        param_external_id: MPT parameter external id.
+        value: parameter value.
+
+    Returns:
+        Updated MPT order.
+    """
+    updated_order = copy.deepcopy(order)
+    param = get_fulfillment_parameter(
         updated_order,
         param_external_id,
     )
@@ -353,3 +376,62 @@ def update_agreement_params_visibility(
             param["constraints"]["hidden"] = param["externalId"] not in visible_params
 
     return updated_order
+
+
+def set_flex_discounts_parameter(order: dict, adobe_order: dict) -> dict:
+    """
+    Save flex discounts to the order.
+
+    Args:
+        order: MPT order.
+        adobe_order: Adobe order.
+
+    Returns:
+        Updated MPT order.
+    """
+    flex_discounts = [
+        {
+            "extLineItemNumber": line.get("extLineItemNumber"),
+            "offerId": line.get("offerId"),
+            "subscriptionId": line.get("subscriptionId"),
+            "flexDiscountCode": [flex_discount["code"] for flex_discount in line["flexDiscounts"]],
+        }
+        for line in adobe_order["lineItems"]
+        if line.get("flexDiscounts")
+    ]
+    flex_discounts = json.dumps(flex_discounts) if flex_discounts else None
+    return update_fulfillment_parameter_value(order, Param.FLEXIBLE_DISCOUNTS.value, flex_discounts)
+
+
+def set_adobe_order_ids_created_parameter(context, order_ids: list[str | None]) -> dict:
+    """Persist Adobe order IDs for Change orders as comma-separated values."""
+    sanitized_order_ids = [
+        order_id.strip() for order_id in order_ids if order_id and order_id.strip()
+    ]
+    if not sanitized_order_ids:
+        return context.order
+
+    order_ids_param = get_ordering_parameter(context.order, Param.ADOBE_ORDER_IDS.value)
+    existing_order_ids = [
+        order_id.strip()
+        for order_id in (order_ids_param.get("value") or "").split(",")
+        if order_id.strip()
+    ]
+    merged_order_ids = list(dict.fromkeys(existing_order_ids + sanitized_order_ids))
+    if merged_order_ids == existing_order_ids:
+        return context.order
+
+    adobe_order_ids = ",".join(merged_order_ids)
+    if not order_ids_param:
+        context.order.setdefault("parameters", {}).setdefault(
+            Param.PHASE_ORDERING.value, []
+        ).append({
+            "externalId": Param.ADOBE_ORDER_IDS.value,
+            "value": adobe_order_ids,
+        })
+
+    context.order = update_ordering_parameter_value(
+        context.order, Param.ADOBE_ORDER_IDS.value, adobe_order_ids
+    )
+
+    return context.order

--- a/migrations/20260306113000_add_adobe_order_ids_ordering_parameter.py
+++ b/migrations/20260306113000_add_adobe_order_ids_ordering_parameter.py
@@ -1,0 +1,63 @@
+import logging
+import os
+
+from mpt_tool.migration import SchemaBaseMigration
+from mpt_tool.migration.mixins import MPTAPIClientMixin
+
+logger = logging.getLogger(__name__)
+
+
+class Migration(SchemaBaseMigration, MPTAPIClientMixin):
+    """Migration to create Adobe Order IDs parameter in Order scope."""
+
+    @staticmethod
+    def new_parameter() -> dict:
+        """Return parameter definition for Adobe Order IDs."""
+        return {
+            "externalId": "adobeOrderIds",
+            "displayOrder": 100,
+            "scope": "Order",
+            "phase": "Order",
+            "name": "Adobe Order IDs",
+            "description": "Adobe Order IDs",
+            "multiple": False,
+            "constraints": {"hidden": True, "readonly": True, "required": False},
+            "options": {
+                "placeholderText": "Adobe Order IDs",
+                "hintText": "Comma-separated Adobe order IDs",
+            },
+            "type": "SingleLineText",
+        }
+
+    def run(self):
+        """Create the Adobe Order IDs order parameter for configured products if missing."""
+        product_ids = os.getenv("MPT_PRODUCTS_IDS", "")
+        list_of_product_ids = [
+            product_id.strip() for product_id in product_ids.split(",") if product_id.strip()
+        ]
+
+        if not list_of_product_ids:
+            logger.info("MPT_PRODUCTS_IDS is empty. No products to process.")
+            return
+
+        param_def = self.new_parameter()
+        external_id = param_def["externalId"]
+
+        for product_id in list_of_product_ids:
+            params_service = self.mpt_client.catalog.products.parameters(product_id)
+            existing_external_ids = {
+                parameter.to_dict().get("externalId", "")
+                for parameter in params_service.iterate()
+                if parameter.to_dict().get("status") == "Active"
+            }
+
+            if external_id in existing_external_ids:
+                logger.info(
+                    "Product %s: parameter %s already exists, skipping.",
+                    product_id,
+                    external_id,
+                )
+                continue
+
+            params_service.create(param_def)
+            logger.info("Product %s: created parameter %s.", product_id, external_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,7 @@ def order_parameters_factory():
         p3yc=None,
         p3yc_licenses="",
         p3yc_consumables="",
+        adobe_order_ids="",
     ):
         if address is None:
             address = {
@@ -404,6 +405,14 @@ def order_parameters_factory():
                     "required": False,
                 },
             },
+            {
+                "id": "PAR-0000-0010",
+                "name": "Adobe Order IDs",
+                "externalId": Param.ADOBE_ORDER_IDS.value,
+                "type": "SingleLineText",
+                "value": adobe_order_ids or "",
+                "error": None,
+            },
         ]
 
     return _order_parameters
@@ -420,6 +429,7 @@ def transfer_order_parameters_factory():
         p3yc_licenses=None,
         p3yc_consumables=None,
         agency_type="STATE",
+        adobe_order_ids=None,
     ):
         return [
             {
@@ -528,6 +538,14 @@ def transfer_order_parameters_factory():
                     "hidden": True,
                     "required": False,
                 },
+                "error": None,
+            },
+            {
+                "id": "PAR-0000-0010",
+                "name": "Adobe Order IDs",
+                "externalId": Param.ADOBE_ORDER_IDS.value,
+                "type": "SingleLineText",
+                "value": adobe_order_ids or "",
                 "error": None,
             },
         ]
@@ -693,6 +711,13 @@ def fulfillment_parameters_factory():
                 "externalId": Param.DUE_DATE.value,
                 "type": "Date",
                 "value": due_date,
+            },
+            {
+                "id": "PAR-7771-1778",
+                "name": "Flexible Discounts",
+                "externalId": Param.FLEXIBLE_DISCOUNTS.value,
+                "type": "Object",
+                "value": None,
             },
             {
                 "id": "PAR-9876-5432",

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -56,7 +56,11 @@ from adobe_vipm.flows.utils import (
     get_due_date,
     set_coterm_date,
 )
-from adobe_vipm.flows.utils.parameter import get_fulfillment_parameter
+from adobe_vipm.flows.utils.parameter import (
+    get_fulfillment_parameter,
+    get_ordering_parameter,
+    set_adobe_order_ids_created_parameter,
+)
 
 
 def test_check_processing_template(mocker, mock_mpt_client, mock_order, template):
@@ -603,6 +607,67 @@ def test_submit_return_orders_step(
     mocked_next_step.assert_not_called()
 
 
+def test_submit_return_orders_step_change_order_persists_adobe_order_ids(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    order_factory,
+    fulfillment_parameters_factory,
+    adobe_order_factory,
+    adobe_items_factory,
+    mock_update_order,
+    settings,
+):
+    api_key = "airtable-token"
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": api_key,
+        "AIRTABLE_BASES": {"PRD-1111-1111": "base-id"},
+        "ADOBE_CREDENTIALS_FILE": "a-credentials-file.json",
+        "ADOBE_AUTHORIZATIONS_FILE": "an-authorization-file.json",
+    }
+    adobe_order_1 = adobe_order_factory(
+        order_type="NEW",
+        items=adobe_items_factory(quantity=1),
+        status=AdobeStatus.PROCESSED.value,
+    )
+    ret_info_1 = ReturnableOrderInfo(
+        adobe_order_1,
+        adobe_order_1["lineItems"][0],
+        adobe_order_1["lineItems"][0]["quantity"],
+    )
+    sku = adobe_order_1["lineItems"][0]["offerId"][:10]
+    mock_adobe_client.create_return_order.return_value = adobe_order_factory(
+        order_type="RETURN",
+        order_id="return-order-id",
+        status=AdobeStatus.PENDING.value,
+    )
+    order = order_factory(
+        order_type="Change", fulfillment_parameters=fulfillment_parameters_factory()
+    )
+    order["parameters"]["ordering"] = [
+        {"externalId": Param.ADOBE_ORDER_IDS.value, "value": "new-order-id"}
+    ]
+    context = Context(
+        order=order,
+        order_id=order["id"],
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        adobe_returnable_orders={sku: (ret_info_1,)},
+        adobe_return_orders={},
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitReturnOrders()
+
+    step(mock_mpt_client, context, mocked_next_step)  # act
+
+    mock_update_order.assert_called_once_with(
+        mock_mpt_client,
+        context.order_id,
+        parameters=context.order["parameters"],
+    )
+    mocked_next_step.assert_not_called()
+
+
 def test_submit_return_orders_step_with_deployment_id(
     mocker,
     mock_adobe_client,
@@ -850,9 +915,47 @@ def test_submit_new_order_step(
         mock_mpt_client,
         context.order_id,
         externalIds=context.order["externalIds"],
-        parameters={"fulfillment": [{"externalId": Param.FLEXIBLE_DISCOUNTS.value, "value": None}]},
+        parameters=context.order["parameters"],
     )
     assert get_adobe_order_id(context.order) == new_order["orderId"]
+    mocked_next_step.assert_not_called()
+
+
+def test_submit_new_order_step_change_order_persists_adobe_order_ids(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    order_factory,
+    adobe_order_factory,
+    mock_update_order,
+):
+    order = order_factory(order_type="Change", deployment_id=None)
+    preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW)
+    new_order = adobe_order_factory(
+        order_type=ORDER_TYPE_NEW,
+        order_id="new-order-id",
+        status=AdobeStatus.PENDING.value,
+    )
+    mock_adobe_client.create_new_order.return_value = new_order
+    mocked_next_step = mocker.MagicMock()
+    context = Context(
+        order=order,
+        order_id=order["id"],
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        upsize_lines=order["lines"],
+        adobe_preview_order=preview_order,
+    )
+    step = SubmitNewOrder()
+
+    step(mock_mpt_client, context, mocked_next_step)  # act
+
+    mock_update_order.assert_called_once_with(
+        mock_mpt_client,
+        context.order_id,
+        externalIds=context.order["externalIds"],
+        parameters=context.order["parameters"],
+    )
     mocked_next_step.assert_not_called()
 
 
@@ -888,22 +991,14 @@ def test_submit_new_order_step_flex_discount(
         preview_order,
         deployment_id=None,
     )
-    mock_update_order.assert_called_once_with(
-        mock_mpt_client,
-        context.order_id,
-        externalIds=context.order["externalIds"],
-        parameters={
-            "fulfillment": [
-                {
-                    "externalId": Param.FLEXIBLE_DISCOUNTS.value,
-                    "value": '[{"extLineItemNumber": 1, '
-                    '"offerId": "65304578CA01A12", '
-                    '"subscriptionId": null, '
-                    '"flexDiscountCode": ["BLACK"]}]',
-                }
-            ]
-        },
-    )
+    mock_update_order.assert_has_calls([
+        mocker.call(
+            mock_mpt_client,
+            context.order_id,
+            externalIds=context.order["externalIds"],
+            parameters=context.order["parameters"],
+        )
+    ])
     assert get_adobe_order_id(context.order) == new_order["orderId"]
 
 
@@ -940,12 +1035,14 @@ def test_submit_new_order_step_with_deployment_id(
         preview_order,
         deployment_id=deployment_id,
     )
-    mocked_update.assert_called_once_with(
-        mocked_client,
-        context.order_id,
-        externalIds=context.order["externalIds"],
-        parameters={"fulfillment": [{"externalId": Param.FLEXIBLE_DISCOUNTS.value, "value": None}]},
-    )
+    mocked_update.assert_has_calls([
+        mocker.call(
+            mocked_client,
+            context.order_id,
+            externalIds=context.order["externalIds"],
+            parameters=context.order["parameters"],
+        ),
+    ])
     assert get_adobe_order_id(context.order) == new_order["orderId"]
     mocked_next_step.assert_not_called()
 
@@ -984,6 +1081,42 @@ def test_submit_new_order_step_order_created_and_processed(
     mock_adobe_client.create_preview_order.assert_not_called()
     mock_adobe_client.create_new_order.assert_not_called()
     mocked_update.assert_not_called()
+    mocked_next_step.assert_called_once_with(mocked_client, context)
+
+
+def test_submit_new_order_step_change_order_skips_ids_update_if_already_present(
+    mocker,
+    mock_adobe_client,
+    order_factory,
+    fulfillment_parameters_factory,
+    adobe_order_factory,
+    mock_update_order,
+):
+    adobe_order_id = "new-order-id"
+    order = order_factory(
+        order_type="Change",
+        external_ids={"vendor": adobe_order_id},
+        fulfillment_parameters=fulfillment_parameters_factory(),
+    )
+    mock_adobe_client.get_order.return_value = adobe_order_factory(
+        order_type=ORDER_TYPE_NEW,
+        order_id=adobe_order_id,
+        status=AdobeStatus.PROCESSED.value,
+    )
+    mocked_client = mocker.MagicMock()
+    mocked_next_step = mocker.MagicMock()
+    context = Context(
+        order=order,
+        adobe_new_order_id=adobe_order_id,
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        upsize_lines=order["lines"],
+    )
+    step = SubmitNewOrder()
+
+    step(mocked_client, context, mocked_next_step)  # act
+
+    mock_update_order.assert_not_called()
     mocked_next_step.assert_called_once_with(mocked_client, context)
 
 
@@ -1708,8 +1841,11 @@ def test_create_or_update_subscriptions_step_update_existing_subscription(
 
 @freeze_time("2024-01-01")
 def test_complete_order_step(mocker, mock_mpt_client, order_factory):
-    order = order_factory()
-    resetted_order = order_factory()
+    order = order_factory(external_ids={"vendor": "old-adobe-order-id"})
+    for parameter in order["parameters"]["ordering"]:
+        if parameter["externalId"] == Param.ADOBE_ORDER_IDS.value:
+            parameter["value"] = "new-order-id,return-order-id"
+            break
     completed_order = order_factory(status=MPT_ORDER_STATUS_COMPLETED)
     mocked_get_template = mocker.patch(
         "adobe_vipm.flows.fulfillment.shared.get_product_template_or_default",
@@ -1739,10 +1875,110 @@ def test_complete_order_step(mocker, mock_mpt_client, order_factory):
         mock_mpt_client,
         context.order_id,
         {"id": "TPL-0000"},
-        parameters=resetted_order["parameters"],
+        externalIds={"vendor": "new-order-id,return-order-id"},
+        parameters=order["parameters"],
     )
     assert context.order == completed_order
     mocked_next_step.assert_called_once_with(mock_mpt_client, context)
+
+
+@freeze_time("2024-01-01")
+def test_complete_order_step_preserves_vendor_if_adobe_order_ids_is_empty(
+    mocker, mock_mpt_client, order_factory
+):
+    order = order_factory(external_ids={"vendor": "existing-vendor-id"})
+    for parameter in order["parameters"]["ordering"]:
+        if parameter["externalId"] == Param.ADOBE_ORDER_IDS.value:
+            parameter["value"] = ""
+            break
+    completed_order = order_factory(status=MPT_ORDER_STATUS_COMPLETED)
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.shared.get_product_template_or_default",
+        return_value={"id": "TPL-0000"},
+    )
+    mocked_complete_order = mocker.patch(
+        "adobe_vipm.flows.fulfillment.shared.complete_order",
+        return_value=completed_order,
+    )
+    mocked_next_step = mocker.MagicMock()
+    context = Context(
+        order=order,
+        order_id=order["id"],
+        product_id=order["agreement"]["product"]["id"],
+    )
+    step = CompleteOrder("my-template")
+
+    step(mock_mpt_client, context, mocked_next_step)  # act
+
+    mocked_complete_order.assert_called_once_with(
+        mock_mpt_client,
+        context.order_id,
+        {"id": "TPL-0000"},
+        externalIds={"vendor": "existing-vendor-id"},
+        parameters=order["parameters"],
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, context)
+
+
+def test_set_adobe_order_ids_created_parameter_ignores_empty_values(
+    order_factory, order_parameters_factory
+):
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(adobe_order_ids="existing-id"),
+    )
+    context = Context(order=order)
+
+    updated_order = set_adobe_order_ids_created_parameter(context, [None, "", "  "])  # act
+
+    order_ids_param = get_ordering_parameter(updated_order, Param.ADOBE_ORDER_IDS.value)
+    assert order_ids_param["value"] == "existing-id"
+
+
+def test_set_adobe_order_ids_created_parameter_skips_duplicate_ids(
+    order_factory, order_parameters_factory
+):
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(adobe_order_ids="id-1,id-2"),
+    )
+    context = Context(order=order)
+
+    updated_order = set_adobe_order_ids_created_parameter(context, ["id-1", "id-2"])  # act
+
+    order_ids_param = get_ordering_parameter(updated_order, Param.ADOBE_ORDER_IDS.value)
+    assert order_ids_param["value"] == "id-1,id-2"
+    assert updated_order is order
+
+
+def test_set_adobe_order_ids_created_parameter_appends_new_ids(
+    order_factory, order_parameters_factory
+):
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(adobe_order_ids="id-1"),
+    )
+    context = Context(order=order)
+
+    updated_order = set_adobe_order_ids_created_parameter(context, ["id-2"])  # act
+
+    order_ids_param = get_ordering_parameter(updated_order, Param.ADOBE_ORDER_IDS.value)
+    assert order_ids_param["value"] == "id-1,id-2"
+
+
+def test_set_adobe_order_ids_created_parameter_creates_param_when_missing(
+    order_factory, order_parameters_factory
+):
+    order_params = order_parameters_factory()
+    order_params = [p for p in order_params if p["externalId"] != Param.ADOBE_ORDER_IDS.value]
+    order = order_factory(order_type="Change", order_parameters=order_params)
+    context = Context(order=order)
+
+    updated_order = set_adobe_order_ids_created_parameter(context, ["new-id"])  # act
+
+    order_ids_param = get_ordering_parameter(updated_order, Param.ADOBE_ORDER_IDS.value)
+    assert order_ids_param["externalId"] == Param.ADOBE_ORDER_IDS.value
+    assert order_ids_param["value"] == "new-id"
 
 
 @pytest.mark.parametrize(
@@ -1756,6 +1992,7 @@ def test_complete_configuration_order_selects_template(
     mocker, order_factory, auto_renew, expected_template
 ):
     order = order_factory(subscriptions=[{"autoRenew": auto_renew}])
+    order["externalIds"] = {"vendor": ""}
     completed_order = order_factory(status="Completed")
     context = Context(
         order=order,
@@ -1786,6 +2023,7 @@ def test_complete_configuration_order_selects_template(
         mocked_client,
         context.order_id,
         {"id": "TPL-0000"},
+        externalIds=order.get("externalIds", ""),
         parameters=order["parameters"],
     )
     assert context.order == completed_order

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -180,6 +180,13 @@ def test_transfer(
                     "value": "2024-01-31",
                 },
                 {
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -340,6 +347,14 @@ def test_transfer(
                     "type": "SingleLineText",
                     "value": "STATE",
                 },
+                {
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
             ],
         },
     }
@@ -399,6 +414,13 @@ def test_transfer(
                     "name": "Due Date",
                     "type": "Date",
                     "value": "2024-01-31",
+                },
+                {
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
                 },
                 {
                     "externalId": "3YCEnrollStatus",
@@ -573,6 +595,14 @@ def test_transfer(
                     "type": "SingleLineText",
                     "value": "STATE",
                 },
+                {
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
             ],
         },
     }
@@ -594,6 +624,14 @@ def test_transfer(
                     "id": "PAR-7771-1777",
                     "name": "Due Date",
                     "type": "Date",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
                     "value": None,
                 },
                 {
@@ -779,6 +817,17 @@ def test_transfer(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         }
@@ -861,6 +910,14 @@ def test_transfer(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -1042,6 +1099,15 @@ def test_transfer(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -1267,6 +1333,14 @@ def test_transfer_with_no_profile_address(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -1442,6 +1516,17 @@ def test_transfer_with_no_profile_address(
                     "type": "SingleLineText",
                     "value": "STATE",
                 },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
             ],
         }
     }
@@ -1519,6 +1604,14 @@ def test_transfer_with_no_profile_address(
                     "id": "PAR-7771-1777",
                     "name": "Due Date",
                     "type": "Date",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
                     "value": None,
                 },
                 {
@@ -1697,6 +1790,17 @@ def test_transfer_with_no_profile_address(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -3143,6 +3247,14 @@ def test_transfer_3yc_customer(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -3324,6 +3436,17 @@ def test_transfer_3yc_customer(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         }
@@ -3389,6 +3512,16 @@ def test_transfer_3yc_customer(
                     "value": None,
                 },
                 {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
                     "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
@@ -3571,6 +3704,17 @@ def test_transfer_3yc_customer(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -3758,6 +3902,14 @@ def test_transfer_3yc_customer_with_no_profile_address(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -3932,6 +4084,15 @@ def test_transfer_3yc_customer_with_no_profile_address(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -3998,6 +4159,14 @@ def test_transfer_3yc_customer_with_no_profile_address(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -4172,6 +4341,15 @@ def test_transfer_3yc_customer_with_no_profile_address(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -4246,6 +4424,7 @@ def test_fulfill_transfer_order_already_migrated_all_items_expired_create_new_or
                     adobe_customer_address["country"],
                 ),
             },
+            adobe_order_ids="P0123456789",
         ),
         external_ids={"vendor": "transfer-id"},
     )
@@ -4308,20 +4487,22 @@ def test_fulfill_transfer_order_already_migrated_all_items_expired_create_new_or
         membership_id_param["value"],
     )
     mocked_process_order.assert_called_once_with(mock_mpt_client, order["id"], {"id": "TPL-0000"})
+    order_parameters = order["parameters"]["ordering"]
     assert mocked_update_order.mock_calls[0].args == (mock_mpt_client, order["id"])
     assert mocked_update_order.mock_calls[0].kwargs == {
         "parameters": {
             "fulfillment": fulfillment_parameters_factory(
                 due_date="2012-02-13",
             ),
-            "ordering": order["parameters"]["ordering"],
+            "ordering": order_parameters,
         },
     }
     assert mocked_update_order.mock_calls[2].args == (mock_mpt_client, order["id"])
     assert mocked_update_order.mock_calls[2].kwargs == {
         "externalIds": {"vendor": new_order["orderId"]},
         "parameters": {
-            "fulfillment": [{"externalId": Param.FLEXIBLE_DISCOUNTS.value, "value": None}]
+            "fulfillment": updated_order["parameters"]["fulfillment"],
+            "ordering": updated_order["parameters"]["ordering"],
         },
     }
 
@@ -4378,6 +4559,7 @@ def test_fulfill_transfer_order_already_migrated_empty_adobe_items(
                     adobe_customer_address["country"],
                 ),
             },
+            adobe_order_ids="P0123456789",
         ),
         external_ids={"vendor": "transfer-id"},
     )
@@ -4449,7 +4631,8 @@ def test_fulfill_transfer_order_already_migrated_empty_adobe_items(
     assert mocked_update_order.mock_calls[2].kwargs == {
         "externalIds": {"vendor": new_order["orderId"]},
         "parameters": {
-            "fulfillment": [{"externalId": Param.FLEXIBLE_DISCOUNTS.value, "value": None}]
+            "fulfillment": updated_order["parameters"]["fulfillment"],
+            "ordering": updated_order["parameters"]["ordering"],
         },
     }
 
@@ -4683,6 +4866,13 @@ def test_transfer_gc_account_all_deployments_created(
                     "value": "2024-01-31",
                 },
                 {
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -4854,6 +5044,14 @@ def test_transfer_gc_account_all_deployments_created(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -4880,6 +5078,14 @@ def test_transfer_gc_account_all_deployments_created(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -5061,6 +5267,17 @@ def test_transfer_gc_account_all_deployments_created(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         }
@@ -5139,6 +5356,14 @@ def test_transfer_gc_account_all_deployments_created(
                     "id": "PAR-7771-1777",
                     "name": "Due Date",
                     "type": "Date",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
                     "value": None,
                 },
                 {
@@ -5324,6 +5549,17 @@ def test_transfer_gc_account_all_deployments_created(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -5643,6 +5879,14 @@ def test_transfer_gc_account_no_deployments(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -5824,6 +6068,15 @@ def test_transfer_gc_account_no_deployments(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -7232,6 +7485,14 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -7414,6 +7675,15 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
                     "type": "SingleLineText",
                     "value": "STATE",
                 },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
             ],
         },
     }
@@ -7491,6 +7761,14 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
                     "id": "PAR-7771-1777",
                     "name": "Due Date",
                     "type": "Date",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
                     "value": None,
                 },
                 {
@@ -7676,6 +7954,15 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },
@@ -8431,6 +8718,14 @@ def test_transfer_lga_product_with_lga_agency_type(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -8613,6 +8908,17 @@ def test_transfer_lga_product_with_lga_agency_type(
                     "type": "SingleLineText",
                     "value": "STATE",
                 },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
             ],
         }
     }
@@ -8637,6 +8943,14 @@ def test_transfer_lga_product_with_lga_agency_type(
                     "id": "PAR-7771-1777",
                     "name": "Due Date",
                     "type": "Date",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
                     "value": None,
                 },
                 {
@@ -8822,6 +9136,17 @@ def test_transfer_lga_product_with_lga_agency_type(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         }
@@ -8904,6 +9229,14 @@ def test_transfer_lga_product_with_lga_agency_type(
                 },
                 {
                     "constraints": {"hidden": True},
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
+                    "constraints": {"hidden": True},
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -9085,6 +9418,17 @@ def test_transfer_lga_product_with_lga_agency_type(
                     "name": "Agency type",
                     "type": "SingleLineText",
                     "value": "STATE",
+                },
+                {
+                    "constraints": {
+                        "hidden": True,
+                    },
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
+                    "type": "SingleLineText",
+                    "value": "",
                 },
             ],
         },

--- a/tests/flows/test_helpers.py
+++ b/tests/flows/test_helpers.py
@@ -349,6 +349,13 @@ def test_prepare_customer_no_data_step(
                     "value": None,
                 },
                 {
+                    "externalId": "flexibleDiscounts",
+                    "id": "PAR-7771-1778",
+                    "name": "Flexible Discounts",
+                    "type": "Object",
+                    "value": None,
+                },
+                {
                     "externalId": "3YCEnrollStatus",
                     "id": "PAR-9876-5432",
                     "name": "3YC Enroll Status",
@@ -501,6 +508,14 @@ def test_prepare_customer_no_data_step(
                     "externalId": "3YCConsumables",
                     "id": "PAR-0000-0008",
                     "name": "3YCConsumables",
+                    "type": "SingleLineText",
+                    "value": "",
+                },
+                {
+                    "error": None,
+                    "externalId": "adobeOrderIds",
+                    "id": "PAR-0000-0010",
+                    "name": "Adobe Order IDs",
                     "type": "SingleLineText",
                     "value": "",
                 },


### PR DESCRIPTION
…e order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-18381](https://softwareone.atlassian.net/browse/MPT-18381)

## Release Notes

- Add new ordering parameter constant Param.ADOBE_ORDER_IDS ("adobeOrderIds") to track Adobe order identifiers.
- Persist Adobe order IDs into orders when creating return, new, and transfer orders via set_adobe_order_ids_created_parameter().
- Read ordering-stored Adobe order IDs during order completion and propagate them into order.externalIds when completing orders; complete_order invocations now include externalIds and use parameters=context.order["parameters"] where applicable.
- Add and generalize parameter utilities:
  - set_adobe_order_ids_created_parameter() — sanitize, merge, dedupe, and persist adobeOrderIds in ordering parameters.
  - set_flex_discounts_parameter() — build and JSON-serialize flexible-discounts payload from Adobe order line items into a fulfillment parameter.
  - update_fulfillment_parameter_value() and update_ordering_parameter_value() now accept generic values (Any).
- Remove unused helper and adjust flows to set ordering/fulfillment parameters instead of previous JSON helper usage.
- Add a migration to create the "Adobe Order IDs" ordering parameter for configured products.
- Tests and fixtures updated to include adobeOrderIds and flexibleDiscounts parameters and to cover new behavior in SubmitReturnOrders, SubmitNewOrder, CompleteOrder, transfer flows, and helper tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18381]: https://softwareone.atlassian.net/browse/MPT-18381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ