### PR TITLE
[HF] MPT-21608 process only pending GC agreement deployments

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -707,7 +707,7 @@ def get_gc_agreement_deployments_to_check(product_id: str):
     Retrieves Global Customer (gc) agreement deployments that require verification or review.
 
     This method retrieve the list of GCAgreementDeployment objects associated with the
-    specified product that are in pending or error state
+    specified product that are in pending state
 
     Args:
         product_id: The ID of the product used to determine the AirTable base.
@@ -719,10 +719,7 @@ def get_gc_agreement_deployments_to_check(product_id: str):
         AirTableBaseInfo.for_migrations(product_id)
     )
     return gc_agreement_deployment_model.all(
-        formula=OR(
-            EQ(Field("status"), STATUS_GC_PENDING),
-            EQ(Field("status"), STATUS_GC_ERROR),
-        ),
+        formula=EQ(Field("status"), STATUS_GC_PENDING),
     )
 
 

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -748,7 +748,7 @@ def test_get_gc_agreement_deployments_to_check(mocker, settings):
 
     assert result == [gc_agreement_deployments]
     mocked_gc_agreement_deployments_model.all.assert_called_once_with(
-        formula=OR(EQ(Field("status"), "pending"), EQ(Field("status"), "error")),
+        formula=EQ(Field("status"), "pending"),
     )
 
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Hotfix backport

Hotfix of [#843](https://github.com/softwareone-platform/swo-adobe-vipm-extension/pull/843) (merged to `main`) cherry-picked onto `release/5`.

- Source `main` PR: #843
- Cherry-picked commit: `3015b48c` — `fix(global-customer): process only pending GC agreement deployments`
- Jira: [MPT-21608](https://softwareone.atlassian.net/browse/MPT-21608) (Bug, fixVersion `hotfix`)

## What

`get_gc_agreement_deployments_to_check` now returns only deployments in **`pending`** status — previously it returned `pending` **or** `error`.

## Why

[MPT-21608](https://softwareone.atlassian.net/browse/MPT-21608) is a recurring `[monitoring]` dashboard failure:

```
MPTAPIError: 400 Bad Request - Price list currency 'JPY' does not match
seller's 'SEL-1278-8564' supported currencies.
```

raised from `get_listing` → `create_listing` in `adobe_vipm/flows/global_customer.py`. The **same** deployment record failed hundreds of times. Once a deployment fails, its `authorization_id`/`price_list_id` are already persisted on the Airtable record; because the query also returned `error`-status records, every cron run re-picked the same record and re-issued the identical doomed `create_listing` call.

## Behavior change

- Failed deployments stay in `error` with their descriptive `error_description` for manual review.
- To retry a record after the data is corrected, reset its status to `pending`.

## Testing

- `make check-all` on `release/5` after cherry-pick — **passed** (ruff format/check, flake8, `uv lock --check`, 857 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-21608]: https://softwareone.atlassian.net/browse/MPT-21608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-21608]: https://softwareone.atlassian.net/browse/MPT-21608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21608](https://softwareone.atlassian.net/browse/MPT-21608)

**Changes:**
- Updated `get_gc_agreement_deployments_to_check` to filter for pending GC agreement deployments only (status == `pending`)
- Removed `STATUS_GC_ERROR` from the query filter and function documentation
- Failed deployments now remain in `error` status for manual review instead of being reprocessed on every cron run
- Records with `error` status can be retried by manually resetting the status to `pending`
- Test expectations updated to reflect the new filtering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->