### PR TITLE
MPT-20806 create_listing fails due to missing eligibility parameter o…

### DIFF
--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -280,6 +280,7 @@ def get_listing(mpt_client, authorization_id, price_list_id, agreement_deploymen
             "seller": {"id": agreement_deployment.seller_id},
             "notes": "",
             "primary": False,
+            "eligibility": {"client": True, "partner": False},
         }
         try:
             listing = create_listing(mpt_client, listing)


### PR DESCRIPTION
…n Global Customer cronjob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20806](https://softwareone.atlassian.net/browse/MPT-20806)

- Add `eligibility` to new listing payload in adobe_vipm/flows/global_customer.py: set {"client": True, "partner": False} when creating a listing to fix missing eligibility parameter on Global Customer cronjob
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20806]: https://softwareone.atlassian.net/browse/MPT-20806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ