### PR TITLE
[HF] MPT-22630 Migrate Teams notifications to Workflow webhook Adaptive Cards

### DIFF
--- a/adobe_vipm/notifications.py
+++ b/adobe_vipm/notifications.py
@@ -1,9 +1,10 @@
 import datetime as dt
+import enum
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-import pymsteams
+import requests
 from django.conf import settings
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from mpt_extension_sdk.mpt_http.base import MPTClient
@@ -12,6 +13,18 @@ from mpt_extension_sdk.mpt_http.mpt import notify
 from adobe_vipm.adobe.constants import MPT_NOTIFY_CATEGORIES
 
 logger = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 10
+
+
+class Style(enum.Enum):
+    """Adaptive Card style token, used for both Container.style and TextBlock.color.
+
+    Values are the case-sensitive lower-case Adaptive Card enum tokens.
+    """
+
+    WARNING = "warning"
+    ATTENTION = "attention"
 
 
 def dateformat(date_string: str) -> str:
@@ -45,30 +58,89 @@ class FactsSection:
     data: dict
 
 
+def _build_card(
+    title: str,
+    text: str,
+    style: Style,
+    button: Button | None,
+    facts: FactsSection | None,
+) -> dict:
+    """Builds the Adaptive Card payload wrapped in the Workflows envelope."""
+    body: list[dict] = [
+        {
+            "type": "Container",
+            "style": style.value,
+            "bleed": True,
+            "items": [
+                {
+                    "type": "TextBlock",
+                    "text": title,
+                    "weight": "bolder",
+                    "size": "large",
+                    "color": style.value,
+                    "wrap": True,
+                },
+            ],
+        },
+        {"type": "TextBlock", "text": text, "wrap": True},
+    ]
+
+    if facts:
+        if facts.title:
+            body.append(
+                {"type": "TextBlock", "text": facts.title, "weight": "bolder", "wrap": True},
+            )
+        body.append(
+            {
+                "type": "FactSet",
+                "facts": [
+                    {"title": str(key), "value": str(fact_value)}
+                    for key, fact_value in facts.data.items()
+                ],
+            },
+        )
+
+    card: dict = {
+        "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "msteams": {"width": "Full"},
+        "body": body,
+    }
+
+    if button:
+        card["actions"] = [
+            {"type": "Action.OpenUrl", "title": button.label, "url": button.url},
+        ]
+
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": card,
+            },
+        ],
+    }
+
+
 def send_notification(
     title: str,
     text: str,
-    color: str,
+    style: Style,
     button: Button | None = None,
     facts: FactsSection | None = None,
 ) -> None:
-    """Send notification to the Teams channel."""
-    message = pymsteams.connectorcard(settings.EXTENSION_CONFIG["MSTEAMS_WEBHOOK_URL"])
-    message.color(color)
-    message.title(title)
-    message.text(text)
-    if button:
-        message.addLinkButton(button.label, button.url)
-    if facts:
-        facts_section = pymsteams.cardsection()
-        facts_section.title(facts.title)
-        for key, value in facts.data.items():
-            facts_section.addFact(key, value)
-        message.addSection(facts_section)
+    """Sends an Adaptive Card to the MS Teams Workflow webhook."""
+    payload = _build_card(title, text, style, button, facts)
 
     try:
-        message.send()
-    except pymsteams.TeamsWebhookException:
+        requests.post(
+            settings.EXTENSION_CONFIG["MSTEAMS_WEBHOOK_URL"],
+            json=payload,
+            timeout=_REQUEST_TIMEOUT,
+        ).raise_for_status()
+    except requests.RequestException:
         logger.exception("Error sending notification to MSTeams!")
 
 
@@ -82,7 +154,7 @@ def send_warning(
     send_notification(
         f"\u2622 {title}",
         text,
-        "#ffa500",
+        Style.WARNING,
         button=button,
         facts=facts,
     )
@@ -98,7 +170,7 @@ def send_error(
     send_notification(
         f"\U0001f4a3 {title}",
         text,
-        "#df3422",
+        Style.ATTENTION,
         button=button,
         facts=facts,
     )
@@ -114,7 +186,7 @@ def send_exception(
     send_notification(
         f"\U0001f525 {title}",
         text,
-        "#541c2e",
+        Style.ATTENTION,
         button=button,
         facts=facts,
     )

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ Deployed workloads receive configuration through Helm config maps, secrets, and 
 
 | Environment Variable | Default | Example | Description |
 | --- | --- | --- | --- |
-| `EXT_MSTEAMS_WEBHOOK_URL` | - | `https://...office.com/...` | Microsoft Teams webhook used by notification helpers |
+| `EXT_MSTEAMS_WEBHOOK_URL` | - | `https://<env>.environment.api.powerplatform.com/.../triggers/manual/paths/invoke?...` | Microsoft Teams **Power Automate Workflow** webhook URL used by notification helpers. Must be the new Workflow webhook URL; the deprecated incoming-webhook connector URL is no longer supported |
 | `EXT_EMAIL_NOTIFICATIONS_ENABLED` | - | `true` | Enables email notification flows where configured |
 | `EXT_EMAIL_NOTIFICATIONS_SENDER` | - | `noreply@example.com` | Sender address for email notifications |
 | `EXT_AWS_SES_REGION` | - | `eu-west-1` | AWS SES region |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "openpyxl==3.1.*",
   "phonenumbers==9.0.*",
   "pyairtable==3.3.*",
-  "pymsteams==0.2.*",
   "python-dateutil==2.9.*",
   "regex==2026.*",
   "requests==2.32.*",
@@ -308,7 +307,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "migrations.*"
 disallow_subclassing_any = false
-
-[[tool.mypy.overrides]]
-module = "pymsteams.*"
-ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2145,11 +2145,6 @@ def mock_settings(settings):
 
 
 @pytest.fixture
-def mock_pymsteams(mocker):
-    return mocker.patch("pymsteams.connectorcard", autospec=True)
-
-
-@pytest.fixture
 def mock_mpt_update_agreement(mocker):
     mock = mocker.patch("mpt_extension_sdk.mpt_http.mpt.update_agreement", autospec=True)
     mocker.patch("adobe_vipm.flows.fulfillment.shared.update_agreement", new=mock)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,12 +1,13 @@
+import json
 import logging
 
-import pymsteams
 import pytest
+import requests
 
-from adobe_vipm.adobe.constants import MPT_NOTIFY_CATEGORIES
 from adobe_vipm.notifications import (
     Button,
     FactsSection,
+    Style,
     dateformat,
     mpt_notify,
     send_error,
@@ -16,92 +17,150 @@ from adobe_vipm.notifications import (
 )
 
 
-def test_send_notification_full(mocker, settings):
+def test_send_notification_full(settings, requests_mocker):
     settings.EXTENSION_CONFIG = {
         "MSTEAMS_WEBHOOK_URL": "https://teams.webhook",
     }
-    mocked_message = mocker.MagicMock()
-    mocked_section = mocker.MagicMock()
-    mocked_card = mocker.patch(
-        "adobe_vipm.notifications.pymsteams.connectorcard", return_value=mocked_message
-    )
-    mocker.patch("adobe_vipm.notifications.pymsteams.cardsection", return_value=mocked_section)
+    requests_mocker.post("https://teams.webhook", status=200)
     button = Button("button-label", "button-url")
     facts_section = FactsSection("section-title", {"key": "value"})
 
     send_notification(
         "not-title",
         "not-text",
-        "not-color",
+        Style.WARNING,
         button=button,
         facts=facts_section,
     )  # act
 
-    mocked_message.title.assert_called_once_with("not-title")
-    mocked_message.text.assert_called_once_with("not-text")
-    mocked_message.color.assert_called_once_with("not-color")
-    mocked_message.addLinkButton.assert_called_once_with(button.label, button.url)
-    mocked_section.title.assert_called_once_with(facts_section.title)
-    mocked_section.addFact.assert_called_once_with(
-        next(iter(facts_section.data.keys())),
-        next(iter(facts_section.data.values())),
+    payload = json.loads(requests_mocker.calls[0].request.body)
+    card = payload["attachments"][0]["content"]
+    card_body = card["body"]
+    title_container = card_body[0]["items"][0]
+    fact_sets = [block for block in card_body if block.get("type") == "FactSet"]
+    assert (
+        payload["type"],
+        card["type"],
+        card_body[1]["text"],
+        card["actions"],
+        fact_sets[0]["facts"],
+    ) == (
+        "message",
+        "AdaptiveCard",
+        "not-text",
+        [{"type": "Action.OpenUrl", "title": "button-label", "url": "button-url"}],
+        [{"title": "key", "value": "value"}],
     )
-    mocked_message.addSection.assert_called_once_with(mocked_section)
-    mocked_message.send.assert_called_once()
-    mocked_card.assert_called_once_with("https://teams.webhook")
+    assert title_container["text"] == "not-title"
+    assert (
+        card_body[0]["style"],
+        title_container["weight"],
+        title_container["size"],
+        title_container["color"],
+    ) == ("warning", "bolder", "large", "warning")
+    assert any(block.get("text") == "section-title" for block in card_body)
 
 
-def test_send_notification_simple(mocker, settings):
+def test_send_notification_coerces_facts_to_strings(settings, requests_mocker):
     settings.EXTENSION_CONFIG = {
         "MSTEAMS_WEBHOOK_URL": "https://teams.webhook",
     }
-    mocked_message = mocker.MagicMock()
-    mocker.patch("adobe_vipm.notifications.pymsteams.connectorcard", return_value=mocked_message)
-    mocked_cardsection = mocker.patch("adobe_vipm.notifications.pymsteams.cardsection")
+    requests_mocker.post("https://teams.webhook", status=200)
 
-    send_notification("not-title", "not-text", "not-color")  # act
+    send_notification(
+        "not-title",
+        "not-text",
+        Style.WARNING,
+        facts=FactsSection("section-title", {9999: 123}),
+    )  # act
 
-    mocked_message.title.assert_called_once_with("not-title")
-    mocked_message.text.assert_called_once_with("not-text")
-    mocked_message.color.assert_called_once_with("not-color")
-    mocked_message.addLinkButton.assert_not_called()
-    mocked_cardsection.assert_not_called()
-    mocked_message.send.assert_called_once()
+    payload = json.loads(requests_mocker.calls[0].request.body)
+    card_body = payload["attachments"][0]["content"]["body"]
+    fact_sets = [block for block in card_body if block.get("type") == "FactSet"]
+    assert fact_sets[0]["facts"] == [{"title": "9999", "value": "123"}]
 
 
-def test_send_notification_exception(mocker, settings, caplog):
+def test_send_notification_simple(settings, requests_mocker):
     settings.EXTENSION_CONFIG = {
         "MSTEAMS_WEBHOOK_URL": "https://teams.webhook",
     }
-    mocked_message = mocker.MagicMock()
-    mocked_message.send.side_effect = pymsteams.TeamsWebhookException("error")
-    mocker.patch("adobe_vipm.notifications.pymsteams.connectorcard", return_value=mocked_message)
+    requests_mocker.post("https://teams.webhook", status=200)
+
+    send_notification("not-title", "not-text", Style.WARNING)  # act
+
+    payload = json.loads(requests_mocker.calls[0].request.body)
+    card = payload["attachments"][0]["content"]
+    assert "actions" not in card
+    assert len(card["body"]) == 2
+
+
+def test_send_notification_exception(settings, requests_mocker, caplog):
+    settings.EXTENSION_CONFIG = {
+        "MSTEAMS_WEBHOOK_URL": "https://teams.webhook",
+    }
+    requests_mocker.post("https://teams.webhook", body=requests.ConnectionError("error"))
 
     with caplog.at_level(logging.ERROR):
-        send_notification("not-title", "not-text", "not-color")  # act
+        send_notification("not-title", "not-text", Style.WARNING)  # act
 
     assert "Error sending notification to MSTeams!" in caplog.text
 
 
-@pytest.mark.parametrize(
-    ("function", "color", "icon"),
-    [
-        (send_warning, "#ffa500", "\u2622"),
-        (send_error, "#df3422", "\U0001f4a3"),
-        (send_exception, "#541c2e", "\U0001f525"),
-    ],
-)
-def test_send_others(function, color, icon, mocker):
+def test_send_notification_exception_on_raise_for_status(settings, requests_mocker, caplog):
+    settings.EXTENSION_CONFIG = {
+        "MSTEAMS_WEBHOOK_URL": "https://teams.webhook",
+    }
+    requests_mocker.post("https://teams.webhook", status=500)
+
+    with caplog.at_level(logging.ERROR):
+        send_notification("not-title", "not-text", Style.WARNING)  # act
+
+    assert "Error sending notification to MSTeams!" in caplog.text
+
+
+def test_send_warning(mocker):
     mock_send_notification = mocker.patch("adobe_vipm.notifications.send_notification")
     mocked_button = mocker.MagicMock()
     mocked_facts_section = mocker.MagicMock()
 
-    function("title", "text", button=mocked_button, facts=mocked_facts_section)  # act
+    send_warning("title", "text", button=mocked_button, facts=mocked_facts_section)  # act
 
     mock_send_notification.assert_called_once_with(
-        f"{icon} title",
+        "\u2622 title",
         "text",
-        color,
+        Style.WARNING,
+        button=mocked_button,
+        facts=mocked_facts_section,
+    )
+
+
+def test_send_error(mocker):
+    mock_send_notification = mocker.patch("adobe_vipm.notifications.send_notification")
+    mocked_button = mocker.MagicMock()
+    mocked_facts_section = mocker.MagicMock()
+
+    send_error("title", "text", button=mocked_button, facts=mocked_facts_section)  # act
+
+    mock_send_notification.assert_called_once_with(
+        "\U0001f4a3 title",
+        "text",
+        Style.ATTENTION,
+        button=mocked_button,
+        facts=mocked_facts_section,
+    )
+
+
+def test_send_exception(mocker):
+    mock_send_notification = mocker.patch("adobe_vipm.notifications.send_notification")
+    mocked_button = mocker.MagicMock()
+    mocked_facts_section = mocker.MagicMock()
+
+    send_exception("title", "text", button=mocked_button, facts=mocked_facts_section)  # act
+
+    mock_send_notification.assert_called_once_with(
+        "\U0001f525 title",
+        "text",
+        Style.ATTENTION,
         button=mocked_button,
         facts=mocked_facts_section,
     )
@@ -159,12 +218,12 @@ def test_mpt_notify_exception(mocker, mock_mpt_client, caplog):
         )  # act
 
     assert (
-        f"Cannot send MPT API notification:"
-        f" Category: '{MPT_NOTIFY_CATEGORIES['ORDERS']}',"
-        f" Account ID: 'account_id',"
-        f" Buyer ID: 'buyer_id',"
-        f" Subject: 'email-subject',"
-        f" Message: 'rendered-template'"
+        "Cannot send MPT API notification:"
+        " Category: 'NTC-0000-0006',"
+        " Account ID: 'account_id',"
+        " Buyer ID: 'buyer_id',"
+        " Subject: 'email-subject',"
+        " Message: 'rendered-template'"
     ) in caplog.text
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1500,18 +1500,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pymsteams"
-version = "0.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/f5/8b9b9572d4f582e5a3a135110c07218cd43ad6d067a986576d0467bf6251/pymsteams-0.2.5.tar.gz", hash = "sha256:9f76ca3a3de17b49ce3c5c314ee0e88b8bd2be78fc66f693ade1b7cabf23af70", size = 88943, upload-time = "2025-01-07T23:59:10.763Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/55/2f83baa2a9d1eada20f41dcced4d4fb7ba14d864b160be812786802e39c3/pymsteams-0.2.5-py3-none-any.whl", hash = "sha256:bda78f36c4a59baa10fa21928980349a841b03c78dc7d6020f230aea4aeab2b7", size = 14684, upload-time = "2025-01-07T23:59:08.351Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1899,7 +1887,6 @@ dependencies = [
     { name = "openpyxl" },
     { name = "phonenumbers" },
     { name = "pyairtable" },
-    { name = "pymsteams" },
     { name = "python-dateutil" },
     { name = "regex" },
     { name = "requests" },
@@ -1939,7 +1926,6 @@ requires-dist = [
     { name = "openpyxl", specifier = "==3.1.*" },
     { name = "phonenumbers", specifier = "==9.0.*" },
     { name = "pyairtable", specifier = "==3.3.*" },
-    { name = "pymsteams", specifier = "==0.2.*" },
     { name = "python-dateutil", specifier = "==2.9.*" },
     { name = "regex", specifier = "==2026.*" },
     { name = "requests", specifier = "==2.32.*" },


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Hotfix backport of #869 (MPT-22630) to `release/5`. Migrates Adobe Teams notifications from the deprecated `pymsteams` incoming-webhook connector cards to **Power Automate Workflow webhook Adaptive Cards** posted via `requests.post`.

Cherry-picked from the merged `main` commit `6f6d06d0`.

## Changes

- `adobe_vipm/notifications.py`: replace `pymsteams` with `requests`; add a `Style` enum (lower-case Adaptive Card tokens) and `_REQUEST_TIMEOUT`; `_build_card()` builds the Adaptive Card (FactSet `title`/`value` coerced to `str`); `send_notification()` POSTs the card JSON and calls `raise_for_status()`, catching `requests.RequestException`.
- Removed the `pymsteams` dependency and its mypy override from `pyproject.toml`; updated `uv.lock`.
- `tests/test_notifications.py`: requests/`responses`-based tests (incl. FactSet coercion + lowercase enum assertions).
- `tests/conftest.py`: removed the unused `mock_pymsteams` fixture.
- `docs/deployment.md`: `EXT_MSTEAMS_WEBHOOK_URL` must be the new Power Automate Workflow webhook URL.

> The `docs/architecture.md` and `docs/external-integrations.md` edits from #869 were omitted: those files do not exist on `release/5` (newer docs structure on `main`), so they are out of scope for this hotfix.

> Deployment note: `EXT_MSTEAMS_WEBHOOK_URL` must be repointed to the new Power Automate Workflow webhook URL per environment.

## Testing

- `ruff format --check .` / `ruff check .` — clean
- `flake8 .` (wemake-python-styleguide) — clean
- `uv lock --check` — passes
- `pytest` — **867 passed**

Refs: MPT-22630 (hotfix to release/5; source PR #869 on main)
