### PR TITLE
MPT-22659 Pin mpt-extension-sdk to 5.x and cap requests in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,16 @@ updates:
     ignore:
       - dependency-name: "django"
         versions: ["*"]
+      # This repo must stay on mpt-extension-sdk 5.x: the 6.x line requires
+      # mpt-api-client 6.3.* which is incompatible with mpt-tool 6.0.* (needs
+      # mpt-api-client 5.4.*), so a 6.x bump is unresolvable and must never be
+      # selected.
+      - dependency-name: "mpt-extension-sdk"
+        versions: [">=6"]
+      # mpt-extension-sdk 5.21.* pins requests==2.32.*, so a newer requests is
+      # unresolvable until the sdk lifts that cap.
+      - dependency-name: "requests"
+        versions: [">=2.33"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add two Dependabot ignore rules in `.github/dependabot.yml` (uv ecosystem):
- `mpt-extension-sdk` `>=6`
- `requests` `>=2.33`

No `pyproject.toml` pin or `uv.lock` change — the current pins already resolve.

## Why

The weekly Dependabot `uv` updater run failed with `dependency_file_not_resolvable` (uv: *No solution found*) — see [failing run](https://github.com/softwareone-platform/swo-adobe-vipm-extension/actions/runs/27938491677).

- Dependabot tried to bump `mpt-extension-sdk` 5.21.* → 6.3.3. The 6.x line requires `mpt-api-client==6.3.*`, which is **incompatible with `mpt-tool` 6.0.\*** (requires `mpt-api-client==5.4.*`). This repo must stay on `mpt-extension-sdk` 5.x; 6.x must never be selected.
- `mpt-tool` 6.0.* is **correct and compatible** with sdk 5.x (it pairs with `mpt-api-client` 5.4.*), and 6.0.0 is the latest, so it is intentionally left uncapped.
- Separately, Dependabot tried `requests` 2.32.* → 2.34.2, but `mpt-extension-sdk` 5.21.* pins `requests==2.32.*`.

## Testing

- `dependabot.yml` validated (parses; ignore list = django, mpt-extension-sdk, requests).
- Config-only change; no dependency resolution or code is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `.github/dependabot.yml` to ignore `mpt-extension-sdk` versions `>=6` and `requests` versions `>=2.33` for the `uv` ecosystem.
- Added comments explaining these constraints to prevent Dependabot from proposing upgrades that make the dependency set unresolvable.
- No changes were made to `pyproject.toml` or `uv.lock`; this is a config-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->