### PR TITLE
MPT-21857 Pin SonarQube scan action

### DIFF
--- a/.github/workflows/pr-build-merge.yml
+++ b/.github/workflows/pr-build-merge.yml
@@ -33,7 +33,7 @@ jobs:
       run: make check-all
 
     - name: "Run SonarCloud Scan"
-      uses: SonarSource/sonarqube-scan-action@master
+      uses: SonarSource/sonarqube-scan-action@v8.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What changed
- Pinned the SonarQube scan GitHub Action to `v8.0.0` instead of the moving `master` branch.
- Checked the remaining workflow `uses:` references; they already use version tags rather than `master` or `main`.

## Validation
- `make check-all`