### PR TITLE
[HF] MPT-22921 Use deployment's own address for deployment-scoped agreements

### DIFF
--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -22,6 +22,7 @@ from mpt_extension_sdk.mpt_http.mpt import (
     get_product_template_or_default,
     update_agreement,
 )
+from mpt_extension_sdk.mpt_http.utils import find_first
 
 from adobe_vipm.adobe.client import get_adobe_client
 from adobe_vipm.adobe.constants import AdobeStatus
@@ -319,6 +320,7 @@ def create_gc_agreement_deployment(
     mpt_o_client,
     agreement_deployment,
     adobe_customer,
+    customer_deployments,
     customer_deployment_ids,
     main_agreement,
     listing,
@@ -331,6 +333,7 @@ def create_gc_agreement_deployment(
         mpt_o_client (MPTClient): The MPT Operations client instance.
         agreement_deployment (AgreementDeployment): The agreement deployment instance.
         adobe_customer (dict): The Adobe customer data.
+        customer_deployments (list): List of the customer's Adobe deployments.
         customer_deployment_ids (list): List of customer deployment IDs.
         main_agreement (dict): Main Agreement representation from MPT API
         listing (dict): The listing data.
@@ -348,7 +351,12 @@ def create_gc_agreement_deployment(
         return agreement_deployment.agreement_id
 
     try:
-        address = adobe_customer["companyProfile"].get("address", {})
+        deployment = find_first(
+            lambda item: item.get("deploymentId") == agreement_deployment.deployment_id,
+            customer_deployments,
+        )
+        deployment_address = deployment["companyProfile"].get("address", {}) if deployment else {}
+        address = deployment_address or adobe_customer["companyProfile"].get("address", {})
         contact = adobe_customer["companyProfile"]["contacts"][0]
         param_address = get_address(address)
 
@@ -655,6 +663,7 @@ def process_agreement_deployment(  # noqa: C901
             mpt_o_client,
             agreement_deployment,
             adobe_customer,
+            customer_deployments,
             customer_deployment_ids,
             main_agreement,
             listing,

--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -914,7 +914,40 @@ class AgreementSyncer:  # noqa: WPS214
 
             self._update_agreement_bussiness_parameters(deployment_agreement)
 
+            self._update_deployment_agreement_address(deployment_agreement, adobe_deployments)
+
             self._sync_gc_3yc_agreements(deployment_agreement)
+
+    def _update_deployment_agreement_address(
+        self, deployment_agreement: dict, adobe_deployments: list[dict]
+    ) -> None:
+        """
+        Refresh a deployment agreement's address ordering parameter from Adobe.
+
+        Args:
+            deployment_agreement: MPT deployment agreement.
+            adobe_deployments: Adobe customer deployments.
+        """
+        deployment_id = flows_utils.get_deployment_id(deployment_agreement)
+        deployment = find_first(
+            lambda item: item.get("deploymentId") == deployment_id, adobe_deployments
+        )
+        if not deployment:
+            return
+
+        deployment_address = deployment["companyProfile"].get("address", {})
+        if not deployment_address:
+            return
+
+        parameters = {
+            Param.PHASE_ORDERING.value: [
+                {
+                    "externalId": Param.ADDRESS.value,
+                    "value": flows_utils.get_address(deployment_address),
+                }
+            ]
+        }
+        self._execute_agreement_update(deployment_agreement, parameters)
 
     def _sync_gc_3yc_agreements(self, deployment_agreement: dict) -> None:
         """

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -1550,6 +1550,104 @@ def test_sync_deployment_agreement(
     ]
 
 
+def test_update_deployment_agreement_address(
+    mock_mpt_update_agreement,
+    agreement_factory,
+    fulfillment_parameters_factory,
+    mocked_agreement_syncer,
+):
+    deployment_agreement = agreement_factory(
+        agreement_id="AGR-deployment-1",
+        fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
+    )
+    adobe_deployments = [
+        {
+            "deploymentId": "deployment-1",
+            "status": "1000",
+            "companyProfile": {
+                "address": {
+                    "country": "DE",
+                    "region": "SN",
+                    "city": "Berlin",
+                    "addressLine1": "Marienallee 12",
+                    "postalCode": "01067",
+                }
+            },
+        }
+    ]
+
+    mocked_agreement_syncer._update_deployment_agreement_address(  # act
+        deployment_agreement, adobe_deployments
+    )
+
+    mock_mpt_update_agreement.assert_called_once_with(
+        mocked_agreement_syncer._mpt_client,
+        deployment_agreement["id"],
+        lines=deployment_agreement["lines"],
+        parameters={
+            "ordering": [
+                {
+                    "externalId": "address",
+                    "value": {
+                        "country": "DE",
+                        "state": "SN",
+                        "city": "Berlin",
+                        "addressLine1": "Marienallee 12",
+                        "addressLine2": "",
+                        "postCode": "01067",
+                    },
+                }
+            ]
+        },
+    )
+
+
+def test_update_deployment_agreement_address_no_matching_deployment(
+    mock_mpt_update_agreement,
+    agreement_factory,
+    fulfillment_parameters_factory,
+    mocked_agreement_syncer,
+):
+    deployment_agreement = agreement_factory(
+        agreement_id="AGR-deployment-1",
+        fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
+    )
+    adobe_deployments = [
+        {
+            "deploymentId": "deployment-2",
+            "status": "1000",
+            "companyProfile": {"address": {"country": "DE"}},
+        }
+    ]
+
+    mocked_agreement_syncer._update_deployment_agreement_address(  # act
+        deployment_agreement, adobe_deployments
+    )
+
+    mock_mpt_update_agreement.assert_not_called()
+
+
+def test_update_deployment_agreement_address_no_address_data(
+    mock_mpt_update_agreement,
+    agreement_factory,
+    fulfillment_parameters_factory,
+    mocked_agreement_syncer,
+):
+    deployment_agreement = agreement_factory(
+        agreement_id="AGR-deployment-1",
+        fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
+    )
+    adobe_deployments = [
+        {"deploymentId": "deployment-1", "status": "1000", "companyProfile": {}},
+    ]
+
+    mocked_agreement_syncer._update_deployment_agreement_address(  # act
+        deployment_agreement, adobe_deployments
+    )
+
+    mock_mpt_update_agreement.assert_not_called()
+
+
 @freeze_time("2025-06-19")
 def test_sync_global_customer_parameter_dry_run(
     mocker,

--- a/tests/flows/test_global_customer.py
+++ b/tests/flows/test_global_customer.py
@@ -371,6 +371,70 @@ def test_check_gc_agreement_deployments_create_listing(
     mocked_update_agreement.assert_called_once()
 
 
+def test_check_gc_agreement_deployments_create_listing_uses_deployment_own_address(
+    mocker,
+    mock_adobe_client,
+    adobe_customer_factory,
+    adobe_deployment_factory,
+    adobe_subscription_factory,
+    agreement_factory,
+    created_agreement_factory,
+    provisioning_agreement,
+    gc_agreement_deployment,
+    listing,
+    licensee,
+    template,
+):
+    """The deployment's own address must be used, not the main customer's address."""
+    agreement = agreement_factory()
+    deployment = adobe_deployment_factory(deployment_id="deployment_id", country="DE")
+    expected_created_agreement_arg = created_agreement_factory(
+        deployments="deployment_id - DE", is_profile_address_exists=True
+    )
+    for param in expected_created_agreement_arg["parameters"]["ordering"]:
+        if param["externalId"] == "address":
+            param["value"] = {
+                "country": "DE",
+                "state": "SN",
+                "city": "Berlin",
+                "addressLine1": "Marienallee 12",
+                "addressLine2": "",
+                "postCode": "01067",
+            }
+    mocked_gc_agreement_deployments_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.flows.global_customer.get_listings_by_price_list_and_seller_and_authorization",
+        return_value=[],
+    )
+    mocker.patch("adobe_vipm.flows.global_customer.create_listing", return_value=listing)
+    mocker.patch("adobe_vipm.flows.global_customer.get_licensee", return_value=licensee)
+    mocker.patch(
+        "adobe_vipm.flows.global_customer.get_product_template_or_default", return_value=template
+    )
+    mocked_create_agreement = mocker.patch(
+        "adobe_vipm.flows.global_customer.create_agreement", return_value=agreement
+    )
+    mocker.patch("adobe_vipm.flows.global_customer.update_agreement", return_value=agreement)
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_gc_agreement_deployment_model",
+        return_value=mocked_gc_agreement_deployments_model,
+    )
+    adobe_customer = adobe_customer_factory(company_profile_address_exists=True, country="US")
+    mock_adobe_client.get_customer.return_value = adobe_customer
+    mock_adobe_client.get_customer_deployments_active_status.return_value = [deployment]
+    mock_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription_factory()]}
+    gc_agreement_deployment.listing_id = None
+    gc_agreement_deployment.agreement_id = None
+    mocked_gc_agreement_deployments_model.all.return_value = [gc_agreement_deployment]
+    mocker.patch(
+        "adobe_vipm.flows.global_customer.get_agreement", return_value=provisioning_agreement
+    )
+
+    check_gc_agreement_deployments()  # act
+
+    assert mocked_create_agreement.call_args_list[0].args[1] == expected_created_agreement_arg
+
+
 def test_check_gc_agreement_deployments_create_listing_with_no_address(
     mocker,
     mock_adobe_client,


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Hotfix backport of #889 to `release/5`.

Deployment-scoped Agreements (one per Adobe `deploymentId`) were storing the main Adobe customer's address in the `address` ordering parameter instead of that specific deployment's own location address, even though Adobe's `/v3/customers/{id}/deployments` response already returns each deployment's own `companyProfile.address`.

- `create_gc_agreement_deployment` (`adobe_vipm/flows/global_customer.py`) now matches the deployment being created against the customer's Adobe deployments (by `deploymentId`) and uses that deployment's own address, falling back to the main customer's address when no match or address data is found.
- `AgreementSyncer._sync_deployment_agreements` (`adobe_vipm/flows/sync/agreement.py`) now also refreshes the address ordering parameter on already-created deployment agreements during periodic sync, so pre-existing agreements converge on the correct address over time.

Source PR: #889
Jira: MPT-22921

## Testing

- Cherry-picked cleanly from `main` (no conflicts).
- `make check-all` passes on `release/5`: ruff format/check, flake8, `uv lock --check`, and the full test suite (883 passed, 99% coverage).
