### PR TITLE
[HF] MPT-22233 Flexible discount not applied to example sku related purchase

### DIFF
--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -542,6 +542,17 @@ class OrderClientMixin:
             )
             if match:
                 country = match.group(1)
+                logger.info(
+                    "Flex discounts: using deployment %s country override %s",
+                    context.customer_data[Param.DEPLOYMENT_ID],
+                    country,
+                )
+        logger.info(
+            "Flex discounts: requesting from Adobe market_segment=%s country=%s offer_ids=%s",
+            MARKET_SEGMENTS[context.market_segment],
+            country,
+            offer_ids,
+        )
         try:
             flex_discounts = self._get_flex_discounts(
                 authorization,
@@ -557,11 +568,21 @@ class OrderClientMixin:
                 flex_discounts = ()
             else:
                 raise
+        logger.debug(
+            "Flex discounts: Adobe returned %s discount(s): %s",
+            len(flex_discounts),
+            flex_discounts,
+        )
         base_offers_with_discounts = {}
         for flex_discount in filter(lambda fd: fd["status"] == "ACTIVE", flex_discounts):
             base_offers_with_discounts.update(
                 dict.fromkeys(flex_discount["qualification"]["baseOfferIds"], flex_discount["code"])
             )
+        logger.info(
+            "Flex discounts: resolved %s base offer(s) with active discounts: %s",
+            len(base_offers_with_discounts),
+            base_offers_with_discounts,
+        )
         return base_offers_with_discounts
 
     def _get_fail_discounts_for_cust_not_qualified(self, ex: AdobeError, payload: dict) -> set:
@@ -743,20 +764,25 @@ class OrderClientMixin:
     @wrap_http_error
     def _get_flex_discounts(
         self, authorization: Authorization, segment: str, country: str, offer_ids: tuple[str, ...]
-    ) -> dict:
+    ) -> list:
         headers = self._get_headers(authorization)
         offer_ids = ",".join(offer_ids)
-        response = requests.get(
-            urljoin(
-                self._config.api_base_url,
-                "v3/flex-discounts",
-            ),
-            headers=headers,
-            params={"market-segment": {segment}, "country": {country}, "offer-ids": {offer_ids}},
-            timeout=self._TIMEOUT,
-        )
-        response.raise_for_status()
-        return response.json()["flexDiscounts"]
+        query_params = {"market-segment": {segment}, "country": {country}, "offer-ids": {offer_ids}}
+        next_url = "v3/flex-discounts"
+        flex_discounts = []
+        while next_url:
+            response = requests.get(
+                urljoin(self._config.api_base_url, next_url),
+                headers=headers,
+                params=query_params,
+                timeout=self._TIMEOUT,
+            )
+            response.raise_for_status()
+            page = response.json()
+            flex_discounts.extend(page["flexDiscounts"])
+            next_url = page.get("links", {}).get("next", {}).get("uri")
+            query_params = None
+        return flex_discounts
 
     def _update_payload_by_deployment(
         self, authorization: Authorization, deployment_id: str | None, payload: dict[str, Any]

--- a/tests/adobe/mixins/test_order.py
+++ b/tests/adobe/mixins/test_order.py
@@ -452,3 +452,68 @@ def test_get_flex_discounts_per_base_offer_error(
             context,
             ("99999999CA01A12", "99999999CA01A12"),
         )  # act
+
+
+def test_get_flex_discounts_per_base_offer_collects_all_pages(
+    adobe_client_factory,
+    requests_mocker,
+    settings,
+    mock_order,
+    flex_discounts_factory,
+):
+    mocked_client, authorization, _ = adobe_client_factory()
+    full = flex_discounts_factory()
+    base_url = urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "/v3/flex-discounts")
+    page_one = {
+        **full,
+        "flexDiscounts": full["flexDiscounts"][:1],
+        "links": {
+            "next": {
+                "uri": "/v3/flex-discounts?market-segment=COM&country=US"
+                "&offer-ids=99999999CA01A12,99999999CA01A12&offset=50",
+                "method": "GET",
+                "headers": [],
+            }
+        },
+    }
+    page_two = {
+        **full,
+        "flexDiscounts": full["flexDiscounts"][1:],
+        "links": {"self": full["links"]["self"]},
+    }
+    requests_mocker.get(
+        base_url,
+        json=page_one,
+        match=[
+            matchers.query_param_matcher({
+                "market-segment": "COM",
+                "country": "US",
+                "offer-ids": "99999999CA01A12,99999999CA01A12",
+            })
+        ],
+    )
+    requests_mocker.get(
+        base_url,
+        json=page_two,
+        match=[
+            matchers.query_param_matcher({
+                "market-segment": "COM",
+                "country": "US",
+                "offer-ids": "99999999CA01A12,99999999CA01A12",
+                "offset": "50",
+            })
+        ],
+    )
+    context = Context(order=mock_order, market_segment="COM")
+
+    result = mocked_client.get_flex_discounts_per_base_offer(
+        authorization,
+        context,
+        ("99999999CA01A12", "99999999CA01A12"),
+    )  # act
+
+    assert result == {
+        "65304768CA01A12": "BLACK_FRIDAY_22_FAILURE_3",
+        "65304769CA01A12": "EASTER_26",
+        "65304770CA01A12": "ADOBE_ALL_PROMOTION",
+    }

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -3181,3 +3181,57 @@ def test_get_flex_discounts(
     )
 
     assert result == flex_discount_resp["flexDiscounts"]
+
+
+def test_get_flex_discounts_follows_pagination_links(
+    requests_mocker, adobe_client_factory, settings, flex_discounts_factory
+):
+    client, authorization, _ = adobe_client_factory()
+    full = flex_discounts_factory()
+    base_url = urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "v3/flex-discounts")
+    page_one = {
+        **full,
+        "flexDiscounts": full["flexDiscounts"][:1],
+        "links": {
+            "next": {
+                "uri": "/v3/flex-discounts?market-segment=COM&country=US"
+                "&offer-ids=65304768CA01A12,65304768CA01A12&offset=50",
+                "method": "GET",
+                "headers": [],
+            }
+        },
+    }
+    page_two = {
+        **full,
+        "flexDiscounts": full["flexDiscounts"][1:],
+        "links": {"self": full["links"]["self"]},
+    }
+    requests_mocker.get(
+        base_url,
+        json=page_one,
+        match=[
+            matchers.query_param_matcher({
+                "market-segment": "COM",
+                "country": "US",
+                "offer-ids": "65304768CA01A12,65304768CA01A12",
+            })
+        ],
+    )
+    requests_mocker.get(
+        base_url,
+        json=page_two,
+        match=[
+            matchers.query_param_matcher({
+                "market-segment": "COM",
+                "country": "US",
+                "offer-ids": "65304768CA01A12,65304768CA01A12",
+                "offset": "50",
+            })
+        ],
+    )
+
+    result = client._get_flex_discounts(
+        authorization, "COM", "US", ("65304768CA01A12", "65304768CA01A12")
+    )
+
+    assert result == full["flexDiscounts"]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix backport of [MPT-22233](https://softwareone.atlassian.net/browse/MPT-22233) to `release/5`, cherry-picked from the merged `main` PR #855 (commit `2fd308ca`).

## What

Paginate Adobe's `v3/flex-discounts` retrieval in `_get_flex_discounts` by following `links.next`, collecting every page (default page size). Previously only the first page was fetched. Adds INFO/DEBUG logging in `get_flex_discounts_per_base_offer` so the resolved discounts are observable.

## Why (MPT-22233)

`v3/flex-discounts` is a paginated collection. Fetching only the first page left `get_flex_discounts_per_base_offer` with an incomplete `base-offer → code` map, so `flexDiscountCodes` for discounts on later pages were never attached to the preview order, Adobe returned the undiscounted price, and the purchase wizard showed the base price instead of the discounted one.

## Source

- Main PR: #855 (merged to `main`)
- Cherry-picked commit: `2fd308ca` (single commit, applied cleanly to `release/5`)

## Tests / validation

- Branch-coverage tests for single-page (loop stops immediately) and multi-page (follows `links.next` then stops) cases, plus an end-to-end `get_flex_discounts_per_base_offer` test proving discounts spanning two pages all contribute to the map.
- `make check-all` on `release/5` + this commit: **859 passed**, ruff / flake8 / uv-lock clean.


[MPT-22233]: https://softwareone.atlassian.net/browse/MPT-22233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced flex discount retrieval to properly handle large result sets by implementing pagination support, ensuring complete and accurate data collection across all flex discount records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->