### PR TITLE
MPT-21850 track shared CodeRabbit config from main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 remote_config:
-  url: "https://raw.githubusercontent.com/softwareone-platform/swo-extension-playground/refs/heads/main/.coderabbit.yaml"
+  url: "https://raw.githubusercontent.com/softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Updated the CodeRabbit remote configuration URL to use the main branch version of mpt-extension-skills/coderabbit-shared.yaml.
- Removed the dependency on the playground repository CodeRabbit configuration so this repository reads the shared configuration directly.

## Testing
- ruby -e YAML.load_file(".coderabbit.yaml")
- make check-all

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

[MPT-21850]: https://softwareone.atlassian.net/browse/MPT-21850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21850](https://softwareone.atlassian.net/browse/MPT-21850)

- Updated `.coderabbit.yaml` remote configuration to reference the shared `softwareone-platform/mpt-extension-skills/main/coderabbit-shared.yaml` configuration
- Removed dependency on the playground repository's CodeRabbit configuration, allowing the repository to read shared configuration directly from the main branch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->