### PR TITLE
MPT-21111 Implement the listing/pricelist discovery to process the gl…

### DIFF
--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import pathlib
 
 from django.conf import settings
 from mpt_extension_sdk.core.utils import setup_client, setup_operations_client
@@ -34,7 +36,6 @@ from adobe_vipm.airtable.models import (
     get_sku_price,
 )
 from adobe_vipm.flows.constants import (
-    GLOBAL_SUFFIX,
     MARKET_SEGMENT_COMMERCIAL,
     MPT_ORDER_STATUS_COMPLETED,
     TEMPLATE_ASSET_DEFAULT,
@@ -83,6 +84,16 @@ def get_adobe_subscriptions_by_deployment(adobe_client, authorization_id, agreem
         for item in adobe_subscriptions["items"]
         if item.get("deploymentId", "") == agreement_deployment.deployment_id
     ]
+
+
+def get_region_from_country(country):
+    """Get the region from the country."""
+    with pathlib.Path("adobe_vipm/region_country_mapping.json").open(encoding="utf-8") as file:
+        data = json.load(file)
+    for item in data:
+        if country in item["countries"]:
+            return item["region"].lower()
+    return None
 
 
 def get_authorization(mpt_client, agreement_deployment):
@@ -160,6 +171,8 @@ def get_price_list_id(mpt_client, agreement_deployment):
     Returns:
         str: The price list ID if found, None otherwise.
     """
+    region = get_region_from_country(agreement_deployment.deployment_country)
+
     if agreement_deployment.price_list_id:
         return agreement_deployment.price_list_id
 
@@ -176,30 +189,33 @@ def get_price_list_id(mpt_client, agreement_deployment):
         agreement_deployment.save()
         return None
 
-    global_price_lists = list(
+    local_price_lists = list(
         filter(
             lambda price_list: (
-                price_list.get("externalIds", {}).get("vendor", "").endswith(GLOBAL_SUFFIX)
+                f"{region}-{agreement_deployment.deployment_currency.lower()}"
+                in price_list.get("externalIds", {}).get("vendor", "")
             ),
             price_lists,
         )
     )
 
-    if not global_price_lists:
+    if not local_price_lists:
         logger.error(
-            "Global price list not found for agreement deployment %s",
+            "local price list not found for agreement deployment %s, region %s, currency %s",
             agreement_deployment.deployment_id,
+            region,
+            agreement_deployment.deployment_currency,
         )
         agreement_deployment.status = STATUS_GC_ERROR
         agreement_deployment.error_description = (
-            f"There is no global price list for currency "
-            f"'{agreement_deployment.deployment_currency}'. "
+            f"There is no local price list for currency "
+            f"'{agreement_deployment.deployment_currency}' and region '{region}'. "
             "Please update the price list column with the selected value"
         )
         agreement_deployment.save()
         return None
 
-    if len(global_price_lists) > 1:
+    if len(local_price_lists) > 1:
         logger.error(
             "More than one price list found for agreement deployment %s",
             agreement_deployment.deployment_id,
@@ -207,14 +223,14 @@ def get_price_list_id(mpt_client, agreement_deployment):
         price_list_ids = [price_list["id"] for price_list in price_lists]
         agreement_deployment.status = STATUS_GC_ERROR
         agreement_deployment.error_description = (
-            f"There is more than one global price list available for currency "
-            f"'{agreement_deployment.deployment_currency}': {price_list_ids}. "
+            f"There is more than one price list available for currency "
+            f"'{agreement_deployment.deployment_currency}' and region '{region}':{price_list_ids}."
             "Please update the price list column with the selected value"
         )
         agreement_deployment.save()
         return None
 
-    price_list_id = global_price_lists[0]["id"]
+    price_list_id = local_price_lists[0]["id"]
 
     agreement_deployment.price_list_id = price_list_id
     agreement_deployment.save()

--- a/adobe_vipm/region_country_mapping.json
+++ b/adobe_vipm/region_country_mapping.json
@@ -1,0 +1,53 @@
+[
+    {
+      "region": "AP",
+      "countries": [
+        "BD", "BT", "BN", "CV", "KH", "CN", "CX", "CC", "CK", "FJ", "TF", "HK", "IN", "ID", "KI", "KR", "LA", "MO", "MY", "MV",
+        "MH", "FM", "MN", "NR", "NP", "NU", "NF", "KP", "PK", "PW", "PG", "PH", "WS", "ST", "SG", "SB", "LK", "TW", "TH", "TL",
+        "TK", "TO", "TV", "VU", "VN", "WF"
+      ]
+    },
+    {
+      "region": "EE",
+      "countries": [
+        "AF", "AL", "DZ", "AO", "AM", "AZ", "BH", "BY", "BJ", "BA", "BW", "BF", "BI", "CM", "CF", "TD", "CG", "CI", "CD", "DJ",
+        "EG", "GQ", "ER", "SZ", "ET", "PF", "GA", "GM", "GE", "GH", "GN", "GW", "IQ", "IL", "JO", "KZ", "KE", "KW", "KG", "LB",
+        "LS", "LR", "LY", "MK", "MG", "MW", "ML", "MR", "MU", "YT", "MD", "ME", "MS", "MA", "MZ", "NA", "NC", "NE", "NG", "OM",
+        "PS", "QA", "RE", "RU", "RW", "PM", "SA", "SN", "RS", "SC", "SL", "SO", "ZA", "SS", "SH", "TJ", "TZ", "TG", "TN", "TR",
+        "TM", "UG", "UA", "AE", "UZ", "YE", "ZM", "ZW"
+      ]
+    },
+    {
+      "region": "JP",
+      "countries": [ "JP" ]
+    },
+    {
+      "region": "LA",
+      "countries": [
+        "AI", "AG", "AR", "AW", "BS", "BB", "BZ", "BM", "BO", "BQ", "BR", "KY", "CL", "CO", "CR", "CU", "CW", "DM", "DO", "EC",
+        "SV", "FK", "GF", "GD", "GP", "GT", "GY", "HT", "HN", "JM", "MQ", "AN", "NI", "PA", "PY", "PE", "SX", "KN", "LC", "VC",
+        "SR", "TT", "TC", "UY", "VE", "VG"
+      ]
+    },
+    {
+      "region": "MX",
+      "countries": [ "MX" ]
+    },
+    {
+      "region": "NA",
+      "countries": [ "AS", "CA", "GU", "MP", "PR", "US", "UM", "VI" ]
+    },
+    {
+      "region": "PA",
+      "countries": [ "AU", "NZ" ]
+    },
+    {
+      "region": "WE",
+      "countries": [
+        "AD", "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FO", "FI", "FR", "DE", "GI", "GB", "GR", "GL", "HU", "IS", "IE",
+        "IT", "JE", "LV", "LI", "LT", "LU", "MT", "MC", "NL", "NO", "PL", "PT", "RO", "SM", "SK", "SI", "ES", "SE", "CH", "IM",
+        "VA"
+      ]
+    }
+  ]
+  

--- a/tests/flows/test_global_customer.py
+++ b/tests/flows/test_global_customer.py
@@ -4,12 +4,13 @@ import pytest
 
 from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
 from adobe_vipm.adobe.errors import AdobeAPIError
-from adobe_vipm.airtable.models import get_sku_price
+from adobe_vipm.airtable.models import STATUS_GC_ERROR, get_sku_price
 from adobe_vipm.flows.constants import TEMPLATE_ASSET_DEFAULT, ItemTermsModel, Param
 from adobe_vipm.flows.errors import AirTableAPIError, MPTAPIError
 from adobe_vipm.flows.global_customer import (
     check_gc_agreement_deployments,
     create_gc_agreement_asset,
+    get_region_from_country,
 )
 
 
@@ -240,9 +241,13 @@ def test_check_gc_agreement_deployments_get_price_more_than_one(
     mocker, mock_adobe_client, settings, mpt_error_factory, gc_agreement_deployment
 ):
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
+    price_lists = [
+        {"id": "PRC-111-111-111", "externalIds": {"vendor": "prc-adobe-com-t1-na-usd-01"}},
+        {"id": "PRC-222-222-222", "externalIds": {"vendor": "prc-adobe-com-t1-na-usd-02"}},
+    ]
     mocked_get_gc_price_list_by_currency = mocker.patch(
         "adobe_vipm.flows.global_customer.get_gc_price_list_by_currency",
-        return_value=[mocker.MagicMock(), mocker.MagicMock()],
+        return_value=price_lists,
     )
     mocker.patch(
         "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
@@ -255,14 +260,20 @@ def test_check_gc_agreement_deployments_get_price_more_than_one(
 
     mocked_gc_agreement_deployments_model.all.assert_called_once()
     mocked_get_gc_price_list_by_currency.assert_called_once()
+    assert gc_agreement_deployment.status == STATUS_GC_ERROR
+    assert "PRC-111-111-111" in gc_agreement_deployment.error_description
+    assert "PRC-222-222-222" in gc_agreement_deployment.error_description
+    gc_agreement_deployment.save.assert_called()
 
 
 def test_check_gc_agreement_deployments_get_listing_error(
     mocker, mock_adobe_client, mpt_error_factory, gc_agreement_deployment
 ):
     mocked_gc_agreement_deployments_model = mocker.MagicMock()
-    price_list = mocker.MagicMock()
-    price_list.externalIds = "price_list_global"
+    price_list = {
+        "id": "PRC-123-123-123",
+        "externalIds": {"vendor": "prc-adobe-com-t1-na-usd-01"},
+    }
     mocked_get_gc_price_list_by_currency = mocker.patch(
         "adobe_vipm.flows.global_customer.get_gc_price_list_by_currency",
         return_value=[price_list],
@@ -1238,3 +1249,19 @@ def test_create_gc_agreement_asset(
         mock_mpt_client, "PRD-123-123-123", TEMPLATE_ASSET_DEFAULT
     )
     mock_create_asset.assert_called_once_with(mock_mpt_client, expected_asset)
+
+
+@pytest.mark.parametrize(
+    ("country", "expected_region"),
+    [
+        ("JP", "jp"),
+        ("US", "na"),
+        ("IN", "ap"),
+    ],
+)
+def test_get_region_from_country(country, expected_region):
+    assert get_region_from_country(country) == expected_region  # act
+
+
+def test_get_region_from_country_returns_none_when_country_not_mapped():
+    assert get_region_from_country("XX") is None  # act


### PR DESCRIPTION
…obal customers agreements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21111](https://softwareone.atlassian.net/browse/MPT-21111)

- Added `adobe_vipm/RegionCountryMapping.json` to map region codes to country codes.
- Updated global customer agreement listing/pricelist discovery to derive a pricing region from `agreement_deployment.deployment_country` and select local GC price lists by matching region/currency-specific `externalIds.vendor` values (replacing the previous `GLOBAL_SUFFIX`-based logic).
- Introduced `get_region_from_country(country)` and improved error handling by setting `agreement_deployment.status`/`error_description` and returning `None` when no region-based match is found or when matches are ambiguous.
- Updated `tests/flows/test_global_customer.py` mocks and assertions to reflect the new price-list response structure and added unit tests for region mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21111]: https://softwareone.atlassian.net/browse/MPT-21111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ