### PR TITLE
[HF] MPT-22645 Fix AttributeError when notifying Airtable error saving Global Customer Main Agreement

### DIFF
--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -390,7 +390,7 @@ def check_running_transfers_for_product(product_id):  # noqa: C901
                         button=get_transfer_link_button(filled_tranfer),
                         facts=FactsSection(
                             "Error from checking running transfers",
-                            str(error),
+                            {error.__class__.__name__: str(error)},
                         ),
                     )
         if filled_tranfer.customer_benefits_3yc_status != ThreeYearCommitmentStatus.COMMITTED:

--- a/tests/flows/test_migration.py
+++ b/tests/flows/test_migration.py
@@ -1308,7 +1308,10 @@ def test_checking_running_transfers_with_gc_not_exists_and_airtable_error_for_pr
             "Error saving Global Customer Main Agreement",
             "An error occurred while saving the Global Customer Main Agreement.",
             button=get_transfer_link_button(mock_transfer),
-            facts=FactsSection("Error from checking running transfers", "400 - Bad Request"),
+            facts=FactsSection(
+                "Error from checking running transfers",
+                {"AirTableAPIError": "400 - Bad Request"},
+            ),
         )
 
 
@@ -1416,7 +1419,10 @@ def test_checking_running_transfers_with_gc_not_exists_no_address_and_airtable_e
             "Error saving Global Customer Main Agreement",
             "An error occurred while saving the Global Customer Main Agreement.",
             button=get_transfer_link_button(mock_transfer),
-            facts=FactsSection("Error from checking running transfers", "400 - Bad Request"),
+            facts=FactsSection(
+                "Error from checking running transfers",
+                {"AirTableAPIError": "400 - Bad Request"},
+            ),
         )
 
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix of the `main` fix in #870, cherry-picked to `release/5`.

## What

Fixes a latent `AttributeError` in the Global Customer Main Agreement error-notification path of `check_running_transfers_for_product` (`adobe_vipm/flows/migration.py`).

The `except AirTableHttpError` handler passed `str(error)` to `FactsSection`, whose `data` field must be a `dict`. When that path executed, the notification layer iterated `facts.data.items()` and raised `AttributeError: 'str' object has no attribute 'items'`, which escaped the notification `try/except` and propagated to the caller, aborting the running-transfers check.

## Change

- **`migration.py`**: pass `{error.__class__.__name__: str(error)}` instead of `str(error)`, consistent with the other `FactsSection(...)` call sites.
- **`tests/flows/test_migration.py`**: the two handler tests assert the dict shape.

Cherry-picked commit: `8a5acddf` (from #870, base `main`).

## Testing

- `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` — all pass
- `pytest` — 871 passed (on `release/5`)
