### PR TITLE
MPT-20904 When executing an Agreement Sync, please also sync the Rene…

### DIFF
--- a/adobe_vipm/flows/sync/subscription.py
+++ b/adobe_vipm/flows/sync/subscription.py
@@ -74,7 +74,6 @@ class SubscriptionSyncer:
             prices = price_manager.get_sku_prices_for_agreement_lines(
                 skus, self._product_id, self._currency
             )
-            coterm_date = self._adobe_customer["cotermDate"]
 
             for subscription, adobe_subscription, actual_sku in self._subscriptions_for_update:
                 if actual_sku not in prices:
@@ -88,7 +87,6 @@ class SubscriptionSyncer:
                 self._update_subscription(
                     actual_sku,
                     adobe_subscription,
-                    coterm_date,
                     prices,
                     subscription,
                     sync_prices=sync_prices,
@@ -103,7 +101,6 @@ class SubscriptionSyncer:
         self,
         actual_sku: str,
         adobe_subscription: dict,
-        coterm_date: str,
         prices: dict,
         subscription: dict,
         *,
@@ -157,7 +154,7 @@ class SubscriptionSyncer:
                 subscription["id"],
                 lines,
                 fulfillment_params,
-                coterm_date,
+                adobe_subscription["renewalDate"],
                 auto_renewal_enabled,
                 template_data,
             )
@@ -167,7 +164,7 @@ class SubscriptionSyncer:
                 subscription["id"],
                 lines=lines,
                 parameters=fulfillment_params,
-                commitmentDate=coterm_date,
+                commitmentDate=adobe_subscription["renewalDate"],
                 autoRenew=auto_renewal_enabled,
                 template=template_data,
             )

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -219,7 +219,7 @@ def test_sync_agreement_prices(
                     {"externalId": "lastSyncDate", "value": "2025-06-23"},
                 ]
             },
-            commitmentDate="2025-04-04",
+            commitmentDate=adobe_subscription["renewalDate"],
             autoRenew=adobe_subscription["autoRenewal"]["enabled"],
             template={"id": "TPL-1234", "name": "Renewing"},
         ),
@@ -252,7 +252,7 @@ def test_sync_agreement_prices(
                     {"externalId": "lastSyncDate", "value": "2025-06-23"},
                 ]
             },
-            commitmentDate="2025-04-04",
+            commitmentDate=another_adobe_subscription["renewalDate"],
             autoRenew=another_adobe_subscription["autoRenewal"]["enabled"],
             template={"id": "TPL-1234", "name": "Renewing"},
         ),
@@ -388,7 +388,7 @@ def test_sync_agreement_not_prices(
         mock_mpt_client,
         "SUB-1000-2000-3000",
         autoRenew=True,
-        commitmentDate="2025-04-04",
+        commitmentDate="2026-10-11",
         lines=[{"id": "ALI-2119-4550-8674-5962-0001", "quantity": 10}],
         parameters={
             "fulfillment": [
@@ -780,7 +780,7 @@ def test_sync_agreement_prices_with_3yc(
                     {"externalId": "lastSyncDate", "value": "2024-11-09"},
                 ]
             },
-            commitmentDate="2025-04-04",
+            commitmentDate=adobe_subscription["renewalDate"],
             autoRenew=adobe_subscription["autoRenewal"]["enabled"],
             template={"id": "TPL-1234", "name": TEMPLATE_SUBSCRIPTION_AUTORENEWAL_ENABLE},
         ),
@@ -902,7 +902,7 @@ def test_sync_agreement_prices_large_government_agency(
                     {"externalId": "lastSyncDate", "value": "2024-11-09"},
                 ]
             },
-            commitmentDate="2025-04-04",
+            commitmentDate=adobe_subscription["renewalDate"],
             autoRenew=adobe_subscription["autoRenewal"]["enabled"],
             template={"id": "TPL-1234", "name": TEMPLATE_SUBSCRIPTION_AUTORENEWAL_ENABLE},
         ),
@@ -2066,7 +2066,7 @@ def test_sync_agreement_prices_with_missing_prices(
                     {"externalId": Param.LAST_SYNC_DATE.value, "value": "2025-06-19"},
                 ]
             },
-            commitmentDate="2025-04-04",
+            commitmentDate="2026-10-11",
             autoRenew=True,
             template={"id": "TPL-1234", "name": "Renewing"},
         ),


### PR DESCRIPTION
…wal Date of each Subscription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20904](https://softwareone.atlassian.net/browse/MPT-20904)

## Release Notes

- Refactored Agreement Sync to synchronize the Renewal Date from Adobe subscription data for each subscription
- Modified `SubscriptionSyncer` to use Adobe subscription's `renewalDate` directly as the commitment date instead of reading a separate `cotermDate`
- Removed the `coterm_date` parameter from the `_update_subscription` method signature
- Updated related tests to validate that commitment dates are sourced from Adobe subscription renewal dates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20904]: https://softwareone.atlassian.net/browse/MPT-20904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ