### PR TITLE
MPT-21068 Use json as an value to update parameter of applied discoun…

### DIFF
--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1410,7 +1410,6 @@ class NullifyFlexDiscountParam(Step):
                         {
                             "externalId": Param.FLEXIBLE_DISCOUNTS,
                             "value": None,
-                            #  The Prop is a JSON type, but MPT API accepts only string here
                         },
                     ]
                 },

--- a/adobe_vipm/flows/utils/parameter.py
+++ b/adobe_vipm/flows/utils/parameter.py
@@ -1,6 +1,5 @@
 import copy
 import functools
-import json
 from typing import Any
 
 from django.conf import settings
@@ -399,8 +398,9 @@ def set_flex_discounts_parameter(order: dict, adobe_order: dict) -> dict:
         for line in adobe_order["lineItems"]
         if line.get("flexDiscounts")
     ]
-    flex_discounts = json.dumps(flex_discounts) if flex_discounts else None
-    return update_fulfillment_parameter_value(order, Param.FLEXIBLE_DISCOUNTS.value, flex_discounts)
+    return update_fulfillment_parameter_value(
+        order, Param.FLEXIBLE_DISCOUNTS.value, flex_discounts or None
+    )
 
 
 def set_adobe_order_ids_created_parameter(context, order_ids: list[str | None]) -> dict:


### PR DESCRIPTION
…ts in Adobe Extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated Adobe Extension fulfillment parameters to store applied flexible discounts as JSON values instead of serialized strings.
- Preserved nullification behavior for flexible discount parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->