### PR TITLE
MPT-21189 Agreement sync does not update 3ycLicenses, 3ycConsumables …

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -12,7 +12,7 @@ from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.utils import find_first
 
 from adobe_vipm.adobe.client import AdobeClient
-from adobe_vipm.adobe.constants import THREE_YC_TEMP_3YC_STATUSES, AdobeStatus
+from adobe_vipm.adobe.constants import THREE_YC_TEMP_3YC_STATUSES, AdobeStatus, OfferType
 from adobe_vipm.adobe.errors import AdobeAPIError, AuthorizationNotFoundError
 from adobe_vipm.adobe.utils import get_3yc_commitment_request
 from adobe_vipm.airtable import models
@@ -434,36 +434,35 @@ class AgreementSyncer:  # noqa: WPS214
         return mpt_entitlements_external_ids
 
     def _update_agreement_customer_parameters(self, adobe_customer: dict, agreement: dict) -> None:
-        if adobe_customer.get("linkedMembership"):
-            parameters = {
-                Param.PHASE_FULFILLMENT.value: [
-                    {
-                        "externalId": Param.LINKED_MEMBERSHIP_ID.value,
-                        "value": adobe_customer.get("linkedMembership", {}).get("id"),
-                    },
-                    {
-                        "externalId": Param.LINKED_MEMBERSHIP_NAME.value,
-                        "value": adobe_customer.get("linkedMembership", {}).get("name"),
-                    },
-                    {
-                        "externalId": Param.LINKED_MEMBERSHIP_TYPE.value,
-                        "value": adobe_customer.get("linkedMembership", {}).get("type"),
-                    },
-                    {
-                        "externalId": Param.LINKED_MEMBERSHIP_ROLE.value,
-                        "value": adobe_customer.get("linkedMembership", {}).get(
-                            "linkedMembershipType"
-                        ),
-                    },
-                    {
-                        "externalId": Param.LINKED_MEMBERSHIP_CREATED.value,
-                        "value": adobe_customer.get("linkedMembership", {}).get("creationDate", "")[
-                            :10
-                        ],
-                    },
-                ]
-            }
-            self._execute_agreement_update(agreement, parameters)
+        linked_membership = adobe_customer.get("linkedMembership") or {}
+        creation_date_raw = linked_membership.get("creationDate")
+        creation_date_value = creation_date_raw[:10] if creation_date_raw else None
+
+        parameters = {
+            Param.PHASE_FULFILLMENT.value: [
+                {
+                    "externalId": Param.LINKED_MEMBERSHIP_ID.value,
+                    "value": adobe_customer.get("linkedMembership", {}).get("id"),
+                },
+                {
+                    "externalId": Param.LINKED_MEMBERSHIP_NAME.value,
+                    "value": adobe_customer.get("linkedMembership", {}).get("name"),
+                },
+                {
+                    "externalId": Param.LINKED_MEMBERSHIP_TYPE.value,
+                    "value": adobe_customer.get("linkedMembership", {}).get("type"),
+                },
+                {
+                    "externalId": Param.LINKED_MEMBERSHIP_ROLE.value,
+                    "value": adobe_customer.get("linkedMembership", {}).get("linkedMembershipType"),
+                },
+                {
+                    "externalId": Param.LINKED_MEMBERSHIP_CREATED.value,
+                    "value": creation_date_value,
+                },
+            ]
+        }
+        self._execute_agreement_update(agreement, parameters)
 
     def _update_agreement_bussiness_parameters(self, agreement: dict) -> None:
         parameters = {}
@@ -561,13 +560,21 @@ class AgreementSyncer:  # noqa: WPS214
 
     def _update_3yc_ordering_params(self, commitment_info: dict, parameters: dict):
         parameters.setdefault(Param.PHASE_ORDERING.value, [])
-        for mq in commitment_info.get("minimumQuantities", {}):
-            if mq["offerType"] == "LICENSE":
+
+        minimum_quantities = commitment_info.get("minimumQuantities")
+        if not minimum_quantities:
+            minimum_quantities = [
+                {"offerType": OfferType.LICENSE, "quantity": ""},
+                {"offerType": OfferType.CONSUMABLES, "quantity": ""},
+            ]
+
+        for mq in minimum_quantities:
+            if mq["offerType"] == OfferType.LICENSE:
                 parameters[Param.PHASE_ORDERING.value].append({
                     "externalId": Param.THREE_YC_LICENSES.value,
                     "value": str(mq.get("quantity")),
                 })
-            if mq["offerType"] == "CONSUMABLES":
+            if mq["offerType"] == OfferType.CONSUMABLES:
                 parameters[Param.PHASE_ORDERING.value].append({
                     "externalId": Param.THREE_YC_CONSUMABLES.value,
                     "value": str(mq.get("quantity")),

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -272,10 +272,9 @@ def test_sync_agreement_prices(
                     {"externalId": "cotermDate", "value": "2025-04-04"},
                 ],
                 "ordering": [
-                    {
-                        "externalId": "3YC",
-                        "value": None,
-                    },
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
                 ],
             },
         ),
@@ -318,6 +317,20 @@ def test_sync_agreement_update_agreement_education(
         mock.call(
             mock_mpt_client,
             mocked_agreement_syncer._agreement["id"],
+            lines=[],
+            parameters={
+                "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mock.call(
+            mock_mpt_client,
+            mocked_agreement_syncer._agreement["id"],
             parameters={
                 "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
@@ -327,7 +340,11 @@ def test_sync_agreement_update_agreement_education(
                     {"externalId": "cotermDate", "value": "2024-01-23"},
                     {"externalId": "educationSubSegment", "value": "EDU_1,EDU_2"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
             lines=[],
         ),
@@ -659,7 +676,20 @@ def test_sync_agreement_prices_exception(
         "SUB-1234-5678",
         template={"id": "TPL-1234", "name": "Expired"},
     )
-    mock_mpt_update_agreement.assert_not_called()
+    mock_mpt_update_agreement.assert_called_once_with(
+        mock_mpt_client,
+        agreement["id"],
+        lines=[],
+        parameters={
+            "fulfillment": [
+                {"externalId": "lmID", "value": None},
+                {"externalId": "lmName", "value": None},
+                {"externalId": "lmType", "value": None},
+                {"externalId": "lmRole", "value": None},
+                {"externalId": "lmCreated", "value": None},
+            ]
+        },
+    )
     mock_notify_agreement_unhandled_exception_in_teams.assert_called_once_with(
         agreement["id"], mocker.ANY
     )
@@ -793,6 +823,20 @@ def test_sync_agreement_prices_with_3yc(
             lines=expected_lines,
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": "COMMITTED"},
                     {"externalId": "3YCStartDate", "value": "2024-01-01"},
@@ -909,6 +953,20 @@ def test_sync_agreement_prices_large_government_agency(
     ])
     expected_lines = lines_factory(external_vendor_id="77777777CA", unit_purchase_price=20.22)
     assert mock_mpt_update_agreement.call_args_list == [
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ],
+            },
+        ),
         mocker.call(
             mock_mpt_client,
             agreement["id"],
@@ -1146,13 +1204,31 @@ def test_sync_global_customer_parameter(
             lines=expected_lines,
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
                     {"externalId": "3YCEndDate", "value": None},
                     {"externalId": "cotermDate", "value": "2025-04-04"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
         ),
         mocker.call(
@@ -1177,7 +1253,11 @@ def test_sync_global_customer_parameter(
                     {"externalId": "3YCEndDate", "value": None},
                     {"externalId": "cotermDate", "value": "2025-04-04"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
         ),
         mocker.call(
@@ -1609,13 +1689,31 @@ def test_sync_global_customer_update_not_required(
             lines=[],
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            "AGR-2119-4550-8674-5962",
+            lines=[],
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
                     {"externalId": "3YCEndDate", "value": None},
                     {"externalId": "cotermDate", "value": "2024-01-23"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
         ),
         mocker.call(
@@ -1664,13 +1762,31 @@ def test_sync_global_customer_no_active_deployments(
             lines=[],
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            "AGR-2119-4550-8674-5962",
+            lines=[],
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
                     {"externalId": "3YCEndDate", "value": None},
                     {"externalId": "cotermDate", "value": "2024-01-23"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
         ),
         mocker.call(
@@ -1861,6 +1977,20 @@ def test_sync_agreement_empty_discounts(
             lines=expected_lines,
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -1872,6 +2002,8 @@ def test_sync_agreement_empty_discounts(
                         "externalId": "3YC",
                         "value": None,
                     },
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
                 ],
             },
         ),
@@ -2030,13 +2162,48 @@ def test_sync_agreement_prices_with_missing_prices(
             ],
             parameters={
                 "fulfillment": [
+                    {"externalId": "lmID", "value": None},
+                    {"externalId": "lmName", "value": None},
+                    {"externalId": "lmType", "value": None},
+                    {"externalId": "lmRole", "value": None},
+                    {"externalId": "lmCreated", "value": None},
+                ]
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=[
+                {
+                    "item": {
+                        "id": "ITM-1234-1234-1234-0001",
+                        "name": "Awesome product",
+                        "externalIds": {"vendor": "77777777CA"},
+                    },
+                    "subscription": {
+                        "id": "SUB-1000-2000-3000",
+                        "status": "Active",
+                        "name": "Subscription for Acrobat Pro for Teams; Multi Language",
+                    },
+                    "oldQuantity": 0,
+                    "quantity": 170,
+                    "price": {"unitPP": 20.22},
+                    "id": "ALI-2119-4550-8674-5962-0001",
+                }
+            ],
+            parameters={
+                "fulfillment": [
                     {"externalId": "3YCCommitmentRequestStatus", "value": None},
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
                     {"externalId": "3YCEndDate", "value": None},
                     {"externalId": "cotermDate", "value": "2025-04-04"},
                 ],
-                "ordering": [{"externalId": "3YC", "value": None}],
+                "ordering": [
+                    {"externalId": "3YC", "value": None},
+                    {"externalId": "3YCLicenses", "value": ""},
+                    {"externalId": "3YCConsumables", "value": ""},
+                ],
             },
         ),
         mocker.call(


### PR DESCRIPTION
…or cotermDate parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21189](https://softwareone.atlassian.net/browse/MPT-21189)

- Fix agreement sync to correctly update 3YC ordering parameters (`3YCLicenses`, `3YCConsumables`) and coterm date handling
- Add OfferType import and map offer types (LICENSE / CONSUMABLES) to ordering parameter externalIds
- Safely extract linkedMembership from Adobe customer data (with defaults) and read linked membership creationDate only when present
- Add fallback for missing/empty commitment minimumQuantities by inserting default license/consumable entries to satisfy MPT validation
- Update tests to match the revised agreement update parameter contract (fulfillment linked-membership fields and ordering 3YC parameters) across multiple scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-adobe-vipm-extension/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21189]: https://softwareone.atlassian.net/browse/MPT-21189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ