### PR TITLE
[HF] MPT-20926 trigger release 5 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-- main
+- release/5
 - azure-pipelines
 
 pool:


### PR DESCRIPTION
## What changed
- Replaced the Azure Pipelines trigger branch from main to release/5.
- Kept the azure-pipelines trigger branch enabled.

## Testing
- Not run; configuration-only one-line Azure Pipelines trigger change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20926](https://softwareone.atlassian.net/browse/MPT-20926)

## Changes

- Updated Azure Pipelines trigger branch from `main` to `release/5` to enable automated builds for the release/5 branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20926]: https://softwareone.atlassian.net/browse/MPT-20926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ