### PR TITLE
[BACKPORT] MPT-22523 forward --sync-prices on sync_agreements --all

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -1149,7 +1149,9 @@ def sync_agreements_by_3yc_enroll_status(
             )
 
 
-def sync_all_agreements(mpt_client: MPTClient, adobe_client: AdobeClient, *, dry_run: bool) -> None:
+def sync_all_agreements(
+    mpt_client: MPTClient, adobe_client: AdobeClient, *, dry_run: bool, sync_prices: bool = False
+) -> None:
     """
     Get all the active agreements to update the prices for them.
 
@@ -1158,10 +1160,13 @@ def sync_all_agreements(mpt_client: MPTClient, adobe_client: AdobeClient, *, dry
         adobe_client: The Adobe API client.
         dry_run: if True, it just simulate the prices update but doesn't
         perform it.
+        sync_prices: if True also sync prices.
     """
     agreements = mpt.get_all_agreements(mpt_client)
     for agreement in agreements:
-        sync_agreement(mpt_client, adobe_client, agreement, dry_run=dry_run, sync_prices=False)
+        sync_agreement(
+            mpt_client, adobe_client, agreement, dry_run=dry_run, sync_prices=sync_prices
+        )
 
 
 def sync_agreement(

--- a/adobe_vipm/management/commands/sync_agreements.py
+++ b/adobe_vipm/management/commands/sync_agreements.py
@@ -60,7 +60,12 @@ class Command(AdobeBaseCommand):
                 sync_prices=options["sync_prices"],
             )
         elif options["all"]:
-            sync_all_agreements(mpt_client, adobe_client, dry_run=options["dry_run"])
+            sync_all_agreements(
+                mpt_client,
+                adobe_client,
+                dry_run=options["dry_run"],
+                sync_prices=options["sync_prices"],
+            )
         else:
             sync_agreements_by_3yc_end_date(mpt_client, adobe_client, dry_run=options["dry_run"])
             sync_agreements_by_coterm_date(mpt_client, adobe_client, dry_run=options["dry_run"])

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -3870,6 +3870,7 @@ def test_sync_agreements_by_agreement_ids(
 
 
 @pytest.mark.parametrize("dry_run", [True, False])
+@pytest.mark.parametrize("sync_prices", [True, False])
 def test_sync_all_agreements(
     mocker,
     mock_mpt_client,
@@ -3878,13 +3879,16 @@ def test_sync_all_agreements(
     mock_adobe_client,
     mock_agreement,
     dry_run,
+    sync_prices,
 ):
     mocker.patch("mpt_extension_sdk.mpt_http.mpt.get_all_agreements", return_value=[mock_agreement])
 
-    sync_all_agreements(mock_mpt_client, mock_adobe_client, dry_run=dry_run)  # act
+    sync_all_agreements(
+        mock_mpt_client, mock_adobe_client, dry_run=dry_run, sync_prices=sync_prices
+    )  # act
 
     mock_sync_agreement.assert_called_once_with(
-        mock_mpt_client, mock_adobe_client, mock_agreement, dry_run=dry_run, sync_prices=False
+        mock_mpt_client, mock_adobe_client, mock_agreement, dry_run=dry_run, sync_prices=sync_prices
     )
 
 

--- a/tests/management/commands/test_sync_agreements.py
+++ b/tests/management/commands/test_sync_agreements.py
@@ -50,4 +50,6 @@ def test_process_all(mocker, dry_run, mock_mpt_client, mock_adobe_client):
 
     call_command("sync_agreements", all=True, dry_run=dry_run, sync_prices=True)  # act
 
-    mocked.assert_called_once_with(mock_mpt_client, mock_adobe_client, dry_run=dry_run)
+    mocked.assert_called_once_with(
+        mock_mpt_client, mock_adobe_client, dry_run=dry_run, sync_prices=True
+    )


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

**`[BACKPORT]` of #866 to `release/5`.**

## What

Backports the `--sync-prices` forwarding on `sync_agreements --all` from `main` (#866, commit `d4ab3645`) to `release/5`. The single source commit was cherry-picked and applied cleanly.

`sync_all_agreements` now accepts a `sync_prices` keyword (default `False`), and the command's `--all` branch forwards `options["sync_prices"]`, mirroring `sync_agreements_by_agreement_ids`.

## Why

Per the [Agreement Sync Improvements TDR](https://softwareone.atlassian.net/wiki/spaces/mpt/pages/6440189992/Adobe+VIPM+Agreement+Sync+Improvements+TDR), ad-hoc bulk syncs intentionally do **not** change prices; the force-prices flag was wired only into the `--agreements` path. Stuart Meeks (PM) requested extending it to `--all` so a PM can force a price sync across all active agreements when handling operational issues.

## Behavior

- `sync_agreements --all` (no flag) — unchanged; prices not synced.
- `sync_agreements --all --sync-prices` — now syncs subscription unit prices (opt-in only).
- `--dry-run` honored in both cases.

## Testing

- `ruff check`, `ruff format`, `flake8` clean on the release/5 base.
- `uv run pytest` for the affected suites — 95 passed.

Jira: [MPT-22523](https://softwareone.atlassian.net/browse/MPT-22523)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-22523]: https://softwareone.atlassian.net/browse/MPT-22523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ