### PR TITLE
MPT-21381 Agreement sync doesn't recreate expired subscription in MPT…

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -411,7 +411,7 @@ class AgreementSyncer:  # noqa: WPS214
         mpt_entitlements_external_ids = set()
         entitlements_without_external_ids = set()
         for entitlement in self._agreement["subscriptions"] + self._agreement["assets"]:
-            if entitlement["status"] == SubscriptionStatus.TERMINATED:
+            if entitlement["status"] in {SubscriptionStatus.TERMINATED, SubscriptionStatus.EXPIRED}:
                 continue
 
             try:

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -15,6 +15,7 @@ from adobe_vipm.flows.constants import (
     AgreementStatus,
     ItemTermsModel,
     Param,
+    SubscriptionStatus,
 )
 from adobe_vipm.flows.errors import MPTAPIError
 from adobe_vipm.flows.sync.agreement import (
@@ -2694,6 +2695,51 @@ def test_add_missing_subscriptions_without_vendor_id(
     mock_get_product_items_by_period.assert_not_called()
     mock_mpt_create_asset.assert_not_called()
     mock_mpt_create_agreement_subscription.assert_not_called()
+
+
+@freeze_time("2025-07-24")
+def test_add_missing_subscriptions_recreates_when_mpt_subscription_is_expired(
+    items_factory,
+    mock_mpt_client,
+    mock_adobe_client,
+    agreement_factory,
+    adobe_customer_factory,
+    mock_get_prices_for_skus,
+    adobe_subscription_factory,
+    mock_get_product_items_by_skus,
+    mock_get_product_items_by_period,
+    mock_mpt_create_asset,
+    mock_mpt_create_agreement_subscription,
+    mock_mpt_get_asset_template_by_name,
+    mock_get_template_data_by_adobe_subscription,
+    mocked_agreement_syncer,
+):
+    expired_external_id = "1e5b9c974c4ea1bcabdb0fe697a2f1NA"
+    adobe_subscriptions = [
+        adobe_subscription_factory(subscription_id=expired_external_id, offer_id="65304578CA01A12"),
+    ]
+    agreement = agreement_factory()
+    agreement["subscriptions"] = [agreement["subscriptions"][0]]
+    agreement["subscriptions"][0]["status"] = SubscriptionStatus.EXPIRED.value
+    agreement["assets"] = []
+    mocked_agreement_syncer._adobe_subscriptions = adobe_subscriptions
+    mocked_agreement_syncer._agreement = agreement
+    mocked_agreement_syncer._adobe_customer = adobe_customer_factory()
+    mock_get_prices_for_skus.return_value = {"65304578CA01A12": 12.14}
+    mock_item = items_factory()[0]
+    mock_get_product_items_by_skus.return_value = [mock_item]
+    mock_get_template_data_by_adobe_subscription.return_value = {
+        "id": "TPL-1234",
+        "name": "Renewing",
+    }
+
+    mocked_agreement_syncer._add_missing_subscriptions_and_assets()  # act
+
+    mock_mpt_get_asset_template_by_name.assert_not_called()
+    mock_mpt_create_asset.assert_not_called()
+    mock_mpt_create_agreement_subscription.assert_called_once()
+    create_payload = mock_mpt_create_agreement_subscription.call_args[0][1]
+    assert create_payload["externalIds"]["vendor"] == expired_external_id
 
 
 @freeze_time("2025-07-24")


### PR DESCRIPTION
… when the corresponding subscription was recreated on Adobe API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21381](https://softwareone.atlassian.net/browse/MPT-21381)

## Release Notes

- Fixed agreement synchronization to properly recreate expired subscriptions in MPT when the corresponding subscription is recreated on Adobe API by excluding both terminated and expired subscriptions from entitlement external ID collection
- Added test coverage for recreating MPT subscriptions when their status is marked as expired

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/swo-adobe-vipm-extension/pull/834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21381]: https://softwareone.atlassian.net/browse/MPT-21381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ