### PR TITLE
MPT-22771: add run-name to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release (v${{ inputs.version }})
 
 # Manually-triggered release pipeline. Runs against the branch selected at
 # dispatch time (main -> pre-release, release/* -> latest). No branch input is


### PR DESCRIPTION
## What

Adds the `run-name` property to the release workflow so each manually-dispatched run shows the version in its title:

```yaml
run-name: Release (v${{ inputs.version }})
```

## Why

Improves traceability of release runs in the GitHub Actions UI — the run is labelled with the released version instead of a generic "Release".

## Notes

- Inserted right below `name: Release`; no other changes.
- The workflow is dispatched manually (`workflow_dispatch`) with a required `version` input, so `inputs.version` is always populated.

Jira: **MPT-22771** (parent MPT-21906)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22771](https://softwareone.atlassian.net/browse/MPT-22771)

- Added a `run-name` to the release workflow so manually dispatched runs appear as `Release (vX.Y.Z)` in GitHub Actions.
- Used the required `version` input to label each release run with the selected release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22771]: https://softwareone.atlassian.net/browse/MPT-22771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ