### PR TITLE
MPT-21608 process only pending GC agreement deployments 

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -707,7 +707,7 @@ def get_gc_agreement_deployments_to_check(product_id: str):
     Retrieves Global Customer (gc) agreement deployments that require verification or review.
 
     This method retrieve the list of GCAgreementDeployment objects associated with the
-    specified product that are in pending or error state
+    specified product that are in pending state
 
     Args:
         product_id: The ID of the product used to determine the AirTable base.
@@ -719,10 +719,7 @@ def get_gc_agreement_deployments_to_check(product_id: str):
         AirTableBaseInfo.for_migrations(product_id)
     )
     return gc_agreement_deployment_model.all(
-        formula=OR(
-            EQ(Field("status"), STATUS_GC_PENDING),
-            EQ(Field("status"), STATUS_GC_ERROR),
-        ),
+        formula=EQ(Field("status"), STATUS_GC_PENDING),
     )
 
 

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -748,7 +748,7 @@ def test_get_gc_agreement_deployments_to_check(mocker, settings):
 
     assert result == [gc_agreement_deployments]
     mocked_gc_agreement_deployments_model.all.assert_called_once_with(
-        formula=OR(EQ(Field("status"), "pending"), EQ(Field("status"), "error")),
+        formula=EQ(Field("status"), "pending"),
     )
 
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

`get_gc_agreement_deployments_to_check` now returns only deployments in **`pending`** status — previously it returned `pending` **or** `error`.

## Why

[MPT-21608](https://softwareone.atlassian.net/browse/MPT-21608) is a recurring `[monitoring]` dashboard failure:

```
MPTAPIError: 400 Bad Request - Price list currency 'JPY' does not match
seller's 'SEL-1278-8564' supported currencies.
```

raised from `get_listing` → `create_listing` in `adobe_vipm/flows/global_customer.py`. The **same** deployment record failed hundreds of times (failure counts 288 → 864 → 12).

Root cause of the *recurrence*: once a deployment fails, its `authorization_id`/`price_list_id` are already persisted on the Airtable record. Because `get_gc_agreement_deployments_to_check` also returned `error`-status records, every cron run re-picked the same record; the cached ids short-circuit re-validation in `get_authorization`/`get_price_list_id`, so the identical doomed `create_listing` call was re-issued each run.

This matches the team investigation (David Franco / Stuart Meeks) noted in the ticket: **process only `pending` deployments**.

## Behavior change

- Failed deployments stay in `error` with their descriptive `error_description` for manual review.
- To retry a record after the data is corrected, reset its status to `pending`.

## Out of scope

The underlying seller/currency data inconsistency (a seller owning a JPY authorization while JPY is absent from its `supportedCurrencies`) is **platform-side**, tracked in **MPT-21348**. The per-deployment currency derivation in `_check_update_airtable_missing_deployments` was verified correct (exact `deploymentId` match; `currencyCode` key already fixed in commit `7b4e80b2`), so no change there.

## Testing

- `tests/airtable/test_models.py` — 35 passed (assertion for the formula updated).
- `tests/flows/test_global_customer.py` — passed.
- `ruff format --check`, `ruff check`, `flake8` on changed files — pass (also verified via pre-commit hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MPT-21608]: https://softwareone.atlassian.net/browse/MPT-21608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21608](https://softwareone.atlassian.net/browse/MPT-21608)

- Modified `get_gc_agreement_deployments_to_check` to process only deployments with `pending` status, excluding those in `error` status
- Prevents repeated reprocessing of failed deployments that would otherwise be selected and reprocessed on each cron run
- Failed deployments remain in `error` status with their error descriptions for manual review; manual status reset to `pending` is required to retry after correcting data
- Updated corresponding test assertions to reflect the pending-only query filter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->