### PR TITLE
MPT-22523 forward --sync-prices on sync_agreements --all

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -1137,7 +1137,9 @@ def sync_agreements_by_3yc_enroll_status(
             )
 
 
-def sync_all_agreements(mpt_client: MPTClient, adobe_client: AdobeClient, *, dry_run: bool) -> None:
+def sync_all_agreements(
+    mpt_client: MPTClient, adobe_client: AdobeClient, *, dry_run: bool, sync_prices: bool = False
+) -> None:
     """
     Get all the active agreements to update the prices for them.
 
@@ -1146,10 +1148,13 @@ def sync_all_agreements(mpt_client: MPTClient, adobe_client: AdobeClient, *, dry
         adobe_client: The Adobe API client.
         dry_run: if True, it just simulate the prices update but doesn't
         perform it.
+        sync_prices: if True also sync prices.
     """
     agreements = mpt.get_all_agreements(mpt_client)
     for agreement in agreements:
-        sync_agreement(mpt_client, adobe_client, agreement, dry_run=dry_run, sync_prices=False)
+        sync_agreement(
+            mpt_client, adobe_client, agreement, dry_run=dry_run, sync_prices=sync_prices
+        )
 
 
 def sync_agreement(

--- a/adobe_vipm/management/commands/sync_agreements.py
+++ b/adobe_vipm/management/commands/sync_agreements.py
@@ -60,7 +60,12 @@ class Command(AdobeBaseCommand):
                 sync_prices=options["sync_prices"],
             )
         elif options["all"]:
-            sync_all_agreements(mpt_client, adobe_client, dry_run=options["dry_run"])
+            sync_all_agreements(
+                mpt_client,
+                adobe_client,
+                dry_run=options["dry_run"],
+                sync_prices=options["sync_prices"],
+            )
         else:
             sync_agreements_by_3yc_end_date(mpt_client, adobe_client, dry_run=options["dry_run"])
             sync_agreements_by_coterm_date(mpt_client, adobe_client, dry_run=options["dry_run"])

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -3840,6 +3840,7 @@ def test_sync_agreements_by_agreement_ids(
 
 
 @pytest.mark.parametrize("dry_run", [True, False])
+@pytest.mark.parametrize("sync_prices", [True, False])
 def test_sync_all_agreements(
     mocker,
     mock_mpt_client,
@@ -3848,13 +3849,16 @@ def test_sync_all_agreements(
     mock_adobe_client,
     mock_agreement,
     dry_run,
+    sync_prices,
 ):
     mocker.patch("mpt_extension_sdk.mpt_http.mpt.get_all_agreements", return_value=[mock_agreement])
 
-    sync_all_agreements(mock_mpt_client, mock_adobe_client, dry_run=dry_run)  # act
+    sync_all_agreements(
+        mock_mpt_client, mock_adobe_client, dry_run=dry_run, sync_prices=sync_prices
+    )  # act
 
     mock_sync_agreement.assert_called_once_with(
-        mock_mpt_client, mock_adobe_client, mock_agreement, dry_run=dry_run, sync_prices=False
+        mock_mpt_client, mock_adobe_client, mock_agreement, dry_run=dry_run, sync_prices=sync_prices
     )
 
 

--- a/tests/management/commands/test_sync_agreements.py
+++ b/tests/management/commands/test_sync_agreements.py
@@ -50,4 +50,6 @@ def test_process_all(mocker, dry_run, mock_mpt_client, mock_adobe_client):
 
     call_command("sync_agreements", all=True, dry_run=dry_run, sync_prices=True)  # act
 
-    mocked.assert_called_once_with(mock_mpt_client, mock_adobe_client, dry_run=dry_run)
+    mocked.assert_called_once_with(
+        mock_mpt_client, mock_adobe_client, dry_run=dry_run, sync_prices=True
+    )


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Forward the `--sync-prices` flag on the `sync_agreements --all` path. `sync_all_agreements` now accepts a `sync_prices` keyword (default `False`), and the command's `--all` branch passes `options["sync_prices"]`, mirroring `sync_agreements_by_agreement_ids`.

## Why

Per the [Agreement Sync Improvements TDR](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/6440189992/Adobe+VIPM+Agreement+Sync+Improvements+TDR), ad-hoc bulk syncs intentionally do **not** change prices — *"Only sync prices if the trigger is renewal, end of 3YC, or order completed successfully. Otherwise, don't sync prices."* The force-prices capability was wired only into the `--agreements` ad-hoc path.

Stuart Meeks (PM) requested extending it to `--all`, so a PM can force a price sync across all active agreements when handling operational issues. This is a **change request** (MPT-22523), an agreed amendment to the TDR — not a defect. It supersedes MPT-22357, which was raised as a bug but is working as designed.

## Behavior

- `sync_agreements --all` (no flag) — unchanged; prices not synced (TDR-compliant default).
- `sync_agreements --all --sync-prices` — now syncs subscription unit prices (opt-in only).
- `--dry-run` honored in both cases.

## Testing

- `test_process_all` now asserts the flag is forwarded from the command.
- `test_sync_all_agreements` parametrized over `sync_prices` to verify both `True`/`False` propagate to `sync_agreement`.
- `uv run pytest` (affected suites) — 95 passed; `ruff check`, `ruff format`, and `flake8` clean.

Jira: [MPT-22523](https://softwareone.atlassian.net/browse/MPT-22523)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-22523]: https://softwareone.atlassian.net/browse/MPT-22523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22357](https://softwareone.atlassian.net/browse/MPT-22357)

## Release Notes

- **Added** `sync_prices` parameter to `sync_all_agreements()` function with a default value of `False` to preserve the TDR-intended behavior for ad-hoc bulk syncs
- **Updated** the `sync_agreements --all` command path to forward the `--sync-prices` flag to `sync_all_agreements()`, mirroring the existing behavior of `sync_agreements_by_agreement_ids()`
- **Changed** price synchronization behavior for bulk syncs from silent skip to explicit opt-in: users must now use `--sync-prices` flag to sync subscription unit prices when using `--all`
- **Updated** test coverage with parametrized tests for both `sync_prices=True` and `sync_prices=False` scenarios in both the flow and command layers
- **Preserved** `--dry-run` flag support for both price sync and non-sync paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->