### PR TITLE
MPT-21879 docs: note that PR descriptions must be complete at creation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,3 +53,5 @@ See [testing.md](testing.md) for repository-specific testing expectations.
 Documentation rules live in [documentation.md](documentation.md).
 
 When changing docs, update the smallest relevant file instead of duplicating policy across multiple documents.
+
+Open the pull request with its complete description in place from the start so automated reviewers evaluate the final content.


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Added one line to `docs/contributing.md` stating that pull requests must be opened with their complete description in place.

## Why

Test PR to verify the MPT-21879 fix that landed in `mpt-extension-skills`: the PR description, including this `🤖 AI-generated PR` warning line, is set in the single `gh pr create` call so CodeRabbit reviews the final body on the `opened` event (no stale-description false-positives).

## Scope

- Docs-only change (1 file, +2 lines). No code or behavior changes.

## Testing

- `pre-commit run --files docs/contributing.md` — relevant hooks passed (Python hooks skipped).

Refs: MPT-21879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21879](https://softwareone.atlassian.net/browse/MPT-21879)

- Added guidance to `docs/contributing.md` instructing contributors that pull requests must be opened with their complete description in place from the start, ensuring automated reviewers evaluate the final content on the `opened` event

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21879]: https://softwareone.atlassian.net/browse/MPT-21879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ