### PR TITLE
MPT-22663 Refresh uv.lock for security advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,10 @@ updates:
       # selected.
       - dependency-name: "mpt-extension-sdk"
         versions: [">=6"]
-      # mpt-extension-sdk 5.21.* pins requests==2.32.*, so a newer requests is
+      # mpt-extension-sdk 5.22.* pins requests==2.33.*, so a newer requests is
       # unresolvable until the sdk lifts that cap.
       - dependency-name: "requests"
-        versions: [">=2.33"]
+        versions: [">=2.34"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ dependencies = [
   "django==4.2.*",
   "jinja2==3.1.*",
   "markdown-it-py==4.2.*",
-  "mpt-extension-sdk==5.21.*",
+  "mpt-extension-sdk==5.22.*",
   "mpt-tool==6.0.*",
   "openpyxl==3.1.*",
   "phonenumbers==9.0.*",
   "pyairtable==3.3.*",
   "python-dateutil==2.9.*",
   "regex==2026.*",
-  "requests==2.32.*",
+  "requests==2.33.*",
 ]
 
 [project.entry-points."swo.mpt.ext"]

--- a/uv.lock
+++ b/uv.lock
@@ -493,16 +493,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.29"
+version = "4.2.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/7306757cf2ac016d718d8a5dbae66de630addaa73dca2c341fc388458e71/django-4.2.29.tar.gz", hash = "sha256:86d91bc8086569c8d08f9c55888b583a921ac1f95ed3bdc7d5659d4709542014", size = 10438980, upload-time = "2026-03-03T13:56:42.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707, upload-time = "2026-04-07T14:05:45.57Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/2b/bd0a1d1846d5580e9f209b9e0128b4859e381ec1b39d6d175c61294bb530/django-4.2.29-py3-none-any.whl", hash = "sha256:074d7c4d2808050e528388bda442bd491f06def4df4fe863f27066851bba010c", size = 7996481, upload-time = "2026-03-03T13:56:36.495Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231, upload-time = "2026-04-07T14:05:38.241Z" },
 ]
 
 [[package]]
@@ -606,14 +606,14 @@ wheels = [
 
 [[package]]
 name = "gunicorn"
-version = "25.1.0"
+version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
 ]
 
 [[package]]
@@ -960,7 +960,7 @@ wheels = [
 
 [[package]]
 name = "mpt-extension-sdk"
-version = "5.21.1"
+version = "5.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity" },
@@ -984,9 +984,9 @@ dependencies = [
     { name = "uvicorn-worker" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/bf/a85a02bc828e3e942be6172339e9dbabc80db9a046c75d37aa1ff98897da/mpt_extension_sdk-5.21.1.tar.gz", hash = "sha256:8f8ed5e3bf8e6ea1c00875436a65b4144f8345f7c8f85e1b1051fa7a85eb371d", size = 34324, upload-time = "2026-03-10T11:18:49.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/21/650935e6c1af62fb50fb9794be1e87902d4822460fbad6156802c205d003/mpt_extension_sdk-5.22.1.tar.gz", hash = "sha256:b77ad1f29a88968fecaab0b0ddbbc878d48cca4743c7b8607d0e3c7c2c9a95e7", size = 32983, upload-time = "2026-06-25T16:15:13.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/c1/cc76e2b7423736dcd80ee3c2903d9e189b35abf72d0b30195f088acea77a/mpt_extension_sdk-5.21.1-py3-none-any.whl", hash = "sha256:cc3b09338bd3905eddf5a809937a8354ff643ff61f86202f4ed8d16ebd849b9a", size = 48636, upload-time = "2026-03-10T11:18:48.581Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/e3ddb291238ef11b251e159d8c4cf58e418adc1e0a7140f28c70165170e6/mpt_extension_sdk-5.22.1-py3-none-any.whl", hash = "sha256:7b2868881293e72726d2c00a0ff108ec6b949b3231d912f83ab1a214abdf878e", size = 45889, upload-time = "2026-06-25T16:15:12.448Z" },
 ]
 
 [[package]]
@@ -1531,20 +1531,20 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -1791,7 +1791,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1799,9 +1799,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -1833,15 +1833,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -1957,14 +1957,14 @@ requires-dist = [
     { name = "django", specifier = "==4.2.*" },
     { name = "jinja2", specifier = "==3.1.*" },
     { name = "markdown-it-py", specifier = "==4.2.*" },
-    { name = "mpt-extension-sdk", specifier = "==5.21.*" },
+    { name = "mpt-extension-sdk", specifier = "==5.22.*" },
     { name = "mpt-tool", specifier = "==6.0.*" },
     { name = "openpyxl", specifier = "==3.1.*" },
     { name = "phonenumbers", specifier = "==9.0.*" },
     { name = "pyairtable", specifier = "==3.3.*" },
     { name = "python-dateutil", specifier = "==2.9.*" },
     { name = "regex", specifier = "==2026.*" },
-    { name = "requests", specifier = "==2.32.*" },
+    { name = "requests", specifier = "==2.33.*" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Refresh dependencies for open Dependabot security advisories:
- Bump `mpt-extension-sdk` `5.21.*` → `5.22.*` and the direct `requests` pin `2.32.*` → `2.33.*` in `pyproject.toml`; refresh `uv.lock` (resolves sdk **5.22.1**).
- Resulting upgrades: `django` 4.2.29 → 4.2.30 (5 CVEs), `pygments` 2.19.2 → 2.20.0, `pyjwt` 2.11.0 → **2.13.0**, `requests` 2.32.5 → **2.33.1**.
- `.github/dependabot.yml`: requests ignore `>=2.33` → `>=2.34` (sdk 5.22.* pins `requests==2.33.*`); the `mpt-extension-sdk >=6` cap stays.

## Why
sdk **5.22.1** lifts the transitive `pyjwt==2.11.*` / `requests==2.32.*` caps that previously blocked these advisories, so this now clears **all fixable alerts** for the repo. Part of the fleet-wide remediation tracked by [MPT-22663](https://softwareone.atlassian.net/browse/MPT-22663).

## Testing
Validated locally: `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` all clean, **871 tests pass**.


[MPT-22663]: https://softwareone.atlassian.net/browse/MPT-22663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22663](https://softwareone.atlassian.net/browse/MPT-22663)

- Refreshed `uv.lock` and dependency pins to update `mpt-extension-sdk` to `5.22.*` and `requests` to `2.33.*`.
- Bumped security-related transitive dependencies, including `django` to `4.2.30`, `pygments` to `2.20.0`, `pyjwt` to `2.13.0`, and `requests` to `2.33.1`.
- Updated the Dependabot ignore rule for `requests` to `>=2.34` while keeping the `mpt-extension-sdk >=6` cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->