### PR TITLE
MPT-22051 swo-adobe-vipm-extension documentation fixes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,93 @@
+# Architecture
+
+This document describes the structure, major components, boundaries, and layer
+responsibilities of `swo-adobe-vipm-extension`. For configuration, local setup,
+external systems, testing, and migrations, see the documents linked below.
+
+## Purpose
+
+`swo-adobe-vipm-extension` is a SoftwareOne Marketplace Platform (MPT) extension
+for the Adobe VIP Marketplace program. It fulfils and validates Adobe orders
+(purchase, change, transfer, reseller transfer, termination, configuration),
+synchronises agreements, subscriptions, and pricing from Adobe, manages
+three-year commitments (3YC), and runs reseller/transfer operational jobs.
+
+It is built on the MPT Extension SDK and runs as the registered `swo.mpt.ext`
+extension (`pyproject.toml` `[project.entry-points."swo.mpt.ext"]` ->
+`adobe_vipm.apps:ExtensionConfig`).
+
+## Entry points
+
+- `adobe_vipm/apps.py` — Django `ExtensionConfig` (SDK `DjAppConfig`).
+- `adobe_vipm/extension.py` — registers the SDK hooks:
+  - order fulfilment event listener (`orders`) -> `fulfill_order(client, order)`
+  - order validation endpoint (`POST /v1/orders/validate`) -> `validate_order(client, order)`
+- `adobe_vipm/management/commands/` — Django management commands run by the
+  worker (see Management commands).
+
+## Layers
+
+1. **Entry layer** (`extension.py`) — receives order events and validation requests.
+2. **Fulfilment** (`flows/fulfillment/`) — `fulfill_order()` in `base.py` routes by
+   order type to `purchase.py`, `change.py`, `transfer.py`, `reseller_transfer.py`,
+   `termination.py`, and `configuration.py`; `shared.py` holds common utilities.
+3. **Validation** (`flows/validation/`) — `validate_order()` in `base.py` routes to
+   per-type validators (`purchase.py`, `change.py`, `transfer.py`, `termination.py`).
+4. **Sync** (`flows/sync/`) — Adobe-to-MPT synchronisation for `agreement.py`,
+   `subscription.py`, and `asset.py`, with `price_manager.py` for pricing.
+5. **Integration clients** — the Adobe client (`adobe/`), Airtable (`airtable/`),
+   and notification helpers (`notifications.py`) wrap external systems.
+
+## Major components
+
+| Package / module | Responsibility |
+|---|---|
+| `adobe_vipm/flows/` | Order fulfilment, validation, and sync orchestration |
+| `adobe_vipm/adobe/client.py` + `adobe/mixins/` | Adobe VIPM API client (customer, order, subscription, transfer, deployment, reseller mixins) |
+| `adobe_vipm/adobe/config.py` | `Config` singleton: authorizations, resellers, countries |
+| `adobe_vipm/airtable/models.py` | `pyairtable` models for migration, pricing, and SKU-mapping data |
+| `adobe_vipm/notifications.py` | Microsoft Teams alerts (`pymsteams`) and MPT notifications (Jinja2 templates) |
+| `adobe_vipm/management/commands/` | Worker commands for transfers, 3YC, resellers, and sync |
+
+## Management commands
+
+Run by the worker (locally via `make run` + the Django management interface, and
+in deployment as worker jobs / CronJobs):
+
+- `create_resellers` — create resellers in Adobe VIP Marketplace from an Excel file
+- `process_transfers`, `check_running_transfers` — process and monitor agreement transfers
+- `process_3yc`, `sync_3yc_enrol`, `process_3yc_expiration_notifications` — three-year-commitment lifecycle and expiration notifications
+- `sync_agreements` — synchronise agreements from Adobe to MPT
+- `check_gc_agreement_deployments` — verify global-customer agreement deployments
+
+## External integrations
+
+Adobe VIPM API (`adobe/`), Airtable (`airtable/`), the MPT API (via the SDK),
+Microsoft Teams, NAV, and AWS SES email. See
+[external-integrations.md](external-integrations.md) for purpose, auth, and
+configuration of each.
+
+## Boundaries
+
+- External systems are reached only through their client module (`adobe/`,
+  `airtable/`, `notifications.py`); flows depend on those clients, not raw HTTP.
+- Configuration is read through Django settings / `EXTENSION_CONFIG`, not from the
+  environment directly inside business logic. Adobe credentials and
+  authorizations are loaded from mounted JSON files (see
+  [deployment.md](deployment.md)).
+
+## Deployment shape
+
+Deployed from `helm/swo-extension-adobe` as an **api** workload (webhooks and the
+validation endpoint), a **worker** workload, and **CronJobs** for the management
+commands. The container image is built from the multi-stage `Dockerfile` and
+started via `swoext run`. See [deployment.md](deployment.md) for configuration.
+
+## Related documentation
+
+- [local-development.md](local-development.md) — local setup and run
+- [contributing.md](contributing.md) — development workflow and commands
+- [testing.md](testing.md) — test strategy and execution
+- [deployment.md](deployment.md) — configuration and deployment model
+- [external-integrations.md](external-integrations.md) — external systems
+- [migrations.md](migrations.md) — migration workflow

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,7 +51,7 @@ Deployed workloads receive configuration through Helm config maps, secrets, and 
 | `EXT_AIRTABLE_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for migration and transfer data |
 | `EXT_AIRTABLE_PRICING_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for pricing data |
 | `EXT_AIRTABLE_SKU_MAPPING_BASE` | - | `appXXXXXXXX` | Airtable base id for SKU mapping |
-| `EXT_MIGRATION_RUNNING_MAX_RETRIES` | `10` | `10` | Retry limit for migration-running logic |
+| `EXT_MIGRATION_RUNNING_MAX_RETRIES` | `15` | `15` | Retry limit for migration-running logic |
 
 ## NAV Settings
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,7 +51,7 @@ Deployed workloads receive configuration through Helm config maps, secrets, and 
 | `EXT_AIRTABLE_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for migration and transfer data |
 | `EXT_AIRTABLE_PRICING_BASES` | - | `{"PRD-1111-1111":"app..."}` | Per-product Airtable base mapping for pricing data |
 | `EXT_AIRTABLE_SKU_MAPPING_BASE` | - | `appXXXXXXXX` | Airtable base id for SKU mapping |
-| `EXT_MIGRATION_RUNNING_MAX_RETRIES` | `15` | `15` | Retry limit for migration-running logic |
+| `EXT_MIGRATION_RUNNING_MAX_RETRIES` | `15` | `15` | Retry limit for migration-running logic (code default `15`; the bundled Helm chart ships `10` via `MigrationRunningMaxRetries`) |
 
 ## NAV Settings
 

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -1,0 +1,25 @@
+# External Integrations
+
+This document lists the external systems the extension integrates with, their
+purpose, and how they authenticate. The full environment-variable reference for
+each integration lives in [deployment.md](deployment.md); this document is the
+index and does not duplicate those tables.
+
+## Integrations
+
+| System | Purpose | Auth | Configuration | Code |
+| --- | --- | --- | --- | --- |
+| Adobe VIPM API | Order creation/preview, subscriptions, customers, resellers, transfers, deployments | OAuth 2.0 client credentials; credentials and authorizations loaded from mounted JSON files | `EXT_ADOBE_API_BASE_URL`, `EXT_ADOBE_AUTH_ENDPOINT_URL`, `EXT_ADOBE_CREDENTIALS_FILE`, `EXT_ADOBE_AUTHORIZATIONS_FILE` | [`adobe_vipm/adobe/client.py`](../adobe_vipm/adobe/client.py), [`adobe_vipm/adobe/config.py`](../adobe_vipm/adobe/config.py) |
+| Airtable | Migration tracking, pricing tables, and SKU mapping | Personal Access Token | `EXT_AIRTABLE_API_TOKEN`, `EXT_AIRTABLE_BASES`, `EXT_AIRTABLE_PRICING_BASES`, `EXT_AIRTABLE_SKU_MAPPING_BASE` | [`adobe_vipm/airtable/models.py`](../adobe_vipm/airtable/models.py) |
+| SoftwareOne Marketplace (MPT) API | Order polling, agreement/subscription updates, notifications | Bearer token (JWT) | `MPT_API_BASE_URL`, `MPT_API_TOKEN`, `MPT_PRODUCTS_IDS`, `MPT_NOTIFY_CATEGORIES` | provided by `mpt-extension-sdk` |
+| Microsoft Teams | Operational alerts (warnings, errors, exceptions) | Incoming webhook | `EXT_MSTEAMS_WEBHOOK_URL` | [`adobe_vipm/notifications.py`](../adobe_vipm/notifications.py) |
+| NAV | Customer/reseller validation against NAV | OAuth 2.0 client credentials | `EXT_NAV_API_BASE_URL`, `EXT_NAV_AUTH_ENDPOINT_URL`, `EXT_NAV_AUTH_AUDIENCE`, `EXT_NAV_AUTH_CLIENT_ID`, `EXT_NAV_AUTH_CLIENT_SECRET` | `adobe_vipm/flows/` |
+| AWS SES | Email notifications when enabled | AWS credentials | `EXT_EMAIL_NOTIFICATIONS_ENABLED`, `EXT_EMAIL_NOTIFICATIONS_SENDER`, `EXT_AWS_SES_REGION`, `EXT_AWS_SES_CREDENTIALS` | `adobe_vipm/notifications.py` / flows |
+
+## Notes
+
+- Adobe credentials (`EXT_ADOBE_CREDENTIALS_FILE`) and authorizations
+  (`EXT_ADOBE_AUTHORIZATIONS_FILE`) are JSON files that must stay consistent;
+  their formats are documented in [deployment.md](deployment.md).
+- Email notifications (AWS SES) are optional and only active when
+  `EXT_EMAIL_NOTIFICATIONS_ENABLED` is set.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,48 @@
+# Local Development
+
+This document covers running `swo-adobe-vipm-extension` locally. Docker is the
+default execution model. Runtime configuration and environment variables are
+documented in [deployment.md](deployment.md); the contribution workflow and
+validation commands are in [contributing.md](contributing.md).
+
+## Prerequisites
+
+- Docker and Docker Compose.
+- An `.env` file at the repository root, created from `.env.sample`.
+- Adobe credentials and authorizations JSON files referenced by
+  `EXT_ADOBE_CREDENTIALS_FILE` and `EXT_ADOBE_AUTHORIZATIONS_FILE`. In local runs
+  the repository is mounted at `/extension`, so these usually point at files in
+  the repository root. See the file formats in [deployment.md](deployment.md).
+
+## Setup and run
+
+```bash
+cp .env.sample .env        # then fill in the required values
+make build                 # build the images
+make run                   # start the service (compose, http://localhost:8080)
+```
+
+The Compose service runs `swoext run --no-color` and exposes port `8080`.
+
+## Common commands
+
+| Command | Purpose |
+| --- | --- |
+| `make build` | Build the Docker images |
+| `make run` | Run the service via Docker Compose |
+| `make bash` | Open a shell in the container |
+| `make shell` | Open a Django shell (`swoext shell`) |
+| `make test` | Run the test suite (`args=<filter>` to narrow) |
+| `make check` | Run formatting, lint, type, and lock checks |
+| `make check-all` | Run checks and tests |
+| `make down` | Stop and remove the containers |
+
+For migration commands (`migrate-schema`, `migrate-data`, `migrate-list`, …) see
+[migrations.md](migrations.md).
+
+## Configuration
+
+The minimal local configuration covers the Marketplace API, the Adobe
+integration (API URLs plus the credential/authorization files), Airtable, and
+the webhook secrets. The full variable reference lives in
+[deployment.md](deployment.md).


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Documentation fixes for swo-adobe-vipm-extension (MPT-22051, under MPT-22048).

- **docs/architecture.md** added: structure, entry points, the fulfilment/validation/sync layers, the Adobe client (+ mixins), Airtable, notifications, the worker **management commands** (incl. `create_resellers` and `process_3yc_expiration_notifications`), and the helm api/worker/cron deployment shape.
- **docs/local-development.md** added: Docker setup (`cp .env.sample .env`, `make build`, `make run` → :8080), the make targets, and the Adobe credential/authorization files.
- **docs/external-integrations.md** added: index of Adobe VIPM, Airtable, MPT, MS Teams, NAV, and AWS SES — purpose, auth, config keys (referencing deployment.md), and client module.
- **docs/deployment.md**: `EXT_MIGRATION_RUNNING_MAX_RETRIES` default fixed `10` → `15` to match the code default in `adobe_vipm/flows/migration.py`.

## Testing
- `audit_docs.py`: no missing required docs, no remaining recommendations.
- pre-commit file-hygiene hooks pass.

Subtask: MPT-22051 (parent MPT-22048).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22051](https://softwareone.atlassian.net/browse/MPT-22051)

- Added docs/architecture.md — architecture overview: purpose, SDK entry points, layered responsibilities (entry/fulfilment/validation/sync), major modules, integration clients, management commands, system boundaries, and Helm deployment shape (api/worker/CronJobs).
- Added docs/local-development.md — Docker Compose local setup (cp .env.sample .env; make build; make run → http://localhost:8080), prerequisites, common make targets, and Adobe credential/authorization file guidance.
- Added docs/external-integrations.md — index of external integrations (Adobe VIPM, Airtable, MPT, MS Teams, NAV, AWS SES) with purpose, auth methods, required env vars, and code references; notes on Adobe JSON files and optional AWS SES notifications.
- Updated docs/deployment.md — documented EXT_MIGRATION_RUNNING_MAX_RETRIES as 15 (code default) and noted the bundled Helm chart ships MigrationRunningMaxRetries = 10.
- Tests / hygiene — audit_docs.py reports no missing required docs and pre-commit file-hygiene hooks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22051]: https://softwareone.atlassian.net/browse/MPT-22051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ