### PR TITLE
🤖 AI-generated PR — Please review carefully. MPT-21772 buy terminated/expired upsize items as new lines

### DIFF
--- a/adobe_vipm/adobe/mixins/errors.py
+++ b/adobe_vipm/adobe/mixins/errors.py
@@ -1,6 +1,2 @@
 class AdobeCreatePreviewError(Exception):
     """Create preview Error."""
-
-
-class ProcessingUpsizeLinesError(Exception):
-    """Processing upsize Lines Error."""

--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -14,7 +14,6 @@ from adobe_vipm.adobe import constants as adobe_constants
 from adobe_vipm.adobe.constants import AdobeStatus
 from adobe_vipm.adobe.dataclasses import Authorization, ReturnableOrderInfo
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, wrap_http_error
-from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError, ProcessingUpsizeLinesError
 from adobe_vipm.adobe.utils import (  # noqa: WPS347
     find_first,
     get_item_by_subcription_id,
@@ -173,9 +172,6 @@ class OrderClientMixin:
 
         Returns:
             dict: The Preview order.
-
-        Raises:
-            AdobeCreatePreviewError
         """
         authorization = self._config.get_authorization(context.authorization_id)
         offer_ids = tuple(
@@ -195,18 +191,15 @@ class OrderClientMixin:
         deployment_id = get_deployment_id(context.order)
         self._process_new_lines(context, flex_discounts, payload)
         if context.upsize_lines:
-            try:
-                self._process_upsize_lines(
-                    context.authorization_id,
-                    context.adobe_customer_id,
-                    context.upsize_lines,
-                    flex_discounts,
-                    payload,
-                    context.market_segment,
-                    deployment_id,
-                )
-            except ProcessingUpsizeLinesError as error:
-                raise AdobeCreatePreviewError(error) from error
+            self._process_upsize_lines(
+                context.authorization_id,
+                context.adobe_customer_id,
+                context.upsize_lines,
+                flex_discounts,
+                payload,
+                context.market_segment,
+                deployment_id,
+            )
 
         self._update_payload_by_deployment(authorization, deployment_id, payload)
         if not payload["lineItems"]:
@@ -620,9 +613,23 @@ class OrderClientMixin:
             try:
                 adobe_subscription = map_by_base_offer_subscriptions[adobe_base_sku]
             except KeyError:
-                raise ProcessingUpsizeLinesError(
-                    "Subscription has not been found in Adobe for sku %s.", adobe_base_sku
+                self._logger.info(
+                    "No active Adobe subscription found for sku %s, "
+                    "purchasing the full quantity %s as a new line.",
+                    adobe_base_sku,
+                    line["quantity"],
                 )
+                line_item = self._get_preview_order_line_item(
+                    line,
+                    adobe_base_sku,
+                    line["quantity"],
+                    discounts.get(
+                        get_adobe_product_by_marketplace_sku(adobe_base_sku, market_segment).sku
+                    ),
+                    market_segment,
+                )
+                payload["lineItems"].append(line_item)
+                continue
 
             renewal_quantity = adobe_subscription["autoRenewal"][Param.RENEWAL_QUANTITY.value]
             current_quantity = adobe_subscription[Param.CURRENT_QUANTITY.value]

--- a/tests/adobe/mixins/test_order.py
+++ b/tests/adobe/mixins/test_order.py
@@ -5,22 +5,18 @@ from responses import matchers
 
 from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW, AdobeStatus
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError
-from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
 from adobe_vipm.adobe.utils import to_adobe_line_id
 from adobe_vipm.flows.constants import MARKET_SEGMENT_COMMERCIAL
 from adobe_vipm.flows.context import Context
 
 
-def test_create_preview_order_processing_upsize_lines_error(
+def test_create_preview_order_upsize_without_active_subscription_buys_full_quantity(
     mocker,
     mock_get_adobe_product_by_marketplace_sku,
     mock_order,
-    mock_mpt_client,
     adobe_authorizations_file,
-    adobe_api_error_factory,
     adobe_client_factory,
     flex_discounts_factory,
-    requests_mocker,
 ):
     mocked_client, _, _ = adobe_client_factory()
     mock_get_flex_discounts_per_base_offer = mocker.patch.object(
@@ -38,6 +34,10 @@ def test_create_preview_order_processing_upsize_lines_error(
             }
         ],
     )
+    mock_get_preview_order = mocker.patch.object(
+        mocked_client, "get_preview_order", return_value={"externalReferenceId": "order-id"}
+    )
+    upsize_line = mock_order["lines"][0]
     context = Context(
         order=mock_order,
         order_id="order-id",
@@ -47,11 +47,82 @@ def test_create_preview_order_processing_upsize_lines_error(
         adobe_customer_id="fake-customer-id",
     )
 
-    with pytest.raises(AdobeCreatePreviewError, match="Subscription has not been found in Adobe"):
-        mocked_client.create_preview_order(context)
+    result = mocked_client.create_preview_order(context)
 
+    assert result == {"externalReferenceId": "order-id"}
     mock_get_flex_discounts_per_base_offer.assert_called_once()
     mock_get_subscriptions_for_offers.assert_called_once()
+    payload = mock_get_preview_order.call_args.args[2]
+    assert payload["lineItems"] == [
+        {
+            "extLineItemNumber": to_adobe_line_id(upsize_line["id"]),
+            "offerId": "65304578CA01A12",
+            "quantity": upsize_line["quantity"],
+        }
+    ]
+
+
+def test_create_preview_order_mixes_active_upsize_and_terminated_new_purchase(
+    mocker,
+    mock_get_adobe_product_by_marketplace_sku,
+    order_factory,
+    lines_factory,
+    adobe_authorizations_file,
+    adobe_client_factory,
+    flex_discounts_factory,
+):
+    active_line = lines_factory(
+        line_id=1, item_id=1, external_vendor_id="65304578CA", quantity=170, old_quantity=100
+    )[0]
+    terminated_line = lines_factory(
+        line_id=2, item_id=2, external_vendor_id="77777777CA", quantity=50, old_quantity=30
+    )[0]
+    order = order_factory(lines=[active_line, terminated_line])
+    mocked_client, _, _ = adobe_client_factory()
+    mocker.patch.object(
+        mocked_client, "get_flex_discounts_per_base_offer", return_value=flex_discounts_factory()
+    )
+    mocker.patch.object(
+        mocked_client,
+        "get_subscriptions_for_offers",
+        return_value=[
+            {
+                "subscriptionId": "active-sub",
+                "status": "1000",
+                "offerId": "65304578CA01A12",
+                "currentQuantity": 100,
+                "autoRenewal": {"enabled": True, "renewalQuantity": 100},
+            }
+        ],
+    )
+    mock_get_preview_order = mocker.patch.object(
+        mocked_client, "get_preview_order", return_value={"externalReferenceId": "order-id"}
+    )
+    context = Context(
+        order=order,
+        order_id="order-id",
+        authorization_id=adobe_authorizations_file["authorizations"][0]["authorization_uk"],
+        new_lines=[],
+        upsize_lines=[active_line, terminated_line],
+        adobe_customer_id="fake-customer-id",
+    )
+
+    result = mocked_client.create_preview_order(context)
+
+    assert result == {"externalReferenceId": "order-id"}
+    payload = mock_get_preview_order.call_args.args[2]
+    assert payload["lineItems"] == [
+        {
+            "extLineItemNumber": to_adobe_line_id(active_line["id"]),
+            "offerId": "65304578CA01A12",
+            "quantity": 70,
+        },
+        {
+            "extLineItemNumber": to_adobe_line_id(terminated_line["id"]),
+            "offerId": "77777777CA01A12",
+            "quantity": 50,
+        },
+    ]
 
 
 def test_get_preview_order(


### PR DESCRIPTION
## What

Fixes [MPT-21772](https://softwareone.atlassian.net/browse/MPT-21772): the Adobe extension "ignored" (failed) MPT orders containing items that exist as **Terminated/Expired** subscriptions on the agreement (e.g. `ORD-9692-8023-2402`), forcing manual fulfilment.

## Why it happened

When an order line references an item that already has a subscription on the agreement, MPT sets `oldQuantity > 0`, so `split_downsizes_upsizes_new` classifies it as an **upsize**. Preview-order creation routes upsize lines through `_process_upsize_lines`, which resolves the matching Adobe subscription via `get_subscriptions_for_offers` — a helper that **only returns active (`PROCESSED`) subscriptions**. A Terminated/Expired subscription is filtered out, so the SKU lookup raised `KeyError` → `ProcessingUpsizeLinesError` → `AdobeCreatePreviewError`, and `GetPreviewOrder` failed the order (it never auto-completed).

The existing manual-renewal feature only catches *renewable-expired* subs (`allowedActions: ["MANUAL_RENEWAL"]`); truly terminated subs fall through to this failure.

## What changed

- `adobe_vipm/adobe/mixins/order.py` — in `_process_upsize_lines`, when **no active Adobe subscription** exists for an upsize line, purchase it as a **brand-new line for the full quantity** (mirroring `_process_new_lines`) instead of raising. This matches the manual fulfilment performed for the affected order, and fixes both the fulfilment and draft-validation flows (they share `create_preview_order`).
- Removed the now-dead `ProcessingUpsizeLinesError` class, its `try/except → AdobeCreatePreviewError` wrapper, and the related imports/docstring note. `AdobeCreatePreviewError` is kept (still guards genuine Adobe API errors in fulfilment/validation `GetPreviewOrder`).
- `tests/adobe/mixins/test_order.py` — replaced the old "raises" test with a full-quantity assertion, and added a mixed case (active line upsizes by the diff; terminated line buys the full quantity).

## Verification

- `ruff format --check`, `ruff check`, `flake8` — clean (pre-commit hooks passed).
- Full suite: **858 passed**, 99% coverage; both new branches covered.

## Reviewer notes

- Behaviour and fallback scope (blanket: any not-found active sub → new purchase) were confirmed with the reporter.
- Couldn't verify against live data: downstream in `CreateOrUpdateSubscriptions`, if MPT had linked the *old terminated* subscription to the order line, it would update that record rather than create a new one. All fulfilment tests pass and the reporter's manual flow created new subscriptions, but worth a sanity check against the real order if available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MPT-21772]: https://softwareone.atlassian.net/browse/MPT-21772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21772](https://softwareone.atlassian.net/browse/MPT-21772)

## Changes

- **Fixed preview-order creation failure** when order lines reference items with only Terminated/Expired subscriptions. Previously, upsized lines without active subscriptions would fail with `ProcessingUpsizeLinesError`; now they are treated as new purchases for the full quantity.

- **Updated `_process_upsize_lines` behavior**: When no active Adobe subscription is found for an upsize line, the code now logs an info message and processes the upsized quantity as a new preview line item instead of raising an error.

- **Removed `ProcessingUpsizeLinesError`** exception class, which is no longer needed. The `try/except` wrapper around `_process_upsize_lines()` in `create_preview_order` was also removed.

- **Updated test coverage**: Replaced the error-raising test with assertions validating that upsize lines without active subscriptions are bought at full quantity, and added a mixed-case test covering both active upsizes and terminated lines treated as new purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->