### PR TITLE
[HF] MPT-22333 get_customer_deployments only retrieves the first page of customer deployments

### DIFF
--- a/adobe_vipm/adobe/mixins/deployment.py
+++ b/adobe_vipm/adobe/mixins/deployment.py
@@ -26,18 +26,20 @@ class DeploymentClientMixin:
             dict: Deployments.
 
         """
-        authorization = self._config.get_authorization(authorization_id)
-        headers = self._get_headers(authorization)
-        response = requests.get(
-            urljoin(
-                self._config.api_base_url,
-                f"/v3/customers/{customer_id}/deployments?limit=100&offset=0",
-            ),
-            headers=headers,
-            timeout=self._TIMEOUT,
-        )
-        response.raise_for_status()
-        return response.json()
+        headers = self._get_headers(self._config.get_authorization(authorization_id))
+        next_url = f"/v3/customers/{customer_id}/deployments"
+        deployments = []
+        while next_url:
+            response = requests.get(
+                urljoin(self._config.api_base_url, next_url),
+                headers=headers,
+                timeout=self._TIMEOUT,
+            )
+            response.raise_for_status()
+            page = response.json()
+            deployments.extend(page.get("items", []))
+            next_url = page.get("links", {}).get("next", {}).get("uri")
+        return {"items": deployments, "totalCount": len(deployments)}
 
     def get_customer_deployments_active_status(
         self,

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -2920,7 +2920,7 @@ def test_get_customer_deployments(
     customer_id = "a-customer-id"
     client, authorization, api_token = adobe_client_factory()
     expected_response = {
-        "totalCount": 1,
+        "totalCount": 2,
         "items": [
             {
                 "deploymentId": "deployment-id-1",
@@ -2937,7 +2937,7 @@ def test_get_customer_deployments(
     requests_mocker.get(
         urljoin(
             settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
-            f"/v3/customers/{customer_id}/deployments?limit=100&offset=0",
+            f"/v3/customers/{customer_id}/deployments",
         ),
         status=200,
         json=expected_response,
@@ -2955,7 +2955,7 @@ def test_get_customer_deployments(
 
     result = client.get_customer_deployments(authorization_uk, customer_id)
 
-    assert result == expected_response
+    assert result == {"items": expected_response["items"], "totalCount": 2}
 
 
 def test_get_customer_deployments_active_status(
@@ -2965,6 +2965,7 @@ def test_get_customer_deployments_active_status(
     customer_id = "a-customer-id"
     client, authorization, api_token = adobe_client_factory()
     deployments_response = {
+        "totalCount": 3,
         "items": [
             {
                 "deploymentId": "deployment-1",
@@ -2981,7 +2982,7 @@ def test_get_customer_deployments_active_status(
                 "status": "1000",
                 "companyProfile": {"address": {"country": "ES"}},
             },
-        ]
+        ],
     }
     active_deployments_response = [
         {
@@ -2998,7 +2999,7 @@ def test_get_customer_deployments_active_status(
     requests_mocker.get(
         urljoin(
             settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
-            f"/v3/customers/{customer_id}/deployments?limit=100&offset=0",
+            f"/v3/customers/{customer_id}/deployments",
         ),
         status=200,
         json=deployments_response,
@@ -3018,6 +3019,70 @@ def test_get_customer_deployments_active_status(
 
     assert len(result) == 2
     assert result == active_deployments_response
+
+
+def test_get_customer_deployments_follows_pagination_links(
+    requests_mocker, settings, adobe_client_factory, adobe_authorizations_file
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    customer_id = "a-customer-id"
+    client, authorization, api_token = adobe_client_factory()
+    expected_headers = {
+        "X-Api-Key": authorization.client_id,
+        "Authorization": f"Bearer {api_token.token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    base_url = urljoin(
+        settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+        f"/v3/customers/{customer_id}/deployments",
+    )
+    requests_mocker.get(
+        base_url,
+        status=200,
+        json={
+            "totalCount": 3,
+            "items": [
+                {"deploymentId": "deployment-1", "status": "1000"},
+                {"deploymentId": "deployment-2", "status": "1000"},
+            ],
+            "links": {
+                "next": {
+                    "uri": f"/v3/customers/{customer_id}/deployments?offset=2",
+                    "method": "GET",
+                    "headers": [],
+                }
+            },
+        },
+        match=[
+            matchers.query_param_matcher({}),
+            matchers.header_matcher(expected_headers),
+        ],
+    )
+    requests_mocker.get(
+        base_url,
+        status=200,
+        json={
+            "totalCount": 3,
+            "items": [{"deploymentId": "deployment-3", "status": "1000"}],
+            "links": {"self": {"uri": "", "method": "GET", "headers": []}},
+        },
+        match=[
+            matchers.query_param_matcher({"offset": "2"}),
+            matchers.header_matcher(expected_headers),
+        ],
+    )
+
+    result = client.get_customer_deployments(authorization_uk, customer_id)
+
+    assert result == {
+        "items": [
+            {"deploymentId": "deployment-1", "status": "1000"},
+            {"deploymentId": "deployment-2", "status": "1000"},
+            {"deploymentId": "deployment-3", "status": "1000"},
+        ],
+        "totalCount": 3,
+    }
 
 
 def test_preview_reseller_change(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix backport of [MPT-22333](https://softwareone.atlassian.net/browse/MPT-22333) to `release/5`, cherry-picked from the merged `main` PR #858 (commit `9d4cb5e4`).

## What

Paginate `get_customer_deployments` (`adobe_vipm/adobe/mixins/deployment.py`) so it retrieves **all** pages of a customer's deployments via the default page size + following `links.next`, instead of reading only the first page.

## Why (MPT-22333)

Adobe's `GET /v3/customers/{id}/deployments` is paginated. The method requested `?limit=100&offset=0` (over the max of 50) and never paginated, so a customer / Global Customer with more deployments than one page silently lost the rest — affecting `get_customer_deployments_active_status` and the Global Customer deployment flows.

## Source

- Main PR: #858 (merged to `main`)
- Cherry-picked commit: `9d4cb5e4` (single commit, applied cleanly to `release/5`)

## Tests / validation

- Branch-coverage tests: single-page (no `next` link), multi-page (follows `links.next` then stops, asserting auth headers persist across pages).
- `make check-all` on `release/5` + this commit: **860 passed**, ruff / flake8 / uv-lock clean.


[MPT-22333]: https://softwareone.atlassian.net/browse/MPT-22333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed customer deployment retrieval to properly handle multiple pages of results, ensuring all deployments are returned.

* **Tests**
  * Expanded test coverage for deployment retrieval scenarios, including pagination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->