### PR TITLE
[hotfix] MPT-18860 Discounts not found during sync process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,5 @@ make/local.mk
 
 # mpt-tool
 .migrations-state.json
+
+.claude

--- a/adobe_vipm/flows/utils/customer.py
+++ b/adobe_vipm/flows/utils/customer.py
@@ -120,9 +120,9 @@ def get_customer_licenses_discount_level(customer: dict) -> int:
         Adobe discount level for licensees.
     """
     licenses_discount = find_first(
-        lambda discount: discount["offerType"] == OfferType.LICENSE, customer["discounts"]
+        lambda discount: discount["offerType"] == OfferType.LICENSE, customer["discounts"], {}
     )
-    return licenses_discount["level"]
+    return licenses_discount.get("level")
 
 
 def get_customer_consumables_discount_level(customer: dict) -> int:
@@ -136,9 +136,9 @@ def get_customer_consumables_discount_level(customer: dict) -> int:
         Adobe discount level for consumables.
     """
     licenses_discount = find_first(
-        lambda discount: discount["offerType"] == OfferType.CONSUMABLES, customer["discounts"]
+        lambda discount: discount["offerType"] == OfferType.CONSUMABLES, customer["discounts"], {}
     )
-    return licenses_discount["level"]
+    return licenses_discount.get("level")
 
 
 def is_new_customer(source: dict) -> bool:

--- a/adobe_vipm/flows/utils/notification.py
+++ b/adobe_vipm/flows/utils/notification.py
@@ -113,5 +113,6 @@ def notify_discount_level_error(sku: str, customer: dict) -> None:
         "Error getting discount level",
         f"An error occurred while getting the discount level for SKU **{sku}**.\n\n"
         f"Customer: {customer.get('customerId')}\n\n"
-        f"discounts: {customer.get('discounts')}",
+        f"discounts: {customer.get('discounts')}\n\n"
+        "defaulting to a default level.",
     )

--- a/adobe_vipm/flows/utils/subscription.py
+++ b/adobe_vipm/flows/utils/subscription.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import logging
 
 from mpt_extension_sdk.mpt_http.utils import find_first
 
@@ -14,6 +15,8 @@ from adobe_vipm.flows.utils.customer import (
     get_customer_licenses_discount_level,
 )
 from adobe_vipm.flows.utils.notification import notify_discount_level_error
+
+logger = logging.getLogger(__name__)
 
 
 def get_subscription_by_line_and_item_id(
@@ -143,15 +146,25 @@ def get_sku_with_discount_level(sku: str, customer: dict) -> str:
     Returns:
         Sku with proper discount level based on Adobe customer's discount level.
     """
-    try:
-        discount_level = (
-            get_customer_licenses_discount_level(customer)
-            if not is_consumables_sku(sku)
-            else get_customer_consumables_discount_level(customer)
+    is_consumable = is_consumables_sku(sku)
+    discount_level = (
+        get_customer_consumables_discount_level(customer)
+        if is_consumable
+        else get_customer_licenses_discount_level(customer)
+    )
+    # FIXME: Workaround for MPT-18860. Adobe does not always return the discount level
+    #  (e.g. consumables when 3YC is applied only for licenses). Default to the base level for
+    #  the offer type ("T1" for consumables, "01" for licenses) so the agreement sync does not
+    #  fail. Should be removed after Adobe side fix the issue.
+    if not discount_level:
+        discount_level = "T1" if is_consumable else "01"
+        logger.warning(
+            "Customer %s has no discount level, defaulting to level %s",
+            customer.get("customerId"),
+            discount_level,
         )
-    except Exception:
         notify_discount_level_error(sku, customer)
-        raise
+
     return f"{sku[0:10]}{discount_level}{sku[12:]}"
 
 

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -2886,36 +2886,88 @@ def test_add_missing_subscriptions_fail_recovery_skus(
 ):
     adobe_subscriptions = [
         adobe_subscription_factory(
-            subscription_id="1e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65322572CAT1A10"
-        ),
-        adobe_subscription_factory(
-            subscription_id="2e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65322572CAT1A13"
-        ),
-        adobe_subscription_factory(
-            subscription_id="ae5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="75322572CAT1A11"
-        ),
+            subscription_id="2e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65304578CAT1A13"
+        )
     ]
-    mock_get_consumable_discount_level = mocker.patch(
-        "adobe_vipm.flows.utils.subscription.get_customer_consumables_discount_level"
-    )
-    mock_get_consumable_discount_level.side_effect = Exception("Test Exception")
     mocked_agreement_syncer._adobe_subscriptions = adobe_subscriptions
     mocked_agreement_syncer._adobe_customer = adobe_customer_factory()
-    mock_get_prices_for_skus.side_effect = [
-        {
-            "65322572CAT1A10": 12.14,
-            "65322572CAT1A11": 11.14,
-            "65322572CAT1A12": 10.14,
-            "65322572CAT1A13": 9.14,
-        },
-        {"75322572CAT1A11": 22.14},
-    ]
+    mocked_agreement_syncer._adobe_customer["discounts"] = []
+    mock_get_prices_for_skus.return_value = {
+        "65304578CAT1A10": 12.14,
+        "65304578CAT1A11": 11.14,
+        "65304578CAT1A12": 10.14,
+        "65304578CAT1A13": 9.14,
+    }
 
-    with pytest.raises(Exception, match="Test Exception"):
-        mocked_agreement_syncer._add_missing_subscriptions_and_assets()
+    mocked_agreement_syncer._add_missing_subscriptions_and_assets()  # act
 
     mock_get_product_items_by_skus.assert_called_once()
-    mock_notify_missing_discount_levels.assert_called_once()
+    assert (
+        mock_notify_missing_discount_levels.mock_calls
+        == [
+            mocker.call(
+                "65304578CAT1A13",
+                {
+                    "customerId": "a-client-id",
+                    "companyProfile": {
+                        "companyName": "Migrated Company",
+                        "preferredLanguage": "en-US",
+                        "contacts": [
+                            {
+                                "firstName": "firstName",
+                                "lastName": "lastName",
+                                "email": "email",
+                                "phoneNumber": "+18004449890",
+                            }
+                        ],
+                        "address": {
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "city": "city",
+                            "region": "region",
+                            "postalCode": "postalCode",
+                            "country": "US",
+                            "phoneNumber": "+18004449890",
+                        },
+                    },
+                    "discounts": [],
+                    "cotermDate": "2024-01-23",
+                    "globalSalesEnabled": False,
+                },
+            ),
+            mocker.call(
+                "65304578CAT1A13",
+                {
+                    "customerId": "a-client-id",
+                    "companyProfile": {
+                        "companyName": "Migrated Company",
+                        "preferredLanguage": "en-US",
+                        "contacts": [
+                            {
+                                "firstName": "firstName",
+                                "lastName": "lastName",
+                                "email": "email",
+                                "phoneNumber": "+18004449890",
+                            }
+                        ],
+                        "address": {
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "city": "city",
+                            "region": "region",
+                            "postalCode": "postalCode",
+                            "country": "US",
+                            "phoneNumber": "+18004449890",
+                        },
+                    },
+                    "discounts": [],
+                    "cotermDate": "2024-01-23",
+                    "globalSalesEnabled": False,
+                },
+            ),
+        ]
+        != []
+    )
 
 
 @freeze_time("2025-07-24")

--- a/tests/flows/utils/test_utils.py
+++ b/tests/flows/utils/test_utils.py
@@ -325,5 +325,6 @@ def test_notify_discount_level_error(mocker, adobe_customer_factory):
         "Error getting discount level",
         f"An error occurred while getting the discount level for SKU **{sku}**.\n\n"
         f"Customer: {customer.get('customerId')}\n\n"
-        f"discounts: {customer.get('discounts')}",
+        f"discounts: {customer.get('discounts')}\n\n"
+        "defaulting to a default level.",
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-18860](https://softwareone.atlassian.net/browse/MPT-18860)

- Made customer discount lookup functions tolerant of missing discounts by using `.get()` instead of direct indexing, returning `None` instead of raising an exception when no matching discount is found
- Updated notification message to indicate the system is defaulting to a default discount level when discounts cannot be determined
- Refactored subscription discount level computation to apply a fallback mechanism with appropriate defaults (`T1` for consumables, `01` for licenses) instead of raising exceptions, with warning logs including customer ID
- Updated test cases to reflect new graceful degradation behavior where missing discount levels trigger notifications rather than exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-18860]: https://softwareone.atlassian.net/browse/MPT-18860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ