### PR TITLE
MPT-22920 fix currencyCode placement for deployment-scoped manual renewals

### DIFF
--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -276,10 +276,12 @@ class OrderClientMixin:
         authorization = self._config.get_authorization(authorization_id)
         payload = {
             "externalReferenceId": external_reference_id,
-            "currencyCode": authorization.currency,
             "orderType": order_type,
             "lineItems": line_items,
         }
+        if not any(line_item.get("deploymentId") for line_item in line_items):
+            payload["currencyCode"] = authorization.currency
+
         correlation_id = sha256(json.dumps(payload).encode()).hexdigest()
         headers = self._get_headers(authorization, correlation_id=correlation_id)
         response = requests.post(
@@ -475,16 +477,17 @@ class OrderClientMixin:
         """
         external_reference_id = f"{order_created['externalReferenceId']}_{order_created['orderId']}"
         adobe_order_id = order_created["orderId"]
-        currency_code = self._config.get_authorization(authorization_id).currency
         adobe_line_items = order_created["lineItems"]
 
         payload = {
             "externalReferenceId": external_reference_id,
             "referenceOrderId": adobe_order_id,
             "orderType": adobe_constants.ORDER_TYPE_RETURN,
-            "currencyCode": currency_code,
             "lineItems": adobe_line_items,
         }
+        if not any(line_item.get("deploymentId") for line_item in adobe_line_items):
+            payload["currencyCode"] = self._config.get_authorization(authorization_id).currency
+
         return self._create_return_order_base(authorization_id, customer_id, payload)
 
     def get_preview_order(  # noqa: WPS231

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -614,15 +614,19 @@ def get_existing_renewal_order(adobe_client, context, ext_ref) -> dict | None:
 
 def build_renewal_line_items(manual_renewal_lines: dict) -> list[dict]:
     """Build PREVIEW_RENEWAL/RENEWAL line items from manual renewal lines."""
-    return [
-        {
+    line_items = []
+    for line_item, info in enumerate(manual_renewal_lines.values(), start=1):
+        entry = {
             "extLineItemNumber": line_item,
             "offerId": info["offer_id"],
             "quantity": info["renewal_qty"],
             "subscriptionId": info["adobe_subscription_id"],
         }
-        for line_item, info in enumerate(manual_renewal_lines.values(), start=1)
-    ]
+        if info.get("deployment_id"):
+            entry["deploymentId"] = info["deployment_id"]
+            entry["currencyCode"] = info["currency_code"]
+        line_items.append(entry)
+    return line_items
 
 
 def is_renewal_unsupported_error(error: AdobeAPIError) -> bool:
@@ -1606,6 +1610,8 @@ class CheckManualRenewalSubscriptions(Step):
             "offer_id": adobe_subscription["offerId"],
             "renewal_qty": renewal_qty,
             "excess_qty": excess_qty,
+            "deployment_id": adobe_subscription.get("deploymentId"),
+            "currency_code": adobe_subscription.get("currencyCode"),
         }
 
         for lst in (context.upsize_lines, context.new_lines):

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -1331,7 +1331,72 @@ def test_create_renewal_order(
     client, authorization, api_token = adobe_client_factory()
     expected_payload = {
         "externalReferenceId": external_reference_id,
+        "orderType": ORDER_TYPE_RENEWAL,
+        "lineItems": line_items,
         "currencyCode": authorization.currency,
+    }
+    correlation_id = sha256(json.dumps(expected_payload).encode()).hexdigest()
+    adobe_order = adobe_order_factory(ORDER_TYPE_RENEWAL)
+    requests_mocker.post(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            f"/v3/customers/{customer_id}/orders",
+        ),
+        status=202,
+        json=adobe_order,
+        match=[
+            matchers.header_matcher(
+                {
+                    "X-Api-Key": authorization.client_id,
+                    "Authorization": f"Bearer {api_token.token}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "X-Request-Id": "uuid-1",
+                    "x-correlation-id": correlation_id,
+                },
+            ),
+            matchers.json_params_matcher(expected_payload),
+        ],
+    )
+
+    result = client.create_renewal_order(
+        authorization_uk,
+        customer_id,
+        external_reference_id,
+        line_items,
+    )
+
+    assert result == adobe_order
+
+
+def test_create_renewal_order_with_deployment(
+    mocker,
+    settings,
+    requests_mocker,
+    adobe_authorizations_file,
+    adobe_client_factory,
+    adobe_order_factory,
+):
+    """When a line item carries a deploymentId, currencyCode must live only on that item."""
+    mocker.patch(
+        "adobe_vipm.adobe.client.uuid4",
+        return_value="uuid-1",
+    )
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    customer_id = "a-customer"
+    external_reference_id = "mpt-order-id"
+    line_items = [
+        {
+            "offerId": "65304578CA01A12",
+            "quantity": 10,
+            "subscriptionId": "a-sub-id",
+            "deploymentId": "1400000194",
+            "currencyCode": "USD",
+        },
+    ]
+    client, authorization, api_token = adobe_client_factory()
+    expected_payload = {
+        "externalReferenceId": external_reference_id,
         "orderType": ORDER_TYPE_RENEWAL,
         "lineItems": line_items,
     }
@@ -1648,6 +1713,64 @@ def test_create_return_order_by_adobe_order(
         "referenceOrderId": order_created["orderId"],
         "orderType": ORDER_TYPE_RETURN,
         "currencyCode": "USD",
+        "lineItems": order_created["lineItems"],
+    }
+    requests_mocker.post(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            f"/v3/customers/{customer_id}/orders",
+        ),
+        status=202,
+        json={
+            "orderId": "adobe-order-id",
+        },
+        match=[
+            matchers.header_matcher(
+                {
+                    "X-Api-Key": authorization.client_id,
+                    "Authorization": f"Bearer {api_token.token}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "X-Request-Id": "uuid-1",
+                    "x-correlation-id": "uuid-1",
+                },
+            ),
+            matchers.json_params_matcher(expected_body),
+        ],
+    )
+
+    result = client.create_return_order_by_adobe_order(authorization_uk, customer_id, order_created)
+
+    assert result == {"orderId": "adobe-order-id"}
+
+
+def test_create_return_order_by_adobe_order_with_deployment(
+    mocker,
+    settings,
+    requests_mocker,
+    adobe_client_factory,
+    adobe_authorizations_file,
+    adobe_order_factory,
+):
+    """When the returned order's line items carry a deploymentId, skip order-level currency."""
+    mocker.patch(
+        "adobe_vipm.adobe.client.uuid4",
+        return_value="uuid-1",
+    )
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    customer_id = "a-customer"
+    client, authorization, api_token = adobe_client_factory()
+    order_created = adobe_order_factory(
+        ORDER_TYPE_NEW,
+        external_id="ORD-1234",
+        order_id="order-id",
+        status=AdobeStatus.PROCESSED.value,
+        deployment_id="1400000194",
+    )
+    expected_body = {
+        "externalReferenceId": f"{order_created['externalReferenceId']}_{order_created['orderId']}",
+        "referenceOrderId": order_created["orderId"],
+        "orderType": ORDER_TYPE_RETURN,
         "lineItems": order_created["lineItems"],
     }
     requests_mocker.post(

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -54,6 +54,7 @@ from adobe_vipm.flows.fulfillment.shared import (
     ValidateDuplicateLines,
     ValidateRenewalWindow,
     add_asset,
+    build_renewal_line_items,
     check_processing_template,
     send_gc_mpt_notification,
     set_customer_coterm_date_if_null,
@@ -2859,6 +2860,8 @@ def test_check_manual_renewal_subscriptions_upsize_line_full_renewal(
             "offer_id": "65304578CA01A12",
             "renewal_qty": 5,
             "excess_qty": 0,
+            "deployment_id": "",
+            "currency_code": "USD",
         }
     }
     assert "subscription 65304578CA (a-sub-id) requires manual renewal" in caplog.text
@@ -2881,6 +2884,8 @@ def test_check_manual_renewal_subscriptions_upsize_line_full_renewal(
                 "offer_id": "65304578CA01A12",
                 "renewal_qty": 5,
                 "excess_qty": 0,
+                "deployment_id": "",
+                "currency_code": "USD",
             }
         },
         "diverted": {},
@@ -2920,6 +2925,8 @@ def test_check_manual_renewal_subscriptions_new_line_full_renewal(
             "offer_id": "65304578CA01A12",
             "renewal_qty": 5,
             "excess_qty": 0,
+            "deployment_id": "",
+            "currency_code": "USD",
         }
     }
     mocked_next_step.assert_called_once_with(mocked_client, context)
@@ -2957,6 +2964,8 @@ def test_check_manual_renewal_subscriptions_upsize_line_with_excess(
             "offer_id": "65304578CA01A12",
             "renewal_qty": 10,
             "excess_qty": 5,
+            "deployment_id": "",
+            "currency_code": "USD",
         }
     }
     assert len(context.new_lines) == 1
@@ -2999,6 +3008,8 @@ def test_check_manual_renewal_subscriptions_new_line_with_excess(
             "offer_id": "65304578CA01A12",
             "renewal_qty": 10,
             "excess_qty": 5,
+            "deployment_id": "",
+            "currency_code": "USD",
         }
     }
     assert len(context.new_lines) == 1
@@ -3046,6 +3057,98 @@ def test_check_manual_renewal_subscriptions_mixed_lines(
     assert context.upsize_lines == [order["lines"][1]]
     assert context.new_lines == []
     mocked_next_step.assert_called_once_with(mocked_client, context)
+
+
+def test_check_manual_renewal_subscriptions_deployment_scoped(
+    mocker, mock_adobe_client, order_factory, lines_factory, adobe_subscription_factory
+):
+    """Deployment/currency data from the Adobe subscription is captured onto the renewal line."""
+    mocked_client = mocker.MagicMock()
+    mocked_next_step = mocker.MagicMock()
+    mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
+    order = order_factory(lines=lines_factory(quantity=5))
+    adobe_subscription = {
+        **adobe_subscription_factory(
+            current_quantity=10,
+            subscription_id="a-sub-id",
+            deployment_id="1400000194",
+            currency_code="USD",
+        ),
+        "allowedActions": ["MANUAL_RENEWAL"],
+    }
+    mock_adobe_client.get_subscriptions_by_deployment.return_value = {"items": [adobe_subscription]}
+    context = Context(
+        order=order,
+        order_id=order["id"],
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        upsize_lines=list(order["lines"]),
+        new_lines=[],
+    )
+
+    CheckManualRenewalSubscriptions()(mocked_client, context, mocked_next_step)  # act
+
+    assert context.manual_renewal_lines == {
+        "65304578CA": {
+            "line": order["lines"][0],
+            "adobe_subscription_id": "a-sub-id",
+            "offer_id": "65304578CA01A12",
+            "renewal_qty": 5,
+            "excess_qty": 0,
+            "deployment_id": "1400000194",
+            "currency_code": "USD",
+        }
+    }
+    mocked_next_step.assert_called_once_with(mocked_client, context)
+
+
+def test_build_renewal_line_items_without_deployment():
+    """A falsy deployment_id (no deployment) omits deploymentId/currencyCode from the line item."""
+    manual_renewal_lines = {
+        "65304578CA": {
+            "offer_id": "65304578CA01A12",
+            "renewal_qty": 5,
+            "adobe_subscription_id": "a-sub-id",
+            "deployment_id": "",
+            "currency_code": "USD",
+        }
+    }
+
+    line_items = build_renewal_line_items(manual_renewal_lines)  # act
+
+    assert line_items == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65304578CA01A12",
+            "quantity": 5,
+            "subscriptionId": "a-sub-id",
+        }
+    ]
+
+
+def test_build_renewal_line_items_with_deployment():
+    manual_renewal_lines = {
+        "65304578CA": {
+            "offer_id": "65304578CA01A12",
+            "renewal_qty": 5,
+            "adobe_subscription_id": "a-sub-id",
+            "deployment_id": "1400000194",
+            "currency_code": "USD",
+        }
+    }
+
+    line_items = build_renewal_line_items(manual_renewal_lines)  # act
+
+    assert line_items == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65304578CA01A12",
+            "quantity": 5,
+            "subscriptionId": "a-sub-id",
+            "deploymentId": "1400000194",
+            "currencyCode": "USD",
+        }
+    ]
 
 
 def test_check_manual_renewal_subscriptions_restore_from_stored(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Problem

Manual renewal orders for Adobe subscriptions tied to a deployment failed with:

```
Manual renewal preview failed for subscription ORD-6558-7620-0831_RENEWAL: Currency code not aligned.
```

Adobe's Order API requires that when a `lineItem` carries a `deploymentId`, `currencyCode` must
live on that line item **only** — never at the order level:

- order-level-only currency → Adobe error `2137` ("Currency code not aligned")
- currency at both levels → Adobe error `2140` ("Order contains order level currency and line
  item level currency")
- currency on the line item only → succeeds

`create_new_order` and `create_preview_order` already implement this rule correctly. `create_renewal_order`
— used for both `PREVIEW_RENEWAL` and `RENEWAL` order types in the manual-renewal flow — did not:
it unconditionally set `currencyCode` at the order level and never looked at `deploymentId`.
`build_renewal_line_items` also dropped the deployment/currency data already available on the
Adobe subscription object before it ever reached the order payload. The same bug class also
affected `create_return_order_by_adobe_order`, used during rollback of quantity-increase change
orders.

## Fix

- `create_renewal_order` and `create_return_order_by_adobe_order`
  (`adobe_vipm/adobe/mixins/order.py`) now only set order-level `currencyCode` when no line item
  carries a `deploymentId`, matching the existing pattern in `create_new_order`/`create_preview_order`/`create_return_order`.
- `CheckManualRenewalSubscriptions._process_renewal_line` (`adobe_vipm/flows/fulfillment/shared.py`)
  now captures `deploymentId`/`currencyCode` from the Adobe subscription onto
  `manual_renewal_lines`.
- `build_renewal_line_items` now emits `deploymentId`/`currencyCode` on the line item when
  present, mirroring `_build_line_item`.

## Testing

- `make check-all` clean: `ruff format --check`, `ruff check`, `flake8`, `uv lock --check`, and
  the full test suite — **884 passed**.
- New tests: `create_renewal_order` and `create_return_order_by_adobe_order` deployment-scoped
  cases, `build_renewal_line_items` with/without deployment, and a
  `CheckManualRenewalSubscriptions` case asserting deployment/currency capture.

Jira: MPT-22920


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed Adobe manual renewal and return order payloads so order-level `currencyCode` is only sent when no line item is deployment-scoped.
- Preserved `deploymentId` and `currencyCode` from Adobe subscriptions during manual renewal processing.
- Updated renewal line-item निर्माण to include `deploymentId` and `currencyCode` when available.
- Expanded test coverage for deployment-scoped renewal/return orders, renewal line-item building, and manual renewal subscription processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->