### PR TITLE
MPT-23009 Keep updating subscriptions when a price can't be resolved

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -560,47 +560,19 @@ def _get_prices_3yc_for_skus_from_airtable(
     )
 
 
-def get_prices_for_3yc_skus(  # noqa: C901
-    product_id: str, currency: str, start_date: dt.date, skus: list[str]
-) -> dict:
-    """
-    Given a currency and a list of SKUs and the 3YC start date it retrieves the purchase price.
-
-    For each SKU in the given currency from the pricelist that was valid
-    when the 3YC started.
-    Such prices are cached since they will not change ever to reduce the amount of API calls
-    to the AirTable API.
-
-    Args:
-        product_id: The ID of the product used to determine the AirTable base.
-        currency: The currency for which the price must be retrieved.
-        start_date: The date in which the 3YC started.
-        skus: List of SKUs which purchase prices must be retrieved.
-
-    Returns:
-        dict: A dictionary with SKU, purchase price items.
-    """
-    prices = {}
-    for sku in skus:
-        pricelist_item = find_first(
-            lambda item: (
-                item["currency"] == currency
-                and item["valid_from"] <= start_date
-                and item["valid_until"] > start_date
-            ),
-            PRICELIST_CACHE[sku],
-        )
-        if pricelist_item:
-            prices[sku] = pricelist_item["unit_pp"]
-
-    skus_to_lookup = sorted(set(skus) - set(prices.keys()))
-    if not skus_to_lookup:
-        return prices
-
-    items = _get_prices_3yc_for_skus_from_airtable(
-        product_id, currency, start_date, skus_to_lookup, "sku"
+def _find_cached_3yc_price(sku: str, currency: str, start_date: dt.date) -> float | None:
+    pricelist_item = find_first(
+        lambda item: (
+            item["currency"] == currency
+            and item["valid_from"] <= start_date
+            and item["valid_until"] > start_date
+        ),
+        PRICELIST_CACHE[sku],
     )
+    return pricelist_item["unit_pp"] if pricelist_item else None
 
+
+def _collect_3yc_prices_from_items(items, prices: dict) -> None:
     for item in items:
         if item.valid_until:
             PRICELIST_CACHE[item.sku].append(
@@ -613,6 +585,56 @@ def get_prices_for_3yc_skus(  # noqa: C901
             )
         if item.sku not in prices:
             prices[item.sku] = item.unit_pp
+
+
+def get_prices_for_3yc_skus(
+    product_id: str, currency: str, start_date: dt.date, skus: list[str]
+) -> dict:
+    """
+    Given a currency and a list of SKUs and the 3YC start date it retrieves the purchase price.
+
+    For each SKU in the given currency from the pricelist that was valid
+    when the 3YC started. SKUs with no pricelist row covering the start date
+    (e.g. a gap between historical windows) fall back to their most recent price.
+    Prices valid at the start date are cached since they will not change ever, to
+    reduce the amount of API calls to the AirTable API.
+
+    Args:
+        product_id: The ID of the product used to determine the AirTable base.
+        currency: The currency for which the price must be retrieved.
+        start_date: The date in which the 3YC started.
+        skus: List of SKUs which purchase prices must be retrieved.
+
+    Returns:
+        dict: A dictionary with SKU, purchase price items.
+    """
+    prices = {}
+    for sku in skus:
+        cached_price = _find_cached_3yc_price(sku, currency, start_date)
+        if cached_price is not None:
+            prices[sku] = cached_price
+
+    skus_to_lookup = sorted(set(skus) - set(prices.keys()))
+    if not skus_to_lookup:
+        return prices
+
+    items = _get_prices_3yc_for_skus_from_airtable(
+        product_id, currency, start_date, skus_to_lookup, "sku"
+    )
+    _collect_3yc_prices_from_items(items, prices)
+
+    still_missing = sorted(set(skus_to_lookup) - set(prices.keys()))
+    if not still_missing:
+        return prices
+
+    # No row covers the 3YC start date for these SKUs (e.g. a gap between historical
+    # windows). Fall back to the most recent price rather than leaving them unpriced.
+    # Not cached: unlike a start-date match, this price isn't guaranteed to stay correct.
+    historical_items = _get_historical_prices_for_skus_from_airtable(
+        product_id, currency, still_missing, "sku"
+    )
+    for item in historical_items:
+        prices.setdefault(item.sku, item.unit_pp)
     return prices
 
 

--- a/adobe_vipm/flows/sync/subscription.py
+++ b/adobe_vipm/flows/sync/subscription.py
@@ -78,11 +78,11 @@ class SubscriptionSyncer:
             for subscription, adobe_subscription, actual_sku in self._subscriptions_for_update:
                 if actual_sku not in prices:
                     logger.error(
-                        "Skipping subscription %s because the sku %s is not in the prices",
+                        "No price found for subscription %s sku %s; "
+                        "updating other properties without changing the price.",
                         subscription["id"],
                         actual_sku,
                     )
-                    continue
 
                 self._update_subscription(
                     actual_sku,
@@ -138,10 +138,14 @@ class SubscriptionSyncer:
                 "quantity": adobe_subscription["autoRenewal"][Param.RENEWAL_QUANTITY.value],
             }
         ]
-        if sync_prices:
+        if sync_prices and actual_sku in prices:
             lines[0]["price"] = {"unitPP": prices[actual_sku]}
         else:
-            logger.info("Skipping price sync - sync_prices %s.", sync_prices)
+            logger.info(
+                "Skipping price sync - sync_prices %s, price available %s.",
+                sync_prices,
+                actual_sku in prices,
+            )
 
         template_data = get_template_data_by_adobe_subscription(
             adobe_subscription, self._product_id

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -538,6 +538,72 @@ def test_get_prices_for_3yc_skus(mocker, settings, mocked_pricelist_cache):
     }
 
 
+def test_get_prices_for_3yc_skus_falls_back_to_most_recent_when_no_window_match(
+    mocker, settings, mocked_pricelist_cache
+):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_PRICING_BASES": {"product_id": "base_id"},
+    }
+    mocked_pricelist_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_pricelist_model",
+        return_value=mocked_pricelist_model,
+    )
+    newest_historical = mocker.MagicMock()
+    newest_historical.sku = "sku-1"
+    newest_historical.unit_pp = 8.00
+    older_historical = mocker.MagicMock()
+    older_historical.sku = "sku-1"
+    older_historical.unit_pp = 5.00
+    # first call: no row covers the start date; second call: fallback historical lookup,
+    # sorted by -valid_until, so the newest row comes first
+    mocked_pricelist_model.all.side_effect = [[], [newest_historical, older_historical]]
+
+    result = get_prices_for_3yc_skus(
+        "product_id",
+        "currency",
+        dt.date.fromisoformat("2024-03-03"),
+        ["sku-1"],
+    )
+
+    assert result == {"sku-1": 8.00}
+    assert mocked_pricelist_model.all.call_count == 2
+    assert mocked_pricelist_model.all.call_args_list[1] == mocker.call(
+        formula=AND(
+            EQ(Field("currency"), "currency"),
+            NE(Field("valid_until"), BLANK()),
+            OR(EQ(Field("sku"), "sku-1")),
+        ),
+        sort=["-valid_until"],
+    )
+    # fallback prices aren't guaranteed correct at future lookups, so they're not cached
+    assert mocked_pricelist_cache == {"sku-1": []}
+
+
+def test_get_prices_for_3yc_skus_missing_everywhere(mocker, settings, mocked_pricelist_cache):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_PRICING_BASES": {"product_id": "base_id"},
+    }
+    mocked_pricelist_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_pricelist_model",
+        return_value=mocked_pricelist_model,
+    )
+    mocked_pricelist_model.all.side_effect = [[], []]
+
+    result = get_prices_for_3yc_skus(
+        "product_id",
+        "currency",
+        dt.date.fromisoformat("2024-03-03"),
+        ["sku-1"],
+    )
+
+    assert result == {}
+    assert mocked_pricelist_model.all.call_count == 2
+
+
 def test_get_prices_for_3yc_skus_hit_cache(mocker, settings, mock_pricelist_cache_factory):
     cache = defaultdict(list)
     cache["sku-1"].append({

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -2205,7 +2205,7 @@ def test_sync_agreement_prices_with_missing_prices(
     with caplog.at_level(logging.ERROR):
         mocked_agreement_syncer.sync(sync_prices=True)  # act
 
-    assert "Skipping subscription" in caplog.text
+    assert "No price found for subscription" in caplog.text
     assert "65304578CA01A12" in caplog.text
     mock_notify_missing_prices.assert_called_once_with(
         "AGR-2119-4550-8674-5962", ["65304578CA01A12"], "PRD-1111-1111", "USD", None
@@ -2286,6 +2286,23 @@ def test_sync_agreement_prices_with_missing_prices(
             mock_mpt_client,
             terminated_mpt_subscription["id"],
             template={"id": "TPL-2345", "name": "Expired"},
+        ),
+        mocker.call(
+            mock_mpt_client,
+            mpt_subscription["id"],
+            lines=[{"id": "ALI-2119-4550-8674-5962-0001", "quantity": 10}],
+            parameters={
+                "fulfillment": [
+                    {"externalId": Param.ADOBE_SKU.value, "value": "65304578CA01A12"},
+                    {"externalId": Param.CURRENT_QUANTITY.value, "value": "10"},
+                    {"externalId": Param.RENEWAL_QUANTITY.value, "value": "10"},
+                    {"externalId": Param.RENEWAL_DATE.value, "value": "2026-10-11"},
+                    {"externalId": Param.LAST_SYNC_DATE.value, "value": "2025-06-19"},
+                ]
+            },
+            commitmentDate="2026-10-11",
+            autoRenew=True,
+            template={"id": "TPL-1234", "name": "Renewing"},
         ),
         mocker.call(
             mock_mpt_client,


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Newly-started 3YC (three-year-commitment) customers were failing to sync pricing correctly.

- `get_prices_for_3yc_skus` (`adobe_vipm/airtable/models.py`) only matched a pricelist row whose `valid_from`/`valid_until` window covered the commitment start date. If a SKU had gone end-of-sale and there was a gap between its last historical window and the 3YC start date, no price was returned for that SKU at all. It now falls back to the SKU's most recent price when no window match exists, mirroring the existing end-of-sale fallback already implemented in `get_prices_for_skus`.
- `SubscriptionSyncer.sync` (`adobe_vipm/flows/sync/subscription.py`) skipped the *entire* subscription update — fulfillment params (current/renewal quantity, renewal date, last sync date), the line quantity, auto-renewal status, and the template — whenever a price couldn't be resolved for a SKU, not just the price. It now still performs all of those updates and only omits the price line, while keeping the existing missing-price Teams notification.

Jira: MPT-23009

## Testing

- Added `test_get_prices_for_3yc_skus_falls_back_to_most_recent_when_no_window_match` and `test_get_prices_for_3yc_skus_missing_everywhere` in `tests/airtable/test_models.py`.
- Updated `test_sync_agreement_prices_with_missing_prices` in `tests/flows/sync/test_agreement.py` to assert the previously-skipped subscription is now updated (quantity, fulfillment params, renewal date, auto-renew, template) without a price.
- `make check-all` passes: ruff format/check, flake8, `uv lock --check`, and the full test suite (890 passed, 99% coverage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23009](https://softwareone.atlassian.net/browse/MPT-23009)

- Updated 3YC price lookup to fall back to the SKU’s most recent historical price when no pricelist entry matches the commitment start-date window, including end-of-sale SKUs with gaps in pricing history.
- Changed subscription sync to keep updating fulfillment parameters, quantity, auto-renewal, and template even when a SKU price cannot be resolved, while omitting only the price line and preserving the missing-price Teams notification.
- Added and updated tests to cover the new 3YC fallback behavior and verify subscriptions still sync correctly when pricing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23009]: https://softwareone.atlassian.net/browse/MPT-23009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ