### PR TITLE
MPT-23110 Agreement sync does not keep companyName, address, and contact parameters up to date with Adobe

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -14,7 +14,11 @@ from mpt_extension_sdk.mpt_http.utils import find_first
 from adobe_vipm.adobe.client import AdobeClient
 from adobe_vipm.adobe.constants import THREE_YC_TEMP_3YC_STATUSES, AdobeStatus, OfferType
 from adobe_vipm.adobe.errors import AdobeAPIError, AuthorizationNotFoundError
-from adobe_vipm.adobe.utils import get_3yc_commitment_request
+from adobe_vipm.adobe.utils import (
+    get_3yc_commitment_request,
+    sanitize_company_name,
+    sanitize_first_last_name,
+)
 from adobe_vipm.airtable import models
 from adobe_vipm.flows import utils as flows_utils
 from adobe_vipm.flows.benefits import send_3yc_expiration_notification
@@ -134,6 +138,10 @@ class AgreementSyncer:  # noqa: WPS214
             self._update_agreement_line_prices(self._agreement, self._currency, self.product_id)
 
             self._update_agreement_bussiness_parameters(self._agreement)
+
+            self._update_agreement_profile_parameters(
+                self._agreement, self._adobe_customer.get("companyProfile", {}).get("address", {})
+            )
 
             if self._adobe_customer.get("globalSalesEnabled", False):
                 adobe_deployments = self._adobe_client.get_customer_deployments_active_status(
@@ -485,6 +493,60 @@ class AgreementSyncer:  # noqa: WPS214
 
         self._execute_agreement_update(agreement, parameters)
         logger.info("Agreement updated %s", agreement["id"])
+
+    def _update_agreement_profile_parameters(self, agreement: dict, address_source: dict) -> None:
+        company_profile = self._adobe_customer.get("companyProfile", {})
+        parameters = {Param.PHASE_ORDERING.value: []}
+
+        parameters[Param.PHASE_ORDERING.value].append({
+            "externalId": Param.COMPANY_NAME.value,
+            "value": sanitize_company_name(company_profile.get("companyName", "")),
+        })
+
+        if address_source:
+            parameters[Param.PHASE_ORDERING.value].append({
+                "externalId": Param.ADDRESS.value,
+                "value": flows_utils.get_address(address_source),
+            })
+
+        contact_value = self._resolve_contact_parameter(agreement, company_profile)
+        if contact_value is not None:
+            parameters[Param.PHASE_ORDERING.value].append({
+                "externalId": Param.CONTACT.value,
+                "value": contact_value,
+            })
+
+        self._execute_agreement_update(agreement, parameters)
+
+    def _resolve_contact_parameter(self, agreement: dict, company_profile: dict) -> dict | None:
+        contacts = company_profile.get("contacts", [])
+        if not contacts:
+            return None
+
+        country = company_profile.get("address", {}).get("country", "")
+        current_contact = (
+            flows_utils.get_ordering_parameter(agreement, Param.CONTACT.value).get("value") or {}
+        )
+        current_email = current_contact.get("email")
+
+        matched = (
+            find_first(lambda contact: contact.get("email") == current_email, contacts)
+            if current_email
+            else None
+        )
+
+        if not matched:
+            return flows_utils.get_contact(contacts[0], country)
+
+        new_first = sanitize_first_last_name(matched.get("firstName", ""))
+        new_last = sanitize_first_last_name(matched.get("lastName", ""))
+        if (
+            current_contact.get("firstName") == new_first
+            and current_contact.get("lastName") == new_last
+        ):
+            return None
+
+        return {**current_contact, "firstName": new_first, "lastName": new_last}
 
     def _execute_agreement_update(self, agreement: dict, parameters: dict) -> None:
         if self._dry_run:
@@ -902,40 +964,14 @@ class AgreementSyncer:  # noqa: WPS214
 
             self._update_agreement_bussiness_parameters(deployment_agreement)
 
-            self._update_deployment_agreement_address(deployment_agreement, adobe_deployments)
+            deployment_id = flows_utils.get_deployment_id(deployment_agreement)
+            deployment = find_first(
+                partial(_check_adobe_deployment_id, deployment_id), adobe_deployments
+            )
+            address_source = deployment["companyProfile"].get("address", {}) if deployment else {}
+            self._update_agreement_profile_parameters(deployment_agreement, address_source)
 
             self._sync_gc_3yc_agreements(deployment_agreement)
-
-    def _update_deployment_agreement_address(
-        self, deployment_agreement: dict, adobe_deployments: list[dict]
-    ) -> None:
-        """
-        Refresh a deployment agreement's address ordering parameter from Adobe.
-
-        Args:
-            deployment_agreement: MPT deployment agreement.
-            adobe_deployments: Adobe customer deployments.
-        """
-        deployment_id = flows_utils.get_deployment_id(deployment_agreement)
-        deployment = find_first(
-            lambda item: item.get("deploymentId") == deployment_id, adobe_deployments
-        )
-        if not deployment:
-            return
-
-        deployment_address = deployment["companyProfile"].get("address", {})
-        if not deployment_address:
-            return
-
-        parameters = {
-            Param.PHASE_ORDERING.value: [
-                {
-                    "externalId": Param.ADDRESS.value,
-                    "value": flows_utils.get_address(deployment_address),
-                }
-            ]
-        }
-        self._execute_agreement_update(deployment_agreement, parameters)
 
     def _sync_gc_3yc_agreements(self, deployment_agreement: dict) -> None:
         """

--- a/adobe_vipm/flows/utils/__init__.py
+++ b/adobe_vipm/flows/utils/__init__.py
@@ -26,6 +26,7 @@ from .deployment import (
 )
 from .formatting import (
     get_address,
+    get_contact,
     md2html,
     split_phone_number,
     strip_trace_id,

--- a/adobe_vipm/flows/utils/formatting.py
+++ b/adobe_vipm/flows/utils/formatting.py
@@ -3,6 +3,8 @@ import re
 import phonenumbers
 from markdown_it import MarkdownIt
 
+from adobe_vipm.adobe.utils import sanitize_first_last_name
+
 TRACE_ID_REGEX = re.compile(r"(\(00-[0-9a-f]{32}-[0-9a-f]{16}-01\))")
 
 
@@ -65,4 +67,23 @@ def get_address(address: dict) -> dict:
         "addressLine1": address.get("addressLine1", ""),
         "addressLine2": address.get("addressLine2", ""),
         "postCode": address.get("postalCode", ""),
+    }
+
+
+def get_contact(contact: dict, country: str) -> dict:
+    """
+    Set the contact fields in the contact object.
+
+    Args:
+        contact: The Adobe contact to map.
+        country: Country code used to parse the contact's phone number.
+
+    Returns:
+        Mapped dictionary of the Adobe contact following MPT Contact type parameter format.
+    """
+    return {
+        "firstName": sanitize_first_last_name(contact.get("firstName", "")),
+        "lastName": sanitize_first_last_name(contact.get("lastName", "")),
+        "email": contact.get("email", ""),
+        "phone": split_phone_number(contact.get("phoneNumber"), country),
     }

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -279,6 +279,36 @@ def test_sync_agreement_prices(
         mocker.call(
             mock_mpt_client,
             agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
             parameters={"fulfillment": [{"externalId": "lastSyncDate", "value": "2025-06-23"}]},
         ),
     ])
@@ -342,6 +372,36 @@ def test_sync_agreement_update_agreement_education(
                 ],
             },
             lines=[],
+        ),
+        mock.call(
+            mock_mpt_client,
+            mocked_agreement_syncer._agreement["id"],
+            lines=[],
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
         ),
         mock.call(
             mock_mpt_client,
@@ -845,6 +905,36 @@ def test_sync_agreement_prices_with_3yc(
         mocker.call(
             mock_mpt_client,
             agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
             parameters={"fulfillment": [{"externalId": "lastSyncDate", "value": "2024-11-09"}]},
         ),
     ]
@@ -966,6 +1056,36 @@ def test_sync_agreement_prices_large_government_agency(
             parameters={
                 "fulfillment": [
                     {"externalId": "cotermDate", "value": "2025-04-04"},
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
                 ],
             },
         ),
@@ -1223,6 +1343,36 @@ def test_sync_global_customer_parameter(
         mocker.call(
             mock_mpt_client,
             agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
             parameters={
                 "fulfillment": [
                     {"externalId": "globalCustomer", "value": ["Yes"]},
@@ -1243,6 +1393,25 @@ def test_sync_global_customer_parameter(
                     {"externalId": "3YCLicenses", "value": ""},
                     {"externalId": "3YCConsumables", "value": ""},
                     {"externalId": "cotermDate", "value": "2025-04-04"},
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            deployment_agreements[0]["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
                 ],
             },
         ),
@@ -1535,7 +1704,7 @@ def test_sync_deployment_agreement(
     ]
 
 
-def test_update_deployment_agreement_address(
+def test_update_agreement_profile_parameters_with_address(
     mock_mpt_update_agreement,
     agreement_factory,
     fulfillment_parameters_factory,
@@ -1545,24 +1714,16 @@ def test_update_deployment_agreement_address(
         agreement_id="AGR-deployment-1",
         fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
     )
-    adobe_deployments = [
-        {
-            "deploymentId": "deployment-1",
-            "status": "1000",
-            "companyProfile": {
-                "address": {
-                    "country": "DE",
-                    "region": "SN",
-                    "city": "Berlin",
-                    "addressLine1": "Marienallee 12",
-                    "postalCode": "01067",
-                }
-            },
-        }
-    ]
+    address_source = {
+        "country": "DE",
+        "region": "SN",
+        "city": "Berlin",
+        "addressLine1": "Marienallee 12",
+        "postalCode": "01067",
+    }
 
-    mocked_agreement_syncer._update_deployment_agreement_address(  # act
-        deployment_agreement, adobe_deployments
+    mocked_agreement_syncer._update_agreement_profile_parameters(  # act
+        deployment_agreement, address_source
     )
 
     mock_mpt_update_agreement.assert_called_once_with(
@@ -1571,6 +1732,7 @@ def test_update_deployment_agreement_address(
         lines=deployment_agreement["lines"],
         parameters={
             "ordering": [
+                {"externalId": "companyName", "value": "Migrated Company"},
                 {
                     "externalId": "address",
                     "value": {
@@ -1581,13 +1743,22 @@ def test_update_deployment_agreement_address(
                         "addressLine2": "",
                         "postCode": "01067",
                     },
-                }
+                },
+                {
+                    "externalId": "contact",
+                    "value": {
+                        "firstName": "firstName",
+                        "lastName": "lastName",
+                        "email": "email",
+                        "phone": {"prefix": "+1", "number": "8004449890"},
+                    },
+                },
             ]
         },
     )
 
 
-def test_update_deployment_agreement_address_no_matching_deployment(
+def test_update_agreement_profile_parameters_no_address_source(
     mock_mpt_update_agreement,
     agreement_factory,
     fulfillment_parameters_factory,
@@ -1597,40 +1768,102 @@ def test_update_deployment_agreement_address_no_matching_deployment(
         agreement_id="AGR-deployment-1",
         fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
     )
-    adobe_deployments = [
-        {
-            "deploymentId": "deployment-2",
-            "status": "1000",
-            "companyProfile": {"address": {"country": "DE"}},
-        }
-    ]
 
-    mocked_agreement_syncer._update_deployment_agreement_address(  # act
-        deployment_agreement, adobe_deployments
+    mocked_agreement_syncer._update_agreement_profile_parameters(  # act
+        deployment_agreement, {}
     )
 
-    mock_mpt_update_agreement.assert_not_called()
+    mock_mpt_update_agreement.assert_called_once_with(
+        mocked_agreement_syncer._mpt_client,
+        deployment_agreement["id"],
+        lines=deployment_agreement["lines"],
+        parameters={
+            "ordering": [
+                {"externalId": "companyName", "value": "Migrated Company"},
+                {
+                    "externalId": "contact",
+                    "value": {
+                        "firstName": "firstName",
+                        "lastName": "lastName",
+                        "email": "email",
+                        "phone": {"prefix": "+1", "number": "8004449890"},
+                    },
+                },
+            ]
+        },
+    )
 
 
-def test_update_deployment_agreement_address_no_address_data(
-    mock_mpt_update_agreement,
-    agreement_factory,
-    fulfillment_parameters_factory,
-    mocked_agreement_syncer,
+def test_resolve_contact_parameter_no_match_overwrites_with_first_contact(
+    agreement_factory, mocked_agreement_syncer
 ):
-    deployment_agreement = agreement_factory(
-        agreement_id="AGR-deployment-1",
-        fulfillment_parameters=fulfillment_parameters_factory(deployment_id="deployment-1"),
-    )
-    adobe_deployments = [
-        {"deploymentId": "deployment-1", "status": "1000", "companyProfile": {}},
-    ]
+    agreement = agreement_factory()
+    company_profile = mocked_agreement_syncer._adobe_customer["companyProfile"]
 
-    mocked_agreement_syncer._update_deployment_agreement_address(  # act
-        deployment_agreement, adobe_deployments
-    )
+    result = mocked_agreement_syncer._resolve_contact_parameter(agreement, company_profile)  # act
 
-    mock_mpt_update_agreement.assert_not_called()
+    assert result == {
+        "firstName": "firstName",
+        "lastName": "lastName",
+        "email": "email",
+        "phone": {"prefix": "+1", "number": "8004449890"},
+    }
+
+
+def test_resolve_contact_parameter_match_updates_differing_names(
+    agreement_factory, order_parameters_factory, mocked_agreement_syncer
+):
+    agreement = agreement_factory(
+        ordering_parameters=order_parameters_factory(
+            contact={
+                "firstName": "Old",
+                "lastName": "Name",
+                "email": "email",
+                "phone": {"prefix": "+1", "number": "5551234567"},
+            }
+        )
+    )
+    company_profile = mocked_agreement_syncer._adobe_customer["companyProfile"]
+
+    result = mocked_agreement_syncer._resolve_contact_parameter(agreement, company_profile)  # act
+
+    assert result == {
+        "firstName": "firstName",
+        "lastName": "lastName",
+        "email": "email",
+        "phone": {"prefix": "+1", "number": "5551234567"},
+    }
+
+
+def test_resolve_contact_parameter_match_no_changes_returns_none(
+    agreement_factory, order_parameters_factory, mocked_agreement_syncer
+):
+    agreement = agreement_factory(
+        ordering_parameters=order_parameters_factory(
+            contact={
+                "firstName": "firstName",
+                "lastName": "lastName",
+                "email": "email",
+                "phone": {"prefix": "+1", "number": "5551234567"},
+            }
+        )
+    )
+    company_profile = mocked_agreement_syncer._adobe_customer["companyProfile"]
+
+    result = mocked_agreement_syncer._resolve_contact_parameter(agreement, company_profile)  # act
+
+    assert result is None
+
+
+def test_resolve_contact_parameter_no_contacts_returns_none(
+    agreement_factory, mocked_agreement_syncer
+):
+    agreement = agreement_factory()
+    company_profile = {"contacts": []}
+
+    result = mocked_agreement_syncer._resolve_contact_parameter(agreement, company_profile)  # act
+
+    assert result is None
 
 
 @freeze_time("2025-06-19")
@@ -1800,6 +2033,36 @@ def test_sync_global_customer_update_not_required(
         mocker.call(
             mock_mpt_client,
             "AGR-2119-4550-8674-5962",
+            lines=[],
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            "AGR-2119-4550-8674-5962",
             parameters={"fulfillment": [{"externalId": "lastSyncDate", "value": "2025-06-30"}]},
         ),
     ])
@@ -1864,6 +2127,36 @@ def test_sync_global_customer_no_active_deployments(
                     {"externalId": "3YCLicenses", "value": ""},
                     {"externalId": "3YCConsumables", "value": ""},
                     {"externalId": "cotermDate", "value": "2024-01-23"},
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            "AGR-2119-4550-8674-5962",
+            lines=[],
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
                 ],
             },
         ),
@@ -2082,6 +2375,36 @@ def test_sync_agreement_empty_discounts(
         mocker.call(
             mock_mpt_client,
             agreement["id"],
+            lines=expected_lines,
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
             parameters={"fulfillment": [{"externalId": "lastSyncDate", "value": "2025-06-23"}]},
         ),
     ])
@@ -2272,6 +2595,53 @@ def test_sync_agreement_prices_with_missing_prices(
                     {"externalId": "3YCLicenses", "value": ""},
                     {"externalId": "3YCConsumables", "value": ""},
                     {"externalId": "cotermDate", "value": "2025-04-04"},
+                ],
+            },
+        ),
+        mocker.call(
+            mock_mpt_client,
+            agreement["id"],
+            lines=[
+                {
+                    "item": {
+                        "id": "ITM-1234-1234-1234-0001",
+                        "name": "Awesome product",
+                        "externalIds": {"vendor": "77777777CA"},
+                    },
+                    "subscription": {
+                        "id": "SUB-1000-2000-3000",
+                        "status": "Active",
+                        "name": "Subscription for Acrobat Pro for Teams; Multi Language",
+                    },
+                    "oldQuantity": 0,
+                    "quantity": 170,
+                    "price": {"unitPP": 20.22},
+                    "id": "ALI-2119-4550-8674-5962-0001",
+                }
+            ],
+            parameters={
+                "ordering": [
+                    {"externalId": "companyName", "value": "Migrated Company"},
+                    {
+                        "externalId": "address",
+                        "value": {
+                            "country": "US",
+                            "state": "region",
+                            "city": "city",
+                            "addressLine1": "addressLine1",
+                            "addressLine2": "addressLine2",
+                            "postCode": "postalCode",
+                        },
+                    },
+                    {
+                        "externalId": "contact",
+                        "value": {
+                            "firstName": "firstName",
+                            "lastName": "lastName",
+                            "email": "email",
+                            "phone": {"prefix": "+1", "number": "8004449890"},
+                        },
+                    },
                 ],
             },
         ),


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Agreement sync previously only refreshed `cotermDate`, 3YC fields, and linked-membership fields from Adobe, leaving `companyName`, `address` (on main agreements), and `contact` as order-time-input-only. Once set at order time, these could drift out of sync with Adobe indefinitely (or never get corrected if entered incorrectly).

This change adds sync support for all three ordering parameters:

- **`companyName`** — synced for all agreements (main + deployment), always from the main Adobe customer's `companyProfile.companyName` (deployments don't carry their own company name).
- **`address`** — synced for all agreements: main agreements (no `deploymentId`) from the main customer's `companyProfile.address`; deployment agreements from the matching deployment's `companyProfile.address` (unchanged behavior, now folded into the same update call).
- **`contact`** — synced for all agreements from the main customer's `companyProfile.contacts` collection, matched by **email** against the agreement's current `contact` value:
  - No match → overwrite the whole `contact` parameter with the first contact in the collection.
  - Match found → leave `email`/`phone` untouched, but correct `firstName`/`lastName` if they differ from the matched entry. If nothing differs, the parameter is left untouched entirely, so a manually-selected contact from the valid collection is never clobbered.

## Changes

- `adobe_vipm/flows/utils/formatting.py` — new `get_contact()` helper (mirrors the existing `get_address()` pattern).
- `adobe_vipm/flows/utils/__init__.py` — export `get_contact`.
- `adobe_vipm/flows/sync/agreement.py` — new `_update_agreement_profile_parameters()` and `_resolve_contact_parameter()` methods on `AgreementSyncer`, wired into `sync()` (main agreements) and `_sync_deployment_agreements()` (deployment agreements). Removes the now-superseded `_update_deployment_agreement_address()`, folding its address-only logic into the new combined update.
- `tests/flows/sync/test_agreement.py` — updates full-sync tests whose exact `update_agreement` call sequences changed, replaces the old deployment-address-only tests with tests for the new combined profile-parameter update and the contact-resolution branches (no match, match with differing names, match with identical names, empty contacts collection).

## Test plan

- [x] `make check` — ruff format, ruff check, flake8, `uv lock --check` all pass
- [x] `make test` — full suite passes (893 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Synchronizes agreement company names, addresses, and contacts with Adobe customer profiles.
- Preserves manually selected contacts while correcting stale contact names through email matching.
- Adds contact formatting and profile-parameter update helpers.
- Updates agreement synchronization tests for profile updates and contact-resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->