### PR TITLE
MPT-22645 Fix AttributeError when notifying Airtable error saving Global Customer Main Agreement

### DIFF
--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -390,7 +390,7 @@ def check_running_transfers_for_product(product_id):  # noqa: C901
                         button=get_transfer_link_button(filled_tranfer),
                         facts=FactsSection(
                             "Error from checking running transfers",
-                            str(error),
+                            {error.__class__.__name__: str(error)},
                         ),
                     )
         if filled_tranfer.customer_benefits_3yc_status != ThreeYearCommitmentStatus.COMMITTED:

--- a/tests/flows/test_migration.py
+++ b/tests/flows/test_migration.py
@@ -1308,7 +1308,10 @@ def test_checking_running_transfers_with_gc_not_exists_and_airtable_error_for_pr
             "Error saving Global Customer Main Agreement",
             "An error occurred while saving the Global Customer Main Agreement.",
             button=get_transfer_link_button(mock_transfer),
-            facts=FactsSection("Error from checking running transfers", "400 - Bad Request"),
+            facts=FactsSection(
+                "Error from checking running transfers",
+                {"AirTableAPIError": "400 - Bad Request"},
+            ),
         )
 
 
@@ -1416,7 +1419,10 @@ def test_checking_running_transfers_with_gc_not_exists_no_address_and_airtable_e
             "Error saving Global Customer Main Agreement",
             "An error occurred while saving the Global Customer Main Agreement.",
             button=get_transfer_link_button(mock_transfer),
-            facts=FactsSection("Error from checking running transfers", "400 - Bad Request"),
+            facts=FactsSection(
+                "Error from checking running transfers",
+                {"AirTableAPIError": "400 - Bad Request"},
+            ),
         )
 
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fixes a latent `AttributeError` in the Global Customer Main Agreement error-notification path of `check_running_transfers_for_product` (`adobe_vipm/flows/migration.py`).

The `except AirTableHttpError` handler passed `str(error)` to `FactsSection`, whose `data` field must be a `dict`. When that path executed, `send_notification` (`adobe_vipm/notifications.py`) iterated `facts.data.items()` and raised `AttributeError: 'str' object has no attribute 'items'`. Because that is **not** a `pymsteams.TeamsWebhookException`, it escaped the `try/except` in `send_notification` and propagated to the caller, aborting the running-transfers check.

## Change

- **`migration.py`**: pass `{error.__class__.__name__: str(error)}` instead of `str(error)`, consistent with the other `FactsSection(...)` call sites in the file. `__class__.__name__` is used as the key because the handler catches the base `AirTableHttpError`, which has no `.code`/`.message` (those exist only on the `AirTableAPIError` subclass).
- **`tests/flows/test_migration.py`**: updated the two existing handler tests to assert the dict shape `{"AirTableAPIError": "400 - Bad Request"}` instead of the previous bare string.

## Testing

- `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` — all pass
- `pytest` — 869 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed the Global Customer Main Agreement running-transfers error path so `FactsSection` now receives a dict payload instead of a raw string, preventing an `AttributeError` during notification sending.
- Updated the affected migration tests to expect the structured Airtable error payload: `{"AirTableAPIError": "400 - Bad Request"}`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->