### PR TITLE
MPT-23137 Retry transient Airtable 5xx errors

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -6,6 +6,7 @@ from functools import cache
 from django.conf import settings
 from mpt_extension_sdk.mpt_http.utils import find_first
 from mpt_extension_sdk.runtime.djapp.conf import get_for_product
+from pyairtable.api.retrying import retry_strategy
 from pyairtable.formulas import (
     AND,
     BLANK,
@@ -35,6 +36,8 @@ STATUS_GC_PENDING = "pending"
 STATUS_GC_TRANSFERRED = "transferred"
 TYPE_3YC_CONSUMABLE = "Consumable"
 TYPE_3YC_LICENSE = "License"
+
+AIRTABLE_RETRY_STRATEGY = retry_strategy(status_forcelist=(429, 500, 502, 503, 504))
 
 PRICELIST_CACHE = defaultdict(list)
 
@@ -161,6 +164,7 @@ def get_transfer_model(base_info: AirTableBaseInfo):
             table_name = "Transfers"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return Transfer
 
@@ -197,6 +201,7 @@ def get_gc_main_agreement_model(base_info: AirTableBaseInfo):
             table_name = "Global Customer Main Agreements"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return GCMainAgreement
 
@@ -244,6 +249,7 @@ def get_gc_agreement_deployment_model(base_info: AirTableBaseInfo):
             table_name = "Global Customer Agreement Deployments"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return GCAgreementDeployment
 
@@ -274,6 +280,7 @@ def get_offer_model(base_info: AirTableBaseInfo):
             table_name = "Offers"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return Offer
 
@@ -431,6 +438,7 @@ def get_pricelist_model(base_info: AirTableBaseInfo):
             table_name = "PriceList"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return PriceList
 
@@ -829,6 +837,7 @@ def get_sku_adobe_mapping_model(base_info: AirTableBaseInfo):
             table_name = "SKU Mapping"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
         @classmethod
         def from_short_id(cls, vendor_external_id: str, market_segment: str):

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -1005,3 +1005,46 @@ def test_get_adobe_product_by_marketplace_sku(mocker, mock_get_sku_adobe_mapping
     assert not result.is_consumable()
     assert result.is_license()
     assert result.is_valid_3yc_type()
+
+
+def test_adobe_product_mapping_retry_strategy_configured():
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+
+    result = get_sku_adobe_mapping_model(base_info)
+
+    assert set(result.meta.retry_strategy.status_forcelist) == {429, 500, 502, 503, 504}
+
+
+def test_adobe_product_mapping_from_short_id_retries_on_transient_server_error(requests_mocker):
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+    adobe_product_mapping_model = get_sku_adobe_mapping_model(base_info)
+    records_url = "https://api.airtable.com/v0/base-id/SKU%20Mapping"
+    requests_mocker.get(
+        records_url,
+        status=500,
+        json={"type": "SERVER_ERROR", "message": "Server encountered an error"},
+    )
+    requests_mocker.get(
+        records_url,
+        status=200,
+        json={
+            "records": [
+                {
+                    "id": "rec123",
+                    "createdTime": "2024-01-01T00:00:00.000Z",
+                    "fields": {
+                        "vendor_external_id": "65304578CA",
+                        "sku": "65304578CA01A12",
+                        "segment": "COM",
+                        "name": "Some Adobe Product",
+                        "type_3yc": "License",
+                    },
+                }
+            ]
+        },
+    )
+
+    result = adobe_product_mapping_model.from_short_id("65304578CA", "COM")
+
+    assert result.vendor_external_id == "65304578CA"
+    assert result.sku == "65304578CA01A12"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Widen the Airtable `pyairtable` ORM retry configuration so transient server errors (5xx) are retried, not just rate-limit responses (429).

## Why

A transient Airtable `500 Internal Server Error` during the SKU Mapping lookup crashed order fulfillment: `ValidateSkuAvailability` → `get_adobe_product_by_marketplace_sku` → `AdobeProductMapping.from_short_id` propagated a raw `requests.exceptions.HTTPError`, because `pyairtable`'s built-in retry (`Model.Meta.retry`, enabled by default) only covers `429` out of the box — 5xx responses were never retried.

A concrete customer-facing case of this same class of failure (an order failing on a generic Airtable/server error mid-fulfillment) is tracked in the related support ticket MVS-2867.

## Change

- Added a shared `AIRTABLE_RETRY_STRATEGY` constant in `adobe_vipm/airtable/models.py`: `retry_strategy(status_forcelist=(429, 500, 502, 503, 504))`.
- Applied `retry = AIRTABLE_RETRY_STRATEGY` to all 6 Airtable `Model.Meta` classes (`Transfer`, `GCMainAgreement`, `GCAgreementDeployment`, `Offer`, `PriceList`, `AdobeProductMapping`) for consistency, since they all hit the same Airtable API and can all hit the same transient errors.
- Added tests in `tests/airtable/test_models.py`:
  - asserts the retry status_forcelist is configured as expected
  - end-to-end test (via the `requests_mocker` fixture) simulating a transient `500` followed by a successful response, verifying `from_short_id` now succeeds instead of raising

## Scope

This change is deliberately narrow: it only widens retry behavior. It does **not** apply the existing (currently unused) `wrap_airtable_http_error` decorator from `adobe_vipm/flows/errors.py` — that decorator has its own pre-existing issues (its error payload parsing assumes Airtable's 4xx `{"error": {...}}` envelope and mishandles the flat 5xx shape) and is being tracked as a separate follow-up discussion, not part of this fix.

## Testing

- `make build`
- `make check-all` — 895 passed, `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` all clean

Jira: MPT-23137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Expanded Airtable retries to cover transient 500, 502, 503, and 504 errors alongside 429 responses.
- Applied a shared retry strategy across all six Airtable models.
- Added tests for retry configuration and recovery after a transient 500 error.
- Validation passed: 895 tests, formatting, linting, and lock checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->