### PR TITLE
[HF] MPT-23189 Use renewalQuantity instead of currentQuantity when creating subscriptions

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -380,7 +380,7 @@ class AgreementSyncer:  # noqa: WPS214
             "seller": {"id": self._seller_id},
             "lines": [
                 {
-                    "quantity": adobe_subscription[Param.CURRENT_QUANTITY.value],
+                    "quantity": adobe_subscription["autoRenewal"][Param.RENEWAL_QUANTITY.value],
                     "item": item,
                     **unit_price,
                 }

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -3252,7 +3252,10 @@ def test_add_missing_subscriptions(
             subscription_id="1e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65322572CAT1A10"
         ),
         adobe_subscription_factory(
-            subscription_id="2e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65322572CAT1A13"
+            subscription_id="2e5b9c974c4ea1bcabdb0fe697a2f1NA",
+            offer_id="65322572CAT1A13",
+            current_quantity=7,
+            renewal_quantity=10,
         ),
         adobe_subscription_factory(
             subscription_id="ae5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="75322572CAT1A11"
@@ -3333,7 +3336,7 @@ def test_add_missing_subscriptions(
             "parameters": {
                 "fulfillment": [
                     {"externalId": "adobeSKU", "value": "65322572CAT1A13"},
-                    {"externalId": "currentQuantity", "value": "10"},
+                    {"externalId": "currentQuantity", "value": "7"},
                     {"externalId": "renewalQuantity", "value": "10"},
                     {"externalId": "renewalDate", "value": "2026-10-11"},
                 ]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Cherry-picks the `main` fix from #901 onto `release/5`.

`_create_mpt_subscription` set the initial MPT subscription line quantity from Adobe's `currentQuantity` field. The ongoing sync path, `SubscriptionSyncer._update_subscription`, correctly uses `autoRenewal.renewalQuantity` for the same field — that is the value MPT users are meant to see going forward.

This PR aligns subscription creation with the sync path by reading `adobe_subscription["autoRenewal"]["renewalQuantity"]` instead of `adobe_subscription["currentQuantity"]` when building the initial subscription's line quantity. Asset creation (`_create_mpt_asset`) is unaffected — one-time assets have no renewal concept and correctly keep using `currentQuantity`.

## Why

`currentQuantity` and `renewalQuantity` can genuinely differ (e.g. a customer has a pending seat change scheduled for the next renewal). Without this fix, a newly created subscription could show the wrong quantity until the next scheduled sync run corrected it.

## Testing

- `make build`
- `make check-all` — 895 passed, `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` all clean

Jira: MPT-23189
Source PR: #901
