### PR TITLE
MPT-22448 Missing prices for end-of-sale SKUs when a customer's 3YC has ended

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -450,11 +450,29 @@ def _get_prices_for_skus_from_airtable(
     )
 
 
+def _get_historical_prices_for_skus_from_airtable(
+    product_id: str, currency: str, skus: list[str], column_name: str
+) -> dict:
+    pricelist_model = get_pricelist_model(AirTableBaseInfo.for_pricing(product_id))
+    return pricelist_model.all(
+        formula=AND(
+            EQ(Field("currency"), currency),
+            NE(Field("valid_until"), BLANK()),
+            OR(
+                *[EQ(Field(column_name), sku) for sku in skus],
+            ),
+        ),
+        sort=["-valid_until"],
+    )
+
+
 def get_prices_for_skus(product_id: str, currency: str, skus: list[str]) -> dict:
     """
     Given a currency and a list of SKUs it retrieves the purchase price.
 
-    For each SKU in the given currency.
+    For each SKU in the given currency. SKUs without a current price (i.e. end-of-sale
+    items, which no longer have an open-ended pricelist row) fall back to their most
+    recent historical price.
 
     Args:
         product_id: The ID of the product used to determine the AirTable base.
@@ -467,7 +485,19 @@ def get_prices_for_skus(product_id: str, currency: str, skus: list[str]) -> dict
     if not skus:
         return {}
     items = _get_prices_for_skus_from_airtable(product_id, currency, skus, "sku")
-    return {item.sku: item.unit_pp for item in items}
+    prices = {item.sku: item.unit_pp for item in items}
+
+    missing = sorted(set(skus) - set(prices))
+    if not missing:
+        return prices
+
+    historical_items = _get_historical_prices_for_skus_from_airtable(
+        product_id, currency, missing, "sku"
+    )
+    for item in historical_items:
+        # results are sorted by -valid_until, so the first row seen per SKU is the newest
+        prices.setdefault(item.sku, item.unit_pp)
+    return prices
 
 
 def get_skus_with_available_prices(product_id: str, currency: str, skus: list[str]) -> set:

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -293,6 +293,81 @@ def test_get_prices_for_skus_empty(mocker, settings):
     assert result == {}
 
 
+def test_get_prices_for_skus_falls_back_to_historical_for_missing(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_PRICING_BASES": {"product_id": "base_id"},
+    }
+    mocked_pricelist_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_pricelist_model",
+        return_value=mocked_pricelist_model,
+    )
+    current_item = mocker.MagicMock()
+    current_item.sku = "sku-1"
+    current_item.unit_pp = 12.44
+    historical_item = mocker.MagicMock()
+    historical_item.sku = "sku-2"
+    historical_item.unit_pp = 9.99
+    mocked_pricelist_model.all.side_effect = [[current_item], [historical_item]]
+
+    result = get_prices_for_skus("product_id", "currency", ["sku-1", "sku-2"])
+
+    assert result == {"sku-1": 12.44, "sku-2": 9.99}
+    assert mocked_pricelist_model.all.call_count == 2
+    # the fallback queries historical rows (populated valid_until) for the missing SKU only
+    assert mocked_pricelist_model.all.call_args_list[1] == mocker.call(
+        formula=AND(
+            EQ(Field("currency"), "currency"),
+            NE(Field("valid_until"), BLANK()),
+            OR(EQ(Field("sku"), "sku-2")),
+        ),
+        sort=["-valid_until"],
+    )
+
+
+def test_get_prices_for_skus_historical_fallback_uses_newest(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_PRICING_BASES": {"product_id": "base_id"},
+    }
+    mocked_pricelist_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_pricelist_model",
+        return_value=mocked_pricelist_model,
+    )
+    newest = mocker.MagicMock()
+    newest.sku = "sku-1"
+    newest.unit_pp = 8.00
+    older = mocker.MagicMock()
+    older.sku = "sku-1"
+    older.unit_pp = 5.00
+    # sorted by -valid_until, so the newest row comes first
+    mocked_pricelist_model.all.side_effect = [[], [newest, older]]
+
+    result = get_prices_for_skus("product_id", "currency", ["sku-1"])
+
+    assert result == {"sku-1": 8.00}
+
+
+def test_get_prices_for_skus_missing_everywhere(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_PRICING_BASES": {"product_id": "base_id"},
+    }
+    mocked_pricelist_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_pricelist_model",
+        return_value=mocked_pricelist_model,
+    )
+    mocked_pricelist_model.all.side_effect = [[], []]
+
+    result = get_prices_for_skus("product_id", "currency", ["sku-1"])
+
+    assert result == {}
+    assert mocked_pricelist_model.all.call_count == 2
+
+
 def test_get_skus_with_available_prices(mocker, settings):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

In the regular (non-3YC) pricing path, `get_prices_for_skus`
(`adobe_vipm/airtable/models.py`) now falls back, for any SKU without a
current price, to that SKU's **most recent historical** Airtable row
(newest `valid_until`). Items still on sale are unaffected.

## Why ([MPT-22448](https://softwareone.atlassian.net/browse/MPT-22448))

When a customer's 3YC ends, their discount reverts to level 1 and pricing
resolves via the regular path, which queries only **current** Airtable rows
(`valid_until` blank). End-of-sale (EOS) items no longer have a current row —
only historical ones — so their prices were reported as missing and triggered
"Missing prices detected" notifications (e.g. agreement `AGR-8977-3031-0928`,
SKUs `30002255CC01A12` / `30001479CC01A12`), even though a valid historical
price exists in Airtable.

Root cause: the branch that reads historical rows (`get_prices_for_3yc_skus`)
is gated off once the 3YC ends (`get_commitment_start_date` returns `None` for
an expired commitment), so EOS SKUs fell through the current-price query and
the MPT-pricelist fallback to the missing-price path.

## How

- New private helper `_get_historical_prices_for_skus_from_airtable` queries
  rows with a populated `valid_until` (`NE(..., BLANK())`), sorted
  `-valid_until` (newest first) — mirroring the existing
  `_get_prices_3yc_for_skus_from_airtable` query scaffolding.
- `get_prices_for_skus` runs the current-price query first, then for **only**
  the SKUs with no current price, falls back to the newest historical row per
  SKU (`setdefault` over the newest-first results). No extra Airtable call runs
  when nothing is missing, and current prices are never clobbered.
- EOS is detected purely by the absence of a current row; the `status` field is
  not consulted.
- A SKU with neither a current nor a historical row is still reported missing
  (behavior unchanged — `PriceManager` still notifies).

## Tests

- `test_get_prices_for_skus_falls_back_to_historical_for_missing` — current SKU
  kept, missing SKU falls back; asserts the exact historical formula + `sort`
  and that only the missing SKU is re-queried.
- `test_get_prices_for_skus_historical_fallback_uses_newest` — newest
  `valid_until` wins among multiple historical rows.
- `test_get_prices_for_skus_missing_everywhere` — no current and no historical
  row → still reported missing.
- `make check-all`: **863 passed**, ruff / flake8 / uv-lock clean.

[MPT-22448]: https://softwareone.atlassian.net/browse/MPT-22448

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22448](https://softwareone.atlassian.net/browse/MPT-22448)

## Release notes

- Added a new private helper function `_get_historical_prices_for_skus_from_airtable` that queries Airtable rows with populated `valid_until` values (historical pricing data), sorted by most recent `valid_until` first
- Modified `get_prices_for_skus` to implement a two-step fallback strategy: first queries current open-ended prices, then for any missing SKUs, retrieves the most recent historical price per SKU
- End-of-sale SKUs now correctly return prices from historical Airtable rows when current pricing is unavailable, preventing false "Missing prices detected" notifications
- Added three new unit tests validating the partial fallback behavior, newest-historical-wins logic, and behavior when SKUs lack both current and historical pricing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->