### PR TITLE
[HF] MPT-23137 Retry transient Airtable 5xx errors

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -6,6 +6,7 @@ from functools import cache
 from django.conf import settings
 from mpt_extension_sdk.mpt_http.utils import find_first
 from mpt_extension_sdk.runtime.djapp.conf import get_for_product
+from pyairtable.api.retrying import retry_strategy
 from pyairtable.formulas import (
     AND,
     BLANK,
@@ -35,6 +36,8 @@ STATUS_GC_PENDING = "pending"
 STATUS_GC_TRANSFERRED = "transferred"
 TYPE_3YC_CONSUMABLE = "Consumable"
 TYPE_3YC_LICENSE = "License"
+
+AIRTABLE_RETRY_STRATEGY = retry_strategy(status_forcelist=(429, 500, 502, 503, 504))
 
 PRICELIST_CACHE = defaultdict(list)
 
@@ -161,6 +164,7 @@ def get_transfer_model(base_info: AirTableBaseInfo):
             table_name = "Transfers"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return Transfer
 
@@ -197,6 +201,7 @@ def get_gc_main_agreement_model(base_info: AirTableBaseInfo):
             table_name = "Global Customer Main Agreements"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return GCMainAgreement
 
@@ -244,6 +249,7 @@ def get_gc_agreement_deployment_model(base_info: AirTableBaseInfo):
             table_name = "Global Customer Agreement Deployments"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return GCAgreementDeployment
 
@@ -274,6 +280,7 @@ def get_offer_model(base_info: AirTableBaseInfo):
             table_name = "Offers"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return Offer
 
@@ -431,6 +438,7 @@ def get_pricelist_model(base_info: AirTableBaseInfo):
             table_name = "PriceList"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
     return PriceList
 
@@ -829,6 +837,7 @@ def get_sku_adobe_mapping_model(base_info: AirTableBaseInfo):
             table_name = "SKU Mapping"
             api_key = base_info.api_key
             base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
 
         @classmethod
         def from_short_id(cls, vendor_external_id: str, market_segment: str):

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -1005,3 +1005,46 @@ def test_get_adobe_product_by_marketplace_sku(mocker, mock_get_sku_adobe_mapping
     assert not result.is_consumable()
     assert result.is_license()
     assert result.is_valid_3yc_type()
+
+
+def test_adobe_product_mapping_retry_strategy_configured():
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+
+    result = get_sku_adobe_mapping_model(base_info)
+
+    assert set(result.meta.retry_strategy.status_forcelist) == {429, 500, 502, 503, 504}
+
+
+def test_adobe_product_mapping_from_short_id_retries_on_transient_server_error(requests_mocker):
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+    adobe_product_mapping_model = get_sku_adobe_mapping_model(base_info)
+    records_url = "https://api.airtable.com/v0/base-id/SKU%20Mapping"
+    requests_mocker.get(
+        records_url,
+        status=500,
+        json={"type": "SERVER_ERROR", "message": "Server encountered an error"},
+    )
+    requests_mocker.get(
+        records_url,
+        status=200,
+        json={
+            "records": [
+                {
+                    "id": "rec123",
+                    "createdTime": "2024-01-01T00:00:00.000Z",
+                    "fields": {
+                        "vendor_external_id": "65304578CA",
+                        "sku": "65304578CA01A12",
+                        "segment": "COM",
+                        "name": "Some Adobe Product",
+                        "type_3yc": "License",
+                    },
+                }
+            ]
+        },
+    )
+
+    result = adobe_product_mapping_model.from_short_id("65304578CA", "COM")
+
+    assert result.vendor_external_id == "65304578CA"
+    assert result.sku == "65304578CA01A12"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Hotfix backport of #896 to `release/5`.

Widen the Airtable `pyairtable` ORM retry configuration so transient server errors (5xx) are retried, not just rate-limit responses (429).

## Why

A transient Airtable `500 Internal Server Error` during the SKU Mapping lookup crashed order fulfillment in production on `release/5`: `ValidateSkuAvailability` → `get_adobe_product_by_marketplace_sku` → `AdobeProductMapping.from_short_id` propagated a raw `requests.exceptions.HTTPError`, because `pyairtable`'s built-in retry (`Model.Meta.retry`, enabled by default) only covers `429` out of the box — 5xx responses were never retried.

A concrete customer-facing case of this same class of failure is tracked in the related support ticket MVS-2867.

## Source

- Main PR: #896 (merged)
- Cherry-picked commit: `3f040217ea34fc9c73b6838137e8ea4503683b93` — `fix(airtable): retry transient Airtable 5xx errors`
- Applied cleanly to `release/5`, no conflicts.

## Change

- Added a shared `AIRTABLE_RETRY_STRATEGY` constant in `adobe_vipm/airtable/models.py`: `retry_strategy(status_forcelist=(429, 500, 502, 503, 504))`.
- Applied `retry = AIRTABLE_RETRY_STRATEGY` to all 6 Airtable `Model.Meta` classes (`Transfer`, `GCMainAgreement`, `GCAgreementDeployment`, `Offer`, `PriceList`, `AdobeProductMapping`).
- Added tests in `tests/airtable/test_models.py` covering the retry configuration and an end-to-end retry-then-succeed case for a transient 500.

## Testing

- `make build`
- `make check-all` on `release/5` with the cherry-pick applied — 895 passed, `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` all clean

Jira: MPT-23137
