### PR TITLE
MPT-20631 Reseller transfers should NOT use PREVIEW orders to determi…

### DIFF
--- a/adobe_vipm/flows/validation/transfer.py
+++ b/adobe_vipm/flows/validation/transfer.py
@@ -34,7 +34,6 @@ from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.errors import GovernmentLGANotValidOrderError, GovernmentNotValidOrderError
 from adobe_vipm.flows.helpers import (
     FetchResellerChangeData,
-    UpdatePrices,
     ValidateGovernmentTransfer,
     ValidateResellerChange,
 )
@@ -56,7 +55,6 @@ from adobe_vipm.flows.utils import (
     split_downsizes_upsizes_new,
 )
 from adobe_vipm.flows.utils.validation import validate_government_lga_data
-from adobe_vipm.flows.validation.shared import GetPreviewOrder
 from adobe_vipm.notifications import send_error
 from adobe_vipm.utils import get_3yc_commitment, get_partial_sku
 
@@ -526,8 +524,6 @@ def validate_reseller_change(mpt_client, order):
         FetchResellerChangeData(is_validation=True),
         ValidateResellerChange(is_validation=True),
         AddResellerChangeLinesToOrder(),
-        GetPreviewOrder(),
-        UpdatePrices(is_validation=True),
     )
     context = Context(order=order)
     pipeline.run(mpt_client, context)
@@ -595,6 +591,10 @@ class AddResellerChangeLinesToOrder(Step):
         no_deployment_transfer_items = [
             item for item in context.adobe_transfer["lineItems"] if not item.get("deploymentId", "")
         ]
+        commitment = get_3yc_commitment(context.adobe_transfer)
+        sku_list = [item["offerId"] for item in no_deployment_transfer_items]
+        prices = get_prices(context.order, commitment, sku_list)
+
         if not no_deployment_transfer_items:
             logger.info("No transfer items without deployment ID")
             return [], []
@@ -623,7 +623,11 @@ class AddResellerChangeLinesToOrder(Step):
                 logger.error(error_msg)
                 send_error("Transfer Validation - Missing reseller item", error_msg)
                 errors.append(error_msg)
-            order_lines_from_transfer.append({"item": mapped_item, "quantity": item["quantity"]})
+            order_lines_from_transfer.append({
+                "item": mapped_item,
+                "quantity": item["quantity"],
+                "price": {"unitPP": prices.get(item["offerId"], 0)},
+            })
 
         logger.info("Created %d order lines from transfer items", len(order_lines_from_transfer))
         return order_lines_from_transfer, errors

--- a/tests/flows/validation/conftest.py
+++ b/tests/flows/validation/conftest.py
@@ -64,3 +64,12 @@ def mock_update_prices(mocker):
 @pytest.fixture
 def mock_send_error(mocker):
     return mocker.patch("adobe_vipm.flows.validation.transfer.send_error", autospec=True)
+
+
+@pytest.fixture
+def mock_get_prices_for_skus(mocker):
+    return mocker.patch(
+        "adobe_vipm.flows.validation.transfer.get_prices_for_skus",
+        return_value={},
+        spec=True,
+    )

--- a/tests/flows/validation/test_reseller_change.py
+++ b/tests/flows/validation/test_reseller_change.py
@@ -12,7 +12,9 @@ from adobe_vipm.flows.validation.transfer import validate_reseller_change
 pytestmark = pytest.mark.usefixtures("mock_adobe_config")
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_success(
     mock_mpt_client,
     mock_adobe_client,
@@ -21,7 +23,6 @@ def test_validate_reseller_change_success(
     adobe_reseller_change_preview_factory,
     lines_factory,
     adobe_order_factory,
-    mock_get_preview_order,
 ):
     """Test successful reseller change validation with transfer items."""
     mock_adobe_client.create_preview_order.return_value = adobe_order_factory(
@@ -43,12 +44,14 @@ def test_validate_reseller_change_success(
                 "terms": {"model": "quantity", "period": "1y"},
             },
             "quantity": 170,
+            "price": {"unitPP": 0},
         }
     ]
-    mock_get_preview_order.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_success_reviving(
     mock_mpt_client,
     mock_adobe_client,
@@ -57,7 +60,6 @@ def test_validate_reseller_change_success_reviving(
     adobe_reseller_change_preview_factory,
     lines_factory,
     adobe_order_factory,
-    mock_get_preview_order,
 ):
     """Test successful reseller change validation when reviving a reseller."""
     order = order_factory(order_parameters=reseller_change_order_parameters_factory())
@@ -90,7 +92,6 @@ def test_validate_reseller_change_success_reviving(
 
     assert has_errors is False
     assert validated_order["lines"] == order["lines"]
-    mock_get_preview_order.return_value.assert_called_once()
 
 
 @pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
@@ -163,7 +164,9 @@ def test_validate_reseller_change_adobe_api_error(
     mock_validate_reseller_change.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_no_subscriptions(
     mock_adobe_client,
     mock_mpt_client,
@@ -171,7 +174,6 @@ def test_validate_reseller_change_no_subscriptions(
     reseller_change_order_parameters_factory,
     adobe_reseller_change_preview_factory,
     adobe_customer_factory,
-    mock_get_preview_order,
 ):
     """Test validation succeeds when customer has no subscriptions."""
     mock_adobe_client.reseller_change_request.return_value = adobe_reseller_change_preview_factory(
@@ -184,10 +186,11 @@ def test_validate_reseller_change_no_subscriptions(
     has_errors, _ = validate_reseller_change(mock_mpt_client, order)  # act
 
     assert has_errors is False
-    mock_get_preview_order.return_value.assert_called_once()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_lines_mismatch(
     mock_mpt_client,
     mock_adobe_client,
@@ -198,7 +201,6 @@ def test_validate_reseller_change_lines_mismatch(
     adobe_customer_factory,
     lines_factory,
     adobe_order_factory,
-    mock_get_preview_order,
 ):
     """Test validation fails when order lines don't match transfer lines."""
     mock_adobe_client.create_preview_order.return_value = adobe_order_factory(
@@ -239,7 +241,6 @@ def test_validate_reseller_change_lines_mismatch(
             "quantity": 150,
         }
     ]
-    mock_get_preview_order.return_value.assert_not_called()
 
 
 @pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
@@ -249,7 +250,6 @@ def test_validate_reseller_change_no_lines_and_empty_transfer(
     order_factory,
     reseller_change_order_parameters_factory,
     adobe_reseller_change_preview_factory,
-    mock_get_preview_order,
 ):
     """Test validation fails when both order and transfer have no lines."""
     mock_adobe_client.reseller_change_request.return_value = adobe_reseller_change_preview_factory(
@@ -260,10 +260,11 @@ def test_validate_reseller_change_no_lines_and_empty_transfer(
     has_errors, _ = validate_reseller_change(mock_mpt_client, order)  # act
 
     assert has_errors is True
-    mock_get_preview_order.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_filters_items_with_deployment(
     mocker,
     mock_mpt_client,
@@ -275,7 +276,6 @@ def test_validate_reseller_change_filters_items_with_deployment(
     items_factory,
     adobe_order_factory,
     mock_get_product_items_by_skus,
-    mock_get_preview_order,
 ):
     """Test that items with deploymentId are filtered out."""
     adobe_items_no_deployment = adobe_transfer_items_factory(line_number=1, deployment_id="")
@@ -295,10 +295,11 @@ def test_validate_reseller_change_filters_items_with_deployment(
 
     assert has_errors is False
     assert len(validated_order["lines"]) == 1
-    mock_get_preview_order.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_multiple_lines_match(
     mock_mpt_client,
     mock_adobe_client,
@@ -308,7 +309,6 @@ def test_validate_reseller_change_multiple_lines_match(
     adobe_customer_factory,
     adobe_order_factory,
     mock_get_product_items_by_skus,
-    mock_get_preview_order,
 ):
     """Test validation succeeds with multiple matching lines."""
     adobe_items = [
@@ -378,10 +378,11 @@ def test_validate_reseller_change_multiple_lines_match(
 
     assert has_errors is False
     assert len(validated_order["lines"]) == 2
-    mock_get_preview_order.return_value.assert_called_once()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_lines_different_vendor_id(
     mock_mpt_client,
     mock_adobe_client,
@@ -391,7 +392,6 @@ def test_validate_reseller_change_lines_different_vendor_id(
     adobe_transfer_items_factory,
     adobe_customer_factory,
     adobe_order_factory,
-    mock_get_preview_order,
 ):
     """Test validation fails when order line has different vendor ID than transfer."""
     order = order_factory(order_parameters=reseller_change_order_parameters_factory())
@@ -427,10 +427,11 @@ def test_validate_reseller_change_lines_different_vendor_id(
 
     assert has_errors is True
     assert len(validated_order["lines"]) == 1
-    mock_get_preview_order.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_lines_different_line_count(
     mock_mpt_client,
     mock_adobe_client,
@@ -442,7 +443,6 @@ def test_validate_reseller_change_lines_different_line_count(
     items_factory,
     adobe_order_factory,
     mock_get_product_items_by_skus,
-    mock_get_preview_order,
 ):
     """Test validation fails when order has different number of lines than transfer."""
     mock_adobe_client.create_preview_order.return_value = adobe_order_factory(
@@ -482,10 +482,11 @@ def test_validate_reseller_change_lines_different_line_count(
     has_errors, _ = validate_reseller_change(mock_mpt_client, order)  # act
 
     assert has_errors is True
-    mock_get_preview_order.return_value.assert_not_called()
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_missing_reseller_item_sets_order_error(
     mock_adobe_client,
     mock_mpt_client,
@@ -526,7 +527,9 @@ def test_validate_reseller_change_missing_reseller_item_sets_order_error(
     )
 
 
-@pytest.mark.usefixtures("mock_get_product_items_by_skus", "mock_get_agreement")
+@pytest.mark.usefixtures(
+    "mock_get_product_items_by_skus", "mock_get_agreement", "mock_get_prices_for_skus"
+)
 def test_validate_reseller_change_multiple_missing_reseller_items_sets_aggregated_error(
     mock_adobe_client,
     mock_mpt_client,


### PR DESCRIPTION
…ne pricing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20631](https://softwareone.atlassian.net/browse/MPT-20631)

### Changes

- Removed preview order dependency from reseller transfer pricing: Modified the validate_reseller_change pipeline to eliminate GetPreviewOrder() and UpdatePrices(is_validation=True), replacing them with FetchResellerChangeData(is_validation=True), ValidateResellerChange(is_validation=True), and AddResellerChangeLinesToOrder().
- Updated pricing calculation for reseller-mapped items: For transfer items without deploymentId, a 3-year commitment and SKU list are built from context.adobe_transfer and prices are fetched via get_prices(context.order, commitment, sku_list) instead of using preview orders.
- Enhanced order line structure: Reseller-change order lines now include a price field (price.unitPP populated from fetched prices, defaulting to 0) alongside item and quantity.
- Updated tests: Added mock_get_prices_for_skus fixture and updated reseller-change validation tests to use it; removed assertions and usages that expected preview-order calls for pricing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-adobe-vipm-extension/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20631]: https://softwareone.atlassian.net/browse/MPT-20631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ