### PR TITLE
MPT-23183 Split AdobeStatus enum into per-object status codes and API error codes

### DIFF
--- a/adobe_vipm/adobe/constants.py
+++ b/adobe_vipm/adobe/constants.py
@@ -6,40 +6,57 @@ from enum import StrEnum
 import regex as re
 
 
-class AdobeStatus(StrEnum):
-    """Adobe Order Statuses."""
+class AdobeOrderStatus(StrEnum):
+    """Adobe order statuses. A transfer is an order of type TRANSFER and shares this enum."""
 
-    PROCESSED = "1000"
+    COMPLETE = "1000"
+    OPEN = "1002"
+    FAILED = "1004"
+    CANCELLED = "1008"
+    FAILED_INVALID_ADDRESS = "1010"
+    FAILED_INACTIVE_DISTRIBUTOR = "1020"
+    FAILED_INACTIVE_RESELLER = "1022"
+    FAILED_INACTIVE_CUSTOMER = "1024"
+    FAILED_INVALID_CUSTOMER_ID = "1026"
+
+
+class AdobeSubscriptionStatus(StrEnum):
+    """Adobe subscription statuses."""
+
+    ACTIVE = "1000"
     PENDING = "1002"
-    INACTIVE_OR_GENERIC_FAILURE = "1004"
-    ORDER_CANCELLED = "1008"
-    ORDER_INACTIVE_DISTRIBUTOR = "1020"
-    ORDER_INACTIVE_RESELLER = "1022"
-    ORDER_INACTIVE_CUSTOMER = "1024"
-    ORDER_INVALID_CUSTOMER_ID = "1026"
+    INACTIVE = "1004"
+    SCHEDULED = "1009"
+
+
+class AdobeDeploymentStatus(StrEnum):
+    """Adobe deployment statuses."""
+
+    ACTIVE = "1000"
+    INACTIVE = "1004"
+
+
+class AdobeErrorCode(StrEnum):
+    """Adobe API error response codes."""
+
+    INVALID_CUSTOMER = "1116"
     INVALID_FIELDS = "1117"
     INVALID_ADDRESS = "1118"
     REQUEST_IS_MISSING_REQUIRED_FIELDS = "1122"
+    INTERNAL_SERVER_ERROR = "1124"
     INVALID_MINIMUM_QUANTITY = "1135"
-    ACCOUNT_ALREADY_EXISTS = "1127"
-    TRANSFER_INVALID_MEMBERSHIP = "5115"
-    TRANSFER_INVALID_MEMBERSHIP_OR_TRANSFER_IDS = "5116"
-    TRANSFER_INELIGIBLE = "5117"
-    TRANSFER_ALREADY_TRANSFERRED = "5118"
-    TRANSFER_INACTIVE_RESELLER = "5119"
-    TRANSFER_NO_ADMIN_CONTACTS = "5120"
-    TRANSFER_IN_PROGRESS = "5121"
-    TRANSFER_INACTIVE_ACCOUNT = "1010"
-    SUBSCRIPTION_INACTIVE = "3119"  # PATCH error code, not a subscription status value
+    INVALID_COUNTRY_FOR_PARTNER = "1178"
+    CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT = "2141"
+    INACTIVE_SUBSCRIPTION_NOT_EDITABLE = "3119"
     INVALID_RENEWAL_STATE = "3120"
     LINE_ITEM_OFFER_ID_EXPIRED = "3123"
-    INTERNAL_SERVER_ERROR = "1124"
-    GC_DEPLOYMENT_ACTIVE = "1000"
-    SUBSCRIPTION_TERMINATED = "1004"
-    SUBSCRIPTION_ACTIVE = "1000"
-    INVALID_CUSTOMER = "1116"
-    CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT = "2141"
-    INVALID_COUNTRY_FOR_PARTNER = "1178"
+    INVALID_MEMBERSHIP_ID = "5115"
+    INVALID_MEMBERSHIP_OR_TRANSFER_ID = "5116"
+    INELIGIBLE_TRANSFER = "5117"
+    CUSTOMER_ALREADY_TRANSFERRED = "5118"
+    RESELLER_INACTIVE_FOR_TRANSFER = "5119"
+    NO_ADMIN_CONTACTS_FOR_TRANSFER = "5120"
+    TRANSFER_IN_PROGRESS = "5121"
 
 
 class ResellerChangeAction(StrEnum):
@@ -50,28 +67,19 @@ class ResellerChangeAction(StrEnum):
 
 
 ORDER_STATUS_DESCRIPTION = types.MappingProxyType({
-    AdobeStatus.INACTIVE_OR_GENERIC_FAILURE: "Inactive account, failed order or inactive "
-    "subscription.",
-    AdobeStatus.ORDER_CANCELLED: "Order has been cancelled.",
-    AdobeStatus.ORDER_INACTIVE_DISTRIBUTOR: "Distributor is inactive.",
-    AdobeStatus.ORDER_INACTIVE_RESELLER: "Reseller is inactive.",
-    AdobeStatus.ORDER_INACTIVE_CUSTOMER: "Customer is inactive.",
-    AdobeStatus.ORDER_INVALID_CUSTOMER_ID: "The provided customer identifier is invalid.",
+    AdobeOrderStatus.FAILED: "Order has failed.",
+    AdobeOrderStatus.CANCELLED: "Order has been cancelled.",
+    AdobeOrderStatus.FAILED_INACTIVE_DISTRIBUTOR: "Distributor is inactive.",
+    AdobeOrderStatus.FAILED_INACTIVE_RESELLER: "Reseller is inactive.",
+    AdobeOrderStatus.FAILED_INACTIVE_CUSTOMER: "Customer is inactive.",
+    AdobeOrderStatus.FAILED_INVALID_CUSTOMER_ID: "The provided customer identifier is invalid.",
 })
 
 SUBSCRIPTION_STATUS_DESCRIPTION = types.MappingProxyType({
-    AdobeStatus.SUBSCRIPTION_TERMINATED: "Subscription is terminated.",
+    AdobeSubscriptionStatus.INACTIVE: "Subscription is inactive.",
 })
 
 UNRECOVERABLE_ORDER_STATUSES = tuple(ORDER_STATUS_DESCRIPTION.keys())
-
-UNRECOVERABLE_TRANSFER_STATUSES = (
-    AdobeStatus.TRANSFER_INELIGIBLE,
-    AdobeStatus.TRANSFER_ALREADY_TRANSFERRED,
-    AdobeStatus.TRANSFER_INACTIVE_RESELLER,
-    AdobeStatus.TRANSFER_NO_ADMIN_CONTACTS,
-    AdobeStatus.TRANSFER_IN_PROGRESS,
-)
 
 ORDER_TYPE_NEW = "NEW"
 ORDER_TYPE_PREVIEW = "PREVIEW"

--- a/adobe_vipm/adobe/mixins/deployment.py
+++ b/adobe_vipm/adobe/mixins/deployment.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 import requests
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeDeploymentStatus
 from adobe_vipm.adobe.errors import wrap_http_error
 
 
@@ -61,5 +61,5 @@ class DeploymentClientMixin:
         return [
             deployment
             for deployment in customer_deployments.get("items", [])
-            if deployment.get("status") == AdobeStatus.GC_DEPLOYMENT_ACTIVE
+            if deployment.get("status") == AdobeDeploymentStatus.ACTIVE
         ]

--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 import requests
 
 from adobe_vipm.adobe import constants as adobe_constants
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode
 from adobe_vipm.adobe.dataclasses import Authorization, ReturnableOrderInfo
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, wrap_http_error
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError, ProcessingUpsizeLinesError
@@ -393,8 +393,8 @@ class OrderClientMixin:
             filters={
                 "order-type": adobe_constants.ORDER_TYPE_RETURN,
                 "status": [
-                    adobe_constants.AdobeStatus.PROCESSED,
-                    adobe_constants.AdobeStatus.PENDING,
+                    adobe_constants.AdobeOrderStatus.COMPLETE,
+                    adobe_constants.AdobeOrderStatus.OPEN,
                 ],
             },
         )
@@ -564,7 +564,7 @@ class OrderClientMixin:
                 offer_ids,
             )
         except AdobeAPIError as error:
-            if error.code == AdobeStatus.INVALID_COUNTRY_FOR_PARTNER:
+            if error.code == AdobeErrorCode.INVALID_COUNTRY_FOR_PARTNER:
                 logger.warning(
                     "Invalid country %s for partner when getting flex discounts.", country
                 )
@@ -589,7 +589,7 @@ class OrderClientMixin:
         return base_offers_with_discounts
 
     def _get_fail_discounts_for_cust_not_qualified(self, ex: AdobeError, payload: dict) -> set:
-        if ex.code == adobe_constants.AdobeStatus.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT:
+        if ex.code == adobe_constants.AdobeErrorCode.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT:
             logger.warning("%s", ex)
             matched = self.flex_discount_not_qualify_re.match(ex.details[0])
             if not matched:
@@ -760,8 +760,8 @@ class OrderClientMixin:
         order, mpt_item = order_item
 
         return (
-            order["status"] == adobe_constants.AdobeStatus.PROCESSED
-            and mpt_item["status"] == adobe_constants.AdobeStatus.PROCESSED
+            order["status"] == adobe_constants.AdobeOrderStatus.COMPLETE
+            and mpt_item["status"] == adobe_constants.AdobeOrderStatus.COMPLETE
         )
 
     @wrap_http_error

--- a/adobe_vipm/adobe/mixins/subscription.py
+++ b/adobe_vipm/adobe/mixins/subscription.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 import requests
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.adobe.errors import wrap_http_error
 from adobe_vipm.flows.constants import Param
 from adobe_vipm.utils import get_partial_sku
@@ -114,7 +114,7 @@ class SubscriptionClientMixin:
             authorization_id, customer_id, deployment_id
         )["items"]
         active_subscriptions = filter(
-            lambda sub: sub["status"] == AdobeStatus.PROCESSED,
+            lambda sub: sub["status"] == AdobeSubscriptionStatus.ACTIVE,
             subscriptions,
         )
 

--- a/adobe_vipm/flows/fulfillment/change.py
+++ b/adobe_vipm/flows/fulfillment/change.py
@@ -12,7 +12,7 @@ from functools import partial
 from mpt_extension_sdk.mpt_http.utils import find_first
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode, AdobeOrderStatus
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
     ERR_INVALID_RENEWAL_STATE,
@@ -169,7 +169,7 @@ def _is_invalid_renewal_state_ok(context, line):
         check_item_in_order, context.adobe_new_order["lineItems"]
     ):
         invalid_renewal_state_allowed = (
-            context.adobe_new_order["status"] == AdobeStatus.PROCESSED.value
+            context.adobe_new_order["status"] == AdobeOrderStatus.COMPLETE.value
         )
         if invalid_renewal_state_allowed:
             logger.info("> Vendor order with the item has status PROCESSED")
@@ -235,7 +235,7 @@ class UpdateRenewalQuantities(Step):
                 )
             except AdobeAPIError as error:
                 invalid_renewal_state_allowed = False
-                if error.code == AdobeStatus.INVALID_RENEWAL_STATE and old_qty < qty:
+                if error.code == AdobeErrorCode.INVALID_RENEWAL_STATE and old_qty < qty:
                     logger.info(
                         "Got invalid renewal state error for subscription %s while updating"
                         " quantity %s -> %s",
@@ -247,7 +247,7 @@ class UpdateRenewalQuantities(Step):
                 if not (
                     invalid_renewal_state_allowed
                     or (
-                        error.code == AdobeStatus.LINE_ITEM_OFFER_ID_EXPIRED
+                        error.code == AdobeErrorCode.LINE_ITEM_OFFER_ID_EXPIRED
                         and context.adobe_new_order
                     )
                 ):
@@ -283,8 +283,8 @@ class UpdateRenewalQuantities(Step):
     def _handle_subscription_update_error(self, adobe_client, client, context, error):
         self._rollback_updated_subscriptions(adobe_client, context)
         if error.code in {
-            AdobeStatus.INVALID_RENEWAL_STATE,
-            AdobeStatus.SUBSCRIPTION_INACTIVE,
+            AdobeErrorCode.INVALID_RENEWAL_STATE,
+            AdobeErrorCode.INACTIVE_SUBSCRIPTION_NOT_EDITABLE,
         }:
             switch_order_to_failed(
                 client,

--- a/adobe_vipm/flows/fulfillment/purchase.py
+++ b/adobe_vipm/flows/fulfillment/purchase.py
@@ -10,7 +10,7 @@ import logging
 from mpt_extension_sdk.mpt_http.mpt import update_agreement, update_order
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode
 from adobe_vipm.adobe.errors import AdobeError
 from adobe_vipm.adobe.utils import get_3yc_commitment_request
 from adobe_vipm.flows.constants import (
@@ -177,9 +177,9 @@ class CreateCustomer(Step):
             error (Error): API Error.
         """
         if error.code not in {
-            AdobeStatus.INVALID_ADDRESS,
-            AdobeStatus.INVALID_FIELDS,
-            AdobeStatus.INVALID_MINIMUM_QUANTITY,
+            AdobeErrorCode.INVALID_ADDRESS,
+            AdobeErrorCode.INVALID_FIELDS,
+            AdobeErrorCode.INVALID_MINIMUM_QUANTITY,
         }:
             switch_order_to_failed(
                 client,
@@ -187,14 +187,14 @@ class CreateCustomer(Step):
                 ERR_VIPM_UNHANDLED_EXCEPTION.to_dict(error=str(error)),
             )
             return
-        if error.code in {AdobeStatus.INVALID_ADDRESS, AdobeStatus.INVALID_FIELDS}:
+        if error.code in {AdobeErrorCode.INVALID_ADDRESS, AdobeErrorCode.INVALID_FIELDS}:
             param = get_ordering_parameter(context.order, Param.ADDRESS.value)
             context.order = set_ordering_parameter_error(
                 context.order,
                 Param.ADDRESS.value,
                 ERR_ADOBE_ADDRESS.to_dict(title=param["name"], details=str(error)),
             )
-        elif error.code == AdobeStatus.INVALID_MINIMUM_QUANTITY:
+        elif error.code == AdobeErrorCode.INVALID_MINIMUM_QUANTITY:
             if "LICENSE" in str(error):
                 param = get_ordering_parameter(context.order, Param.THREE_YC_LICENSES.value)
                 context.order = set_ordering_parameter_error(

--- a/adobe_vipm/flows/fulfillment/reseller_transfer.py
+++ b/adobe_vipm/flows/fulfillment/reseller_transfer.py
@@ -3,7 +3,7 @@ import logging
 from mpt_extension_sdk.mpt_http.mpt import update_agreement, update_order
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus, ResellerChangeAction
+from adobe_vipm.adobe.constants import AdobeOrderStatus, ResellerChangeAction
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.airtable.models import get_transfer_by_authorization_membership_or_customer
 from adobe_vipm.flows.constants import ERR_ADOBE_RESSELLER_CHANGE_PREVIEW, TEMPLATE_NAME_TRANSFER
@@ -113,7 +113,7 @@ class CheckAdobeResellerTransfer(Step):
             context.adobe_transfer_order.get("status"),
         )
 
-        if context.adobe_transfer_order.get("status") == AdobeStatus.PENDING:
+        if context.adobe_transfer_order.get("status") == AdobeOrderStatus.OPEN:
             return
 
         next_step(mpt_client, context)

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -33,7 +33,9 @@ from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW_RENEWAL,
     ORDER_TYPE_RENEWAL,
     UNRECOVERABLE_ORDER_STATUSES,
-    AdobeStatus,
+    AdobeErrorCode,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
@@ -631,7 +633,7 @@ def build_renewal_line_items(manual_renewal_lines: dict) -> list[dict]:
 
 def is_renewal_unsupported_error(error: AdobeAPIError) -> bool:
     """Return True when Adobe rejected a renewal because an offer can't be renewed."""
-    return error.code == AdobeStatus.REQUEST_IS_MISSING_REQUIRED_FIELDS
+    return error.code == AdobeErrorCode.REQUEST_IS_MISSING_REQUIRED_FIELDS
 
 
 class SetupDueDate(Step):
@@ -912,7 +914,7 @@ class SubmitReturnOrders(Step):
         pending_orders = [
             return_order["orderId"]
             for return_order in all_return_orders
-            if return_order["status"] != AdobeStatus.PROCESSED
+            if return_order["status"] != AdobeOrderStatus.COMPLETE
         ]
         if pending_orders:
             logger.info(
@@ -1001,7 +1003,7 @@ class SubmitNewOrder(Step):
             )
         context.adobe_new_order = adobe_order
         context.adobe_new_order_id = adobe_order["orderId"]
-        if adobe_order["status"] == AdobeStatus.PENDING:
+        if adobe_order["status"] == AdobeOrderStatus.OPEN:
             logger.info("%s: adobe order %s is still pending.", context, context.adobe_new_order_id)
             return
 
@@ -1017,7 +1019,7 @@ class SubmitNewOrder(Step):
             logger.warning("%s: The adobe order has been failed %s.", context, error["message"])
             return
 
-        if adobe_order["status"] != AdobeStatus.PROCESSED:
+        if adobe_order["status"] != AdobeOrderStatus.COMPLETE:
             error = ERR_UNEXPECTED_ADOBE_ERROR_STATUS.to_dict(status=adobe_order["status"])
             switch_order_to_failed(client, context.order, error)
             logger.warning("%s: the order has been failed due to %s.", context, error["message"])
@@ -1048,7 +1050,7 @@ class CreateOrUpdateAssets(Step):
                 context.authorization_id, context.adobe_customer_id, line["subscriptionId"]
             )
 
-            if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+            if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
                 logger.info(
                     "%s: subscription %s for customer %s is in status %s, skip it",
                     context,
@@ -1158,7 +1160,7 @@ class CreateOrUpdateSubscriptions(Step):
             line["subscriptionId"],
         )
 
-        if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+        if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
             logger.warning(
                 "%s: subscription %s for customer %s is in status %s, skip it",
                 context,
@@ -1785,11 +1787,11 @@ class SubmitRenewalOrders(Step):
         if order is None:
             return
 
-        if order["status"] == AdobeStatus.PENDING:
+        if order["status"] == AdobeOrderStatus.OPEN:
             logger.info("%s: renewal order %s is still pending", context, order["orderId"])
             return
 
-        if order["status"] != AdobeStatus.PROCESSED:
+        if order["status"] != AdobeOrderStatus.COMPLETE:
             switch_order_to_failed(
                 client,
                 context.order,

--- a/adobe_vipm/flows/fulfillment/termination.py
+++ b/adobe_vipm/flows/fulfillment/termination.py
@@ -8,7 +8,7 @@ processing.
 import logging
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
     ERR_INVALID_RENEWAL_STATE,
@@ -115,7 +115,7 @@ class SwitchAutoRenewalOff(Step):
                         subscription["id"],
                         adobe_subscription["subscriptionId"],
                     )
-                    if error.code == AdobeStatus.INVALID_RENEWAL_STATE:
+                    if error.code == AdobeErrorCode.INVALID_RENEWAL_STATE:
                         switch_order_to_failed(
                             client,
                             context.order,

--- a/adobe_vipm/flows/fulfillment/transfer.py
+++ b/adobe_vipm/flows/fulfillment/transfer.py
@@ -18,7 +18,12 @@ from mpt_extension_sdk.mpt_http.mpt import (
 )
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
+from adobe_vipm.adobe.constants import (
+    AdobeErrorCode,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
+    ThreeYearCommitmentStatus,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeHttpError
 from adobe_vipm.airtable.models import (
     STATUS_GC_CREATED,
@@ -113,8 +118,8 @@ def _handle_transfer_preview_error(client, order, error):
         isinstance(error, AdobeAPIError)
         and error.code
         in {
-            AdobeStatus.TRANSFER_INVALID_MEMBERSHIP,
-            AdobeStatus.TRANSFER_INVALID_MEMBERSHIP_OR_TRANSFER_IDS,
+            AdobeErrorCode.INVALID_MEMBERSHIP_ID,
+            AdobeErrorCode.INVALID_MEMBERSHIP_OR_TRANSFER_ID,
         }
     ) or (isinstance(error, AdobeHttpError) and error.status_code == 404):
         error_msg = (
@@ -243,10 +248,10 @@ def _check_adobe_transfer_order_fulfilled(mpt_client, order, membership_id, adob
         membership_id,
         adobe_transfer_id,
     )
-    if adobe_order["status"] == AdobeStatus.PENDING:
+    if adobe_order["status"] == AdobeOrderStatus.OPEN:
         handle_retries(mpt_client, order, adobe_transfer_id)
         return None
-    if adobe_order["status"] != AdobeStatus.PROCESSED:
+    if adobe_order["status"] != AdobeOrderStatus.COMPLETE:
         error = ERR_UNEXPECTED_ADOBE_ERROR_STATUS.to_dict(status=adobe_order["status"])
         switch_order_to_failed(mpt_client, order, error)
         logger.warning("Transfer %s has been failed: %s.", order["id"], error["message"])
@@ -302,7 +307,7 @@ def _fulfill_transfer_migrated(  # noqa: C901
         adobe_subscription = adobe_client.get_subscription(
             authorization_id, transfer.customer_id, line["subscriptionId"]
         )
-        if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+        if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
             logger.info(
                 SUBSCRIPTION_SKIP_LOG,
                 adobe_subscription["subscriptionId"],
@@ -906,7 +911,7 @@ def create_agreement_subscriptions(adobe_transfer_order, mpt_client, order, adob
             customer_id,
             item["subscriptionId"],
         )
-        if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+        if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
             logger.info(
                 SUBSCRIPTION_SKIP_LOG,
                 adobe_subscription["subscriptionId"],
@@ -1332,7 +1337,7 @@ class CreateTransferAssets(Step):
             adobe_subscription = adobe_client.get_subscription(
                 context.order["authorization"]["id"], customer_id, item["subscriptionId"]
             )
-            if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+            if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
                 logger.info(
                     SUBSCRIPTION_SKIP_LOG,
                     adobe_subscription["subscriptionId"],

--- a/adobe_vipm/flows/global_customer.py
+++ b/adobe_vipm/flows/global_customer.py
@@ -25,7 +25,7 @@ from mpt_extension_sdk.mpt_http.mpt import (
 from mpt_extension_sdk.mpt_http.utils import find_first
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.adobe.utils import (
     sanitize_company_name,
     sanitize_first_last_name,
@@ -746,7 +746,7 @@ def process_adobe_subscriptions_from_agreement(
     ]
     for adobe_subscription in adobe_subscriptions:
         adobe_subscription_id = adobe_subscription["subscriptionId"]
-        if adobe_subscription["status"] != AdobeStatus.PROCESSED:
+        if adobe_subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
             logger.warning(
                 "Subscription %s is in status %s, skip it",
                 adobe_subscription_id,

--- a/adobe_vipm/flows/helpers.py
+++ b/adobe_vipm/flows/helpers.py
@@ -9,7 +9,11 @@ from django.conf import settings
 from mpt_extension_sdk.mpt_http.mpt import get_agreement, get_licensee, update_order
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus, ResellerChangeAction, ThreeYearCommitmentStatus
+from adobe_vipm.adobe.constants import (
+    AdobeErrorCode,
+    ResellerChangeAction,
+    ThreeYearCommitmentStatus,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeHttpError, AdobeProductNotFoundError
 from adobe_vipm.adobe.utils import get_3yc_commitment_request, get_item_by_partial_sku
 from adobe_vipm.airtable.models import (
@@ -176,7 +180,7 @@ class SetupContext(Step):
                     context.adobe_customer_id,
                 )
             except AdobeAPIError as ex:
-                if ex.code == AdobeStatus.INVALID_CUSTOMER:
+                if ex.code == AdobeErrorCode.INVALID_CUSTOMER:
                     error = f"Received Adobe error {ex.code} - {ex.message}"
                     logger.info(
                         "Received Adobe error %s - %s, assuming lost customer "

--- a/adobe_vipm/flows/migration.py
+++ b/adobe_vipm/flows/migration.py
@@ -4,7 +4,12 @@ import logging
 from django.conf import settings
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
+from adobe_vipm.adobe.constants import (
+    AdobeErrorCode,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
+    ThreeYearCommitmentStatus,
+)
 from adobe_vipm.adobe.errors import (
     AdobeAPIError,
     AuthorizationNotFoundError,
@@ -163,7 +168,7 @@ def populate_offers_for_transfer(product_id, transfer, transfer_preview):
 
 def handle_preview_error(transfer, api_err):
     """Handle Adobe API errors during transfer preview."""
-    if api_err.code == AdobeStatus.TRANSFER_ALREADY_TRANSFERRED:
+    if api_err.code == AdobeErrorCode.CUSTOMER_ALREADY_TRANSFERRED:
         return True
 
     transfer.adobe_error_code = api_err.code
@@ -331,11 +336,11 @@ def check_running_transfers_for_product(product_id):  # noqa: C901
             transfer.save()
             continue
 
-        if adobe_transfer["status"] == AdobeStatus.PENDING:
+        if adobe_transfer["status"] == AdobeOrderStatus.OPEN:
             check_retries(transfer)
             continue
 
-        if adobe_transfer["status"] != AdobeStatus.PROCESSED:
+        if adobe_transfer["status"] != AdobeOrderStatus.COMPLETE:
             transfer.migration_error_description = (
                 f"Unexpected status ({adobe_transfer['status']}) "
                 "received from Adobe while retrieving transfer."
@@ -420,7 +425,7 @@ def check_running_transfers_for_product(product_id):  # noqa: C901
 
 def _update_subscriptions(client, subscriptions, transfer):
     for subscription in subscriptions["items"]:
-        if subscription["status"] != AdobeStatus.PROCESSED:
+        if subscription["status"] != AdobeSubscriptionStatus.ACTIVE:
             continue
         client.update_subscription(
             transfer.authorization_uk,

--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -12,7 +12,12 @@ from mpt_extension_sdk.mpt_http.base import MPTClient
 from mpt_extension_sdk.mpt_http.utils import find_first
 
 from adobe_vipm.adobe.client import AdobeClient
-from adobe_vipm.adobe.constants import THREE_YC_TEMP_3YC_STATUSES, AdobeStatus, OfferType
+from adobe_vipm.adobe.constants import (
+    THREE_YC_TEMP_3YC_STATUSES,
+    AdobeErrorCode,
+    AdobeSubscriptionStatus,
+    OfferType,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AuthorizationNotFoundError
 from adobe_vipm.adobe.utils import (
     get_3yc_commitment_request,
@@ -244,7 +249,7 @@ class AgreementSyncer:  # noqa: WPS214
             subsc
             for subsc in adobe_subscriptions
             if subsc["subscriptionId"] not in mpt_entitlements_external_ids
-            and subsc["status"] == AdobeStatus.SUBSCRIPTION_ACTIVE.value
+            and subsc["status"] == AdobeSubscriptionStatus.ACTIVE.value
         )
         if not missing_adobe_subscriptions:
             logger.info("> No missing subscriptions found")
@@ -717,7 +722,7 @@ class AgreementSyncer:  # noqa: WPS214
 
             actual_sku = adobe_subscription["offerId"]
 
-            if adobe_subscription["status"] == AdobeStatus.SUBSCRIPTION_TERMINATED:
+            if adobe_subscription["status"] == AdobeSubscriptionStatus.INACTIVE:
                 logger.info("Processing terminated Adobe subscription %s.", adobe_subscription_id)
                 self._update_subscription_template(mpt_subscription, TEMPLATE_SUBSCRIPTION_EXPIRED)
                 if self._dry_run:
@@ -729,7 +734,7 @@ class AgreementSyncer:  # noqa: WPS214
                     mpt.terminate_subscription(
                         self._mpt_client,
                         mpt_subscription["id"],
-                        f"Adobe subscription status {AdobeStatus.SUBSCRIPTION_TERMINATED}.",
+                        f"Adobe subscription status {AdobeSubscriptionStatus.INACTIVE}.",
                     )
                 continue
 
@@ -904,8 +909,8 @@ class AgreementSyncer:  # noqa: WPS214
             partial(_is_subscription_in_set, orphaned_subscription_ids), self._adobe_subscriptions
         ):
             if subscription["autoRenewal"]["enabled"] is False or subscription["status"] in {
-                AdobeStatus.SUBSCRIPTION_TERMINATED.value,
-                AdobeStatus.PENDING.value,
+                AdobeSubscriptionStatus.INACTIVE.value,
+                AdobeSubscriptionStatus.PENDING.value,
             }:
                 logger.info(
                     "> Skipping orphaned subscription %s (auto-renewal: %s, status: %s)",
@@ -1314,7 +1319,7 @@ def get_customer_or_process_lost_customer(
     try:
         return adobe_client.get_customer(agreement["authorization"]["id"], customer_id)
     except AdobeAPIError as error:
-        if error.code == AdobeStatus.INVALID_CUSTOMER:
+        if error.code == AdobeErrorCode.INVALID_CUSTOMER:
             logger.info(
                 "Received Adobe error %s - %s, assuming lost customer "
                 "and proceeding with lost customer procedure.",

--- a/adobe_vipm/flows/utils/subscription.py
+++ b/adobe_vipm/flows/utils/subscription.py
@@ -3,7 +3,7 @@ import logging
 
 from mpt_extension_sdk.mpt_http.utils import find_first
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.adobe.utils import get_item_by_partial_sku
 from adobe_vipm.flows.constants import (
     TEMPLATE_SUBSCRIPTION_AUTORENEWAL_DISABLE,
@@ -70,7 +70,7 @@ def is_transferring_item_expired(item: dict) -> bool:
     Returns:
         True if the item is expired.
     """
-    if "status" in item and item["status"] == AdobeStatus.INACTIVE_OR_GENERIC_FAILURE:
+    if "status" in item and item["status"] == AdobeSubscriptionStatus.INACTIVE:
         return True
 
     renewal_date = dt.date.fromisoformat(item["renewalDate"])
@@ -104,7 +104,7 @@ def is_line_item_active_subscription(subscriptions: list[dict], line: dict) -> b
     adobe_item = get_item_by_partial_sku(
         subscriptions["items"], line["item"]["externalIds"]["vendor"]
     )
-    return adobe_item["status"] == AdobeStatus.SUBSCRIPTION_ACTIVE
+    return adobe_item["status"] == AdobeSubscriptionStatus.ACTIVE
 
 
 def get_transfer_item_sku_by_subscription(trf: dict, sub_id: str) -> str | None:
@@ -209,7 +209,7 @@ def get_template_name_by_subscription(adobe_subscription):
     Returns:
         The template name.
     """
-    if adobe_subscription.get("status") == AdobeStatus.SUBSCRIPTION_TERMINATED:
+    if adobe_subscription.get("status") == AdobeSubscriptionStatus.INACTIVE:
         return TEMPLATE_SUBSCRIPTION_EXPIRED
 
     if adobe_subscription.get("autoRenewal", {}).get("enabled"):

--- a/adobe_vipm/flows/validation/transfer.py
+++ b/adobe_vipm/flows/validation/transfer.py
@@ -5,7 +5,7 @@ from typing import Any
 from mpt_extension_sdk.mpt_http.mpt import get_agreement, get_product_items_by_skus
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
+from adobe_vipm.adobe.constants import AdobeOrderStatus, ThreeYearCommitmentStatus
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeHttpError
 from adobe_vipm.airtable.models import (
     STATUS_RUNNING,
@@ -374,7 +374,7 @@ class ValidateTransferStatus(Step):
             self._set_transfer_error(context, order, "Membership has already been migrated")
             return
 
-        if context.adobe_transfer["status"] == AdobeStatus.TRANSFER_INACTIVE_ACCOUNT:
+        if context.adobe_transfer["status"] == AdobeOrderStatus.FAILED_INVALID_ADDRESS:
             context.order = set_ordering_parameter_error(
                 context.order,
                 Param.MEMBERSHIP_ID.value,

--- a/tests/adobe/mixins/test_order.py
+++ b/tests/adobe/mixins/test_order.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 import pytest
 from responses import matchers
 
-from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW, AdobeStatus
+from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW, AdobeErrorCode
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
 from adobe_vipm.adobe.utils import to_adobe_line_id
@@ -272,7 +272,7 @@ def test_get_preview_order_not_qualified(
             payload,
             {
                 "body": AdobeAPIError(
-                    status_code=int(AdobeStatus.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT),
+                    status_code=int(AdobeErrorCode.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT),
                     payload={
                         "code": "2141",
                         "message": "Customer is not qualified for the Flexible Discount",
@@ -325,7 +325,7 @@ def test_get_preview_order_unexpected_message(
             matchers.query_param_matcher({"fetch-price": "true"}),
         ],
         body=AdobeAPIError(
-            status_code=int(AdobeStatus.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT),
+            status_code=int(AdobeErrorCode.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT),
             payload={
                 "code": "2141",
                 "message": "Customer is not qualified for the Flexible Discount",
@@ -396,7 +396,7 @@ def test_get_flex_discounts_per_base_offer_invalid_country(
         urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "/v3/flex-discounts"),
         status=400,
         json=adobe_api_error_factory(
-            AdobeStatus.INVALID_COUNTRY_FOR_PARTNER, "Invalid Country for Partner"
+            AdobeErrorCode.INVALID_COUNTRY_FOR_PARTNER, "Invalid Country for Partner"
         ),
         match=[
             matchers.query_param_matcher({
@@ -435,7 +435,7 @@ def test_get_flex_discounts_per_base_offer_error(
     requests_mocker.get(
         urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "/v3/flex-discounts"),
         status=400,
-        json=adobe_api_error_factory(AdobeStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+        json=adobe_api_error_factory(AdobeErrorCode.INTERNAL_SERVER_ERROR, "Internal server error"),
         match=[
             matchers.query_param_matcher({
                 "market-segment": "COM",

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -17,7 +17,7 @@ from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW_RENEWAL,
     ORDER_TYPE_RENEWAL,
     ORDER_TYPE_RETURN,
-    AdobeStatus,
+    AdobeOrderStatus,
     ResellerChangeAction,
 )
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization, ReturnableOrderInfo
@@ -1604,7 +1604,7 @@ def test_create_return_order(
         ORDER_TYPE_NEW,
         external_id="ORD-1234",
         order_id="returning-order-id",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         deployment_id=deployment_id,
     )
     returning_item = returning_order["lineItems"][0]
@@ -1673,7 +1673,7 @@ def test_create_return_order_bad_request(
         status=400,
         json=error,
     )
-    returning_order = adobe_order_factory(ORDER_TYPE_NEW, status=AdobeStatus.PROCESSED.value)
+    returning_order = adobe_order_factory(ORDER_TYPE_NEW, status=AdobeOrderStatus.COMPLETE.value)
 
     with pytest.raises(AdobeError) as cv:
         client.create_return_order(
@@ -1706,7 +1706,7 @@ def test_create_return_order_by_adobe_order(
         ORDER_TYPE_NEW,
         external_id="ORD-1234",
         order_id="order-id",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     expected_body = {
         "externalReferenceId": f"{order_created['externalReferenceId']}_{order_created['orderId']}",
@@ -1764,7 +1764,7 @@ def test_create_return_order_by_adobe_order_with_deployment(
         ORDER_TYPE_NEW,
         external_id="ORD-1234",
         order_id="order-id",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         deployment_id="1400000194",
     )
     expected_body = {
@@ -1822,7 +1822,7 @@ def test_create_return_order_by_adobe_order_bad_request(
         status=400,
         json=error,
     )
-    order_created = adobe_order_factory(ORDER_TYPE_NEW, status=AdobeStatus.PROCESSED.value)
+    order_created = adobe_order_factory(ORDER_TYPE_NEW, status=AdobeOrderStatus.COMPLETE.value)
 
     with pytest.raises(AdobeError) as cv:
         client.create_return_order_by_adobe_order(authorization_uk, customer_id, order_created)
@@ -2651,45 +2651,45 @@ def test_get_returnable_orders_by_subscription_id(
         order_id="order_ko_0",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3001", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3001", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-06T00:00:00Z",
     )
     order_ok_1 = adobe_order_factory(
         order_id="order_ok_1",
         order_type=ORDER_TYPE_RENEWAL,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-07T00:00:00Z",
     )
     order_ok_2 = adobe_order_factory(
         order_id="order_ok_2",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-08T00:00:00Z",
     )
     order_ko_1 = adobe_order_factory(
         order_id="order_ko_1",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3001", status=AdobeStatus.ORDER_CANCELLED.value
+            subscription_id="SUB-1000-2000-3001", status=AdobeOrderStatus.CANCELLED.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-09T00:00:00Z",
     )
     order_ko_2 = adobe_order_factory(
         order_id="order_ko_2",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.ORDER_CANCELLED.value,
+        status=AdobeOrderStatus.CANCELLED.value,
     )
     # for another sku
     order_ko_3 = adobe_order_factory(
@@ -2698,9 +2698,9 @@ def test_get_returnable_orders_by_subscription_id(
         items=adobe_items_factory(
             subscription_id="SUB-1000-2000-3002",
             offer_id="99999999CA01A12",
-            status=AdobeStatus.PROCESSED.value,
+            status=AdobeOrderStatus.COMPLETE.value,
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-10T00:00:00Z",
     )
     mocked_get_orders = mocker.patch.object(
@@ -2761,45 +2761,45 @@ def test_get_returnable_orders_by_subscription_id_with_returning_orders(
         order_id="order_ko_0",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3001", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3001", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-06T00:00:00Z",
     )
     order_ok_1 = adobe_order_factory(
         order_id="order_ok_1",
         order_type=ORDER_TYPE_RENEWAL,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-07T00:00:00Z",
     )
     order_ok_2 = adobe_order_factory(
         order_id="order_ok_2",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-08T00:00:00Z",
     )
     order_ok_3 = adobe_order_factory(
         order_id="order_ok_3",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.ORDER_CANCELLED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.CANCELLED.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-09T00:00:00Z",
     )
     order_ok_4 = adobe_order_factory(
         order_id="order_ok_4",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.ORDER_CANCELLED.value,
+        status=AdobeOrderStatus.CANCELLED.value,
         creation_date="2024-01-10T00:00:00Z",
     )
     order_ko_1 = adobe_order_factory(
@@ -2808,9 +2808,9 @@ def test_get_returnable_orders_by_subscription_id_with_returning_orders(
         items=adobe_items_factory(
             subscription_id="SUB-1000-2000-3002",
             offer_id="99999999CA01A12",
-            status=AdobeStatus.PROCESSED.value,
+            status=AdobeOrderStatus.COMPLETE.value,
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-11T00:00:00Z",
     )
     ret_order_1 = adobe_order_factory(reference_order_id="order_ok_3", order_type=ORDER_TYPE_RETURN)
@@ -2881,20 +2881,20 @@ def test_get_return_orders_by_external_reference(
 ):
     order_ok_1 = adobe_order_factory(
         order_type=ORDER_TYPE_RETURN,
-        items=adobe_items_factory(status=AdobeStatus.PROCESSED.value),
-        status=AdobeStatus.PROCESSED.value,
+        items=adobe_items_factory(status=AdobeOrderStatus.COMPLETE.value),
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id="returning-mpt-order-123_returned-mpt-order-456_line1",
     )
     order_ok_2 = adobe_order_factory(
         order_type=ORDER_TYPE_RETURN,
-        items=adobe_items_factory(status=AdobeStatus.PROCESSED.value),
-        status=AdobeStatus.PENDING.value,
+        items=adobe_items_factory(status=AdobeOrderStatus.COMPLETE.value),
+        status=AdobeOrderStatus.OPEN.value,
         external_id="returning-mpt-order-123_returned-mpt-order-789_line1",
     )
     order_ko_1 = adobe_order_factory(
         order_type=ORDER_TYPE_RETURN,
-        items=adobe_items_factory(status=AdobeStatus.PROCESSED.value),
-        status=AdobeStatus.PROCESSED.value,
+        items=adobe_items_factory(status=AdobeOrderStatus.COMPLETE.value),
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id="returning-mpt-order-987_returned-mpt-order-456_line1",
     )
     mocked_get_orders = mocker.patch.object(
@@ -2916,7 +2916,7 @@ def test_get_return_orders_by_external_reference(
         customer_id,
         filters={
             "order-type": ORDER_TYPE_RETURN,
-            "status": [AdobeStatus.PROCESSED.value, AdobeStatus.PENDING.value],
+            "status": [AdobeOrderStatus.COMPLETE.value, AdobeOrderStatus.OPEN.value],
         },
     )
 
@@ -2933,45 +2933,45 @@ def test_get_returnable_orders_by_subscription_id_no_renewal_for_period(
         order_id="order_ko_0",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-06T00:00:00Z",
     )
     order_ok_1 = adobe_order_factory(
         order_id="order_ok_1",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-07T00:00:00Z",
     )
     order_ok_2 = adobe_order_factory(
         order_id="order_ok_2",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3000", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3000", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-08T00:00:00Z",
     )
     order_ko_1 = adobe_order_factory(
         order_id="order_ko_1",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3001", status=AdobeStatus.ORDER_CANCELLED.value
+            subscription_id="SUB-1000-2000-3001", status=AdobeOrderStatus.CANCELLED.value
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-09T00:00:00Z",
     )
     order_ko_2 = adobe_order_factory(
         order_id="order_ko_2",
         order_type=ORDER_TYPE_NEW,
         items=adobe_items_factory(
-            subscription_id="SUB-1000-2000-3002", status=AdobeStatus.PROCESSED.value
+            subscription_id="SUB-1000-2000-3002", status=AdobeOrderStatus.COMPLETE.value
         ),
-        status=AdobeStatus.ORDER_CANCELLED.value,
+        status=AdobeOrderStatus.CANCELLED.value,
     )
     # for another sku
     order_ko_3 = adobe_order_factory(
@@ -2980,9 +2980,9 @@ def test_get_returnable_orders_by_subscription_id_no_renewal_for_period(
         items=adobe_items_factory(
             subscription_id="SUB-1000-2000-3003",
             offer_id="99999999CA01A12",
-            status=AdobeStatus.PROCESSED.value,
+            status=AdobeOrderStatus.COMPLETE.value,
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         creation_date="2024-01-10T00:00:00Z",
     )
     mocked_get_orders = mocker.patch.object(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,12 @@ from mpt_extension_sdk.runtime.djapp.conf import get_for_product
 
 from adobe_vipm.adobe import config
 from adobe_vipm.adobe.client import AdobeClient
-from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW, AdobeStatus, OfferType
+from adobe_vipm.adobe.constants import (
+    ORDER_TYPE_PREVIEW,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
+    OfferType,
+)
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization
 from adobe_vipm.airtable.models import (
     AdobeProductNotFoundError,
@@ -1582,7 +1587,7 @@ def adobe_order_factory(adobe_items_factory, adobe_pricing_factory):  # noqa: C9
             order["referenceOrderId"] = reference_order_id
         if status:
             order["status"] = status
-        if status in {AdobeStatus.PENDING.value, AdobeStatus.PROCESSED.value} or order_id:
+        if status in {AdobeOrderStatus.OPEN.value, AdobeOrderStatus.COMPLETE.value} or order_id:
             order["orderId"] = order_id or "P0123456789"
         if creation_date:
             order["creationDate"] = creation_date
@@ -1602,7 +1607,7 @@ def adobe_subscription_factory():
         currency_code="USD",
         autorenewal_enabled=True,  # noqa: FBT002
         deployment_id="",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeSubscriptionStatus.ACTIVE.value,
         renewal_date=None,
     ):
         default_renewal_date = dt.date.fromisoformat("2025-10-10") + dt.timedelta(days=366)
@@ -1688,7 +1693,7 @@ def adobe_transfer_factory(adobe_items_factory):
     def _transfer(
         transfer_id="a-transfer-id",
         customer_id="",
-        status=AdobeStatus.PENDING.value,
+        status=AdobeOrderStatus.OPEN.value,
         items=None,
         membership_id="membership-id",
     ):

--- a/tests/flows/conftest.py
+++ b/tests/flows/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from mpt_extension_sdk.mpt_http.mpt import get_agreements_by_query
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.flows.sync.agreement import AgreementSyncer
 from adobe_vipm.flows.sync.price_manager import PriceManager
 from adobe_vipm.flows.sync.subscription import SubscriptionSyncer
@@ -179,7 +179,7 @@ def mocked_agreement_syncer(
         adobe_subscription_factory(
             subscription_id="55feb5038045e0b1ebf026e7522e17NA",
             offer_id="65304578CA01A12",
-            status=AdobeStatus.SUBSCRIPTION_TERMINATED,
+            status=AdobeSubscriptionStatus.INACTIVE,
         ),
         adobe_subscription_factory(
             subscription_id="1e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65304578CA01A12"

--- a/tests/flows/fulfillment/test_change.py
+++ b/tests/flows/fulfillment/test_change.py
@@ -1,7 +1,7 @@
 import pytest
 from freezegun import freeze_time
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode, AdobeOrderStatus
 from adobe_vipm.adobe.dataclasses import ReturnableOrderInfo
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
@@ -521,7 +521,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state(
     mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            AdobeStatus.SUBSCRIPTION_INACTIVE.value,
+            AdobeErrorCode.INACTIVE_SUBSCRIPTION_NOT_EDITABLE.value,
             "Inactive Subscription or Pending Renewal is not Editable",
         ),
     )
@@ -570,7 +570,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state_ok(
     mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            AdobeStatus.INVALID_RENEWAL_STATE.value,
+            AdobeErrorCode.INVALID_RENEWAL_STATE.value,
             "Update could not be performed because it would create an invalid renewal state",
         ),
     )
@@ -610,7 +610,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state_order_ok(
         adobe_customer_id="adobe-customer-id",
         adobe_new_order=adobe_order_factory(
             order_type="NEW",
-            status=AdobeStatus.PROCESSED.value,
+            status=AdobeOrderStatus.COMPLETE.value,
         ),
     )
     adobe_sub = adobe_subscription_factory(renewal_quantity=10)
@@ -618,7 +618,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state_order_ok(
     mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            AdobeStatus.INVALID_RENEWAL_STATE.value,
+            AdobeErrorCode.INVALID_RENEWAL_STATE.value,
             "Update could not be performed because it would create an invalid renewal state",
         ),
     )
@@ -658,7 +658,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state_order_failed(
         adobe_customer_id="adobe-customer-id",
         adobe_new_order=adobe_order_factory(
             order_type="NEW",
-            status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value,
+            status=AdobeOrderStatus.FAILED.value,
         ),
     )
     adobe_sub = adobe_subscription_factory(renewal_quantity=10)
@@ -666,7 +666,7 @@ def test_validate_update_renewal_quantity_invalid_renewal_state_order_failed(
     mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            AdobeStatus.INVALID_RENEWAL_STATE.value,
+            AdobeErrorCode.INVALID_RENEWAL_STATE.value,
             "Update could not be performed because it would create an invalid renewal state",
         ),
     )

--- a/tests/flows/fulfillment/test_purchase.py
+++ b/tests/flows/fulfillment/test_purchase.py
@@ -1,6 +1,6 @@
 import pytest
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
     ERR_3YC_NO_MINIMUMS,
@@ -417,7 +417,7 @@ def test_create_customer_step_handle_error_address(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.INVALID_ADDRESS.value,
+            code=AdobeErrorCode.INVALID_ADDRESS.value,
             message="Invalid address",
             details=["detail1", "detail2"],
         ),
@@ -441,7 +441,7 @@ def test_create_customer_step_handle_error_3yc_minimum_quantity_licenses(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.INVALID_MINIMUM_QUANTITY.value,
+            code=AdobeErrorCode.INVALID_MINIMUM_QUANTITY.value,
             message="Minimum quantity out of range",
             details=["LICENSE"],
         ),
@@ -467,7 +467,7 @@ def test_create_customer_step_handle_error_3yc_minimum_quantity_consumables(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.INVALID_MINIMUM_QUANTITY.value,
+            code=AdobeErrorCode.INVALID_MINIMUM_QUANTITY.value,
             message="Minimum quantity out of range",
             details=["CONSUMABLES"],
         ),
@@ -493,7 +493,7 @@ def test_create_customer_step_handle_error_3yc_minimum_quantity_no_minimums(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.INVALID_MINIMUM_QUANTITY.value,
+            code=AdobeErrorCode.INVALID_MINIMUM_QUANTITY.value,
             message="Minimum quantity out of range",
             details=[],
         ),
@@ -534,7 +534,7 @@ def test_create_customer_step_handle_error_invalid_fields(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.INVALID_FIELDS.value,
+            code=AdobeErrorCode.INVALID_FIELDS.value,
             message="Invalid fields",
             details=[error_details],
         ),

--- a/tests/flows/fulfillment/test_reseller_change.py
+++ b/tests/flows/fulfillment/test_reseller_change.py
@@ -1,4 +1,4 @@
-from adobe_vipm.adobe.constants import AdobeStatus, ResellerChangeAction
+from adobe_vipm.adobe.constants import AdobeOrderStatus, ResellerChangeAction
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import TEMPLATE_NAME_TRANSFER
 from adobe_vipm.flows.context import Context
@@ -146,7 +146,7 @@ def test_check_adobe_reseller_transfer_step_success(
     mock_adobe_client,
 ):
     adobe_transfer_order = adobe_reseller_change_factory()
-    adobe_transfer_order["status"] = AdobeStatus.PROCESSED
+    adobe_transfer_order["status"] = AdobeOrderStatus.COMPLETE
     mock_adobe_client.get_reseller_transfer.return_value = adobe_transfer_order
     mocker.patch(
         "adobe_vipm.flows.fulfillment.reseller_transfer.get_adobe_client",
@@ -181,7 +181,7 @@ def test_check_adobe_reseller_transfer_step_pending_status(
     mock_adobe_client,
 ):
     adobe_transfer_order = adobe_reseller_change_factory()
-    adobe_transfer_order["status"] = AdobeStatus.PENDING
+    adobe_transfer_order["status"] = AdobeOrderStatus.OPEN
     mock_adobe_client.get_reseller_transfer.return_value = adobe_transfer_order
     mocker.patch(
         "adobe_vipm.flows.fulfillment.reseller_transfer.get_adobe_client",
@@ -239,7 +239,7 @@ def test_check_adobe_reseller_transfer_step_no_line_items_fallback_to_purchase(
     mock_fulfill_purchase_order,
 ):
     adobe_transfer_order = adobe_reseller_change_preview_factory()
-    adobe_transfer_order["status"] = AdobeStatus.PROCESSED
+    adobe_transfer_order["status"] = AdobeOrderStatus.COMPLETE
     adobe_transfer_order["lineItems"] = []
     order = order_factory(
         order_parameters=reseller_change_order_parameters_factory(),
@@ -266,7 +266,7 @@ def test_check_adobe_reseller_transfer_step_reset_order_id_when_ids_match(
     mock_fulfill_purchase_order,
 ):
     adobe_transfer_order = adobe_reseller_change_preview_factory()
-    adobe_transfer_order["status"] = AdobeStatus.PROCESSED
+    adobe_transfer_order["status"] = AdobeOrderStatus.COMPLETE
     adobe_transfer_order["lineItems"] = []
     adobe_transfer_order["transferId"] = "TRANSFER-123"
     mocked_save_adobe_order_id = mocker.patch(

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -11,7 +11,8 @@ from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW,
     ORDER_TYPE_PREVIEW_RENEWAL,
     ORDER_TYPE_RENEWAL,
-    AdobeStatus,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
 )
 from adobe_vipm.adobe.dataclasses import ReturnableOrderInfo
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError
@@ -581,7 +582,7 @@ def test_submit_return_orders_step(
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
         items=adobe_items_factory(quantity=1),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     ret_info_1 = ReturnableOrderInfo(
         adobe_order_1,
@@ -590,7 +591,7 @@ def test_submit_return_orders_step(
     )
     sku = adobe_order_1["lineItems"][0]["offerId"][:10]
     mock_adobe_client.create_return_order.return_value = adobe_order_factory(
-        order_type="RETURN", status=AdobeStatus.PENDING.value
+        order_type="RETURN", status=AdobeOrderStatus.OPEN.value
     )
     context = Context(
         order=mock_order,
@@ -637,7 +638,7 @@ def test_submit_return_orders_step_change_order_persists_adobe_order_ids(
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
         items=adobe_items_factory(quantity=1),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     ret_info_1 = ReturnableOrderInfo(
         adobe_order_1,
@@ -648,7 +649,7 @@ def test_submit_return_orders_step_change_order_persists_adobe_order_ids(
     mock_adobe_client.create_return_order.return_value = adobe_order_factory(
         order_type="RETURN",
         order_id="return-order-id",
-        status=AdobeStatus.PENDING.value,
+        status=AdobeOrderStatus.OPEN.value,
     )
     order = order_factory(
         order_type="Change", fulfillment_parameters=fulfillment_parameters_factory()
@@ -700,7 +701,7 @@ def test_submit_return_orders_step_with_deployment_id(
             deployment_id=deployment_id,
             deployment_currency_code="USD",
         ),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         deployment_id=deployment_id,
     )
     ret_info_1 = ReturnableOrderInfo(
@@ -710,7 +711,7 @@ def test_submit_return_orders_step_with_deployment_id(
     )
     sku = adobe_order_1["lineItems"][0]["offerId"][:10]
     mock_adobe_client.create_return_order.return_value = adobe_order_factory(
-        order_type="RETURN", status=AdobeStatus.PENDING.value, deployment_id=deployment_id
+        order_type="RETURN", status=AdobeOrderStatus.OPEN.value, deployment_id=deployment_id
     )
     order = order_factory(deployment_id=deployment_id)
     context = Context(
@@ -757,7 +758,7 @@ def test_submit_return_orders_step_with_only_main_deployment_id(
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
         items=adobe_items_factory(quantity=1),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         deployment_id=deployment_id,
     )
     ret_info_1 = ReturnableOrderInfo(
@@ -768,7 +769,7 @@ def test_submit_return_orders_step_with_only_main_deployment_id(
     sku = adobe_order_1["lineItems"][0]["offerId"][:10]
     mock_adobe_client.create_return_order.return_value = adobe_order_factory(
         order_type="RETURN",
-        status=AdobeStatus.PENDING.value,
+        status=AdobeOrderStatus.OPEN.value,
     )
     order = order_factory(deployment_id="deployment-id_return")
     context = Context(
@@ -804,7 +805,7 @@ def test_submit_return_orders_step_order_processed(
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
         items=adobe_items_factory(quantity=1),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     ret_info_1 = ReturnableOrderInfo(
         adobe_order_1,
@@ -814,7 +815,7 @@ def test_submit_return_orders_step_order_processed(
     sku = adobe_order_1["lineItems"][0]["offerId"][:10]
     return_order = adobe_order_factory(
         order_type="RETURN",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         reference_order_id=adobe_order_1["orderId"],
     )
     context = Context(
@@ -856,7 +857,7 @@ def test_submit_return_orders_step_error_creating_return_order(
     adobe_order_1 = adobe_order_factory(
         order_type="NEW",
         items=adobe_items_factory(quantity=1),
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     ret_info_1 = ReturnableOrderInfo(
         adobe_order_1,
@@ -898,7 +899,7 @@ def test_submit_new_order_step(
 ):
     order = order_factory(deployment_id=None)
     preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW)
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PENDING.value)
+    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.create_new_order.return_value = new_order
     mocked_update = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocked_next_step = mocker.MagicMock()
@@ -943,7 +944,7 @@ def test_submit_new_order_step_change_order_persists_adobe_order_ids(
     new_order = adobe_order_factory(
         order_type=ORDER_TYPE_NEW,
         order_id="new-order-id",
-        status=AdobeStatus.PENDING.value,
+        status=AdobeOrderStatus.OPEN.value,
     )
     mock_adobe_client.create_new_order.return_value = new_order
     mocked_next_step = mocker.MagicMock()
@@ -978,7 +979,9 @@ def test_submit_new_order_step_flex_discount(
 ):
     order = order_factory(deployment_id=None)
     preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW)
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PROCESSED.value)
+    new_order = adobe_order_factory(
+        order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.COMPLETE.value
+    )
     new_order["lineItems"][0].update({"flexDiscounts": [{"code": "BLACK"}]})
     mock_adobe_client.create_new_order.return_value = new_order
     mocked_next_step = mocker.MagicMock()
@@ -1019,7 +1022,7 @@ def test_submit_new_order_step_with_deployment_id(
     preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW, deployment_id=deployment_id)
     new_order = adobe_order_factory(
         order_type=ORDER_TYPE_NEW,
-        status=AdobeStatus.PENDING.value,
+        status=AdobeOrderStatus.OPEN.value,
         deployment_id=deployment_id,
     )
     mock_adobe_client.create_new_order.return_value = new_order
@@ -1064,7 +1067,7 @@ def test_submit_new_order_step_order_created_and_processed(
 ):
     new_order = adobe_order_factory(
         order_type="NEW",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     order = order_factory(external_ids={"vendor": new_order["orderId"]})
     mock_adobe_client.get_order.return_value = new_order
@@ -1110,7 +1113,7 @@ def test_submit_new_order_step_change_order_skips_ids_update_if_already_present(
     mock_adobe_client.get_order.return_value = adobe_order_factory(
         order_type=ORDER_TYPE_NEW,
         order_id=adobe_order_id,
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     mocked_client = mocker.MagicMock()
     mocked_next_step = mocker.MagicMock()
@@ -1138,7 +1141,7 @@ def test_submit_new_order_step_order_created_and_processed_with_deployment_id(
     deployment_id = "deployment-id"
     new_order = adobe_order_factory(
         order_type="NEW",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
     )
     order = order_factory(
         external_ids={"vendor": new_order["orderId"]}, deployment_id=deployment_id
@@ -1298,7 +1301,7 @@ def test_submit_new_order_step_order_created_unexpected_status(
 def test_get_return_orders_step(mocker, mock_adobe_client, mock_order, adobe_order_factory):
     return_order = adobe_order_factory(
         order_type="RETURN",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         reference_order_id="new-order-id",
     )
     mock_adobe_client.get_return_orders_by_external_reference.return_value = {
@@ -1568,7 +1571,7 @@ def test_create_or_update_asset_step_subscription_not_processed(
     adobe_order = adobe_order_factory(
         order_type=ORDER_TYPE_NEW, items=adobe_items_factory(subscription_id="adobe-sub-id")
     )
-    adobe_subscription = adobe_subscription_factory(status=AdobeStatus.PENDING.value)
+    adobe_subscription = adobe_subscription_factory(status=AdobeSubscriptionStatus.PENDING.value)
     mock_adobe_client.get_subscription.return_value = adobe_subscription
     mocker.patch(
         "adobe_vipm.flows.fulfillment.shared.get_one_time_skus",
@@ -1775,7 +1778,7 @@ def test_create_or_update_subscriptions_step_sub_expired(
         items=adobe_items_factory(subscription_id="adobe-sub-id"),
     )
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.ORDER_CANCELLED.value,
+        status=AdobeSubscriptionStatus.INACTIVE.value,
     )
     mock_adobe_client.get_subscription.return_value = adobe_subscription
     mocker.patch("adobe_vipm.flows.fulfillment.shared.get_one_time_skus", return_value=[])
@@ -3582,7 +3585,7 @@ def test_preview_renewal_orders_preview_created(
     ext_ref = f"{order['id']}_RENEWAL"
     preview_order = adobe_order_factory(
         order_type="PREVIEW_RENEWAL",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id=ext_ref,
     )
     mock_adobe_client.create_renewal_order.return_value = preview_order
@@ -3722,7 +3725,7 @@ def test_preview_renewal_orders_existing_order_skips_preview(
     existing_order = {
         "externalReferenceId": ext_ref,
         "orderId": "EXISTING-ORDER-001",
-        "status": AdobeStatus.PROCESSED.value,
+        "status": AdobeOrderStatus.COMPLETE.value,
         "orderType": "RENEWAL",
         "lineItems": [],
     }
@@ -3777,18 +3780,18 @@ def test_submit_renewal_orders_renewal_completed(
     ext_ref = f"{order['id']}_RENEWAL"
     preview_order = adobe_order_factory(
         order_type="PREVIEW_RENEWAL",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id=ext_ref,
     )
     renewal_order = adobe_order_factory(
         order_type="RENEWAL",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id=ext_ref,
     )
     # Unrelated order that does not match the exact ext_ref
     unrelated_order = adobe_order_factory(
         order_type="RENEWAL",
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         external_id="OTHER_ORDER_RENEWAL",
     )
     mock_adobe_client.get_orders.return_value = [unrelated_order]
@@ -3844,7 +3847,7 @@ def test_submit_renewal_orders_order_creation_failed(
     )
     order = order_factory(lines=lines_factory(quantity=5))
     preview_order = adobe_order_factory(
-        order_type="PREVIEW_RENEWAL", status=AdobeStatus.PROCESSED.value
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
     )
     mock_adobe_client.get_orders.return_value = []
     mock_adobe_client.create_renewal_order.return_value = preview_order
@@ -3886,9 +3889,9 @@ def test_submit_renewal_orders_pending(
     mocked_next_step = mocker.MagicMock()
     order = order_factory(lines=lines_factory(quantity=5))
     preview_order = adobe_order_factory(
-        order_type="PREVIEW_RENEWAL", status=AdobeStatus.PROCESSED.value
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
     )
-    renewal_order = adobe_order_factory(order_type="RENEWAL", status=AdobeStatus.PENDING.value)
+    renewal_order = adobe_order_factory(order_type="RENEWAL", status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.get_orders.return_value = []
     mock_adobe_client.create_renewal_order.return_value = preview_order
     mock_adobe_client.create_renewal_order.return_value = renewal_order
@@ -3924,7 +3927,7 @@ def test_submit_renewal_orders_unexpected_status(
     order = order_factory(lines=lines_factory(quantity=5))
     ext_ref = f"{order['id']}_RENEWAL"
     preview_order = adobe_order_factory(
-        order_type="PREVIEW_RENEWAL", status=AdobeStatus.PROCESSED.value
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
     )
     # Create a renewal order manually with an unexpected status (not PROCESSED, not PENDING)
     renewal_order = {
@@ -3976,7 +3979,7 @@ def test_submit_renewal_orders_existing_order_reused(
     existing_order = {
         "externalReferenceId": ext_ref,
         "orderId": "EXISTING-ORDER-001",
-        "status": AdobeStatus.PROCESSED.value,
+        "status": AdobeOrderStatus.COMPLETE.value,
         "orderType": "RENEWAL",
         "lineItems": [],
     }

--- a/tests/flows/fulfillment/test_transfer.py
+++ b/tests/flows/fulfillment/test_transfer.py
@@ -7,8 +7,9 @@ from freezegun import freeze_time
 from adobe_vipm.adobe.constants import (
     ORDER_TYPE_NEW,
     ORDER_TYPE_PREVIEW,
-    UNRECOVERABLE_TRANSFER_STATUSES,
-    AdobeStatus,
+    AdobeErrorCode,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
     ThreeYearCommitmentStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeHttpError
@@ -24,7 +25,6 @@ from adobe_vipm.flows.constants import (
     ERR_ADOBE_GOVERNMENT_VALIDATE_IS_NOT_LGA,
     ERR_ADOBE_MEMBERSHIP_ID,
     ERR_ADOBE_MEMBERSHIP_NOT_FOUND,
-    ERR_ADOBE_TRANSFER_PREVIEW,
     ERR_DUE_DATE_REACHED,
     ERR_MEMBERSHIP_HAS_BEEN_TRANSFERED,
     ERR_MEMBERSHIP_ITEMS_DONT_MATCH,
@@ -96,7 +96,7 @@ def test_transfer(
         return_value=None,
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -113,7 +113,7 @@ def test_transfer(
     adobe_customer = adobe_customer_factory()
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False
@@ -1184,7 +1184,7 @@ def test_transfer_with_no_profile_address(
         return_value=None,
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -1201,7 +1201,7 @@ def test_transfer_with_no_profile_address(
     adobe_customer = adobe_customer_factory(company_profile_address_exists=False)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False
@@ -1865,7 +1865,7 @@ def test_transfer_not_ready(
         return_value=None,
     )
     mocker.patch("adobe_vipm.flows.helpers.get_agreement", return_value=agreement)
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value)
+    adobe_transfer = adobe_transfer_factory(status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.create_transfer.return_value = adobe_transfer
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
@@ -1914,7 +1914,7 @@ def test_transfer_reached_due_date(
         return_value=None,
     )
     mocker.patch("adobe_vipm.flows.helpers.get_agreement", return_value=agreement)
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value)
+    adobe_transfer = adobe_transfer_factory(status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.create_transfer.return_value = adobe_transfer
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mocker.patch(
@@ -2048,8 +2048,8 @@ def test_transfer_items_mismatch(
 @pytest.mark.parametrize(
     "transfer_status",
     [
-        AdobeStatus.TRANSFER_INVALID_MEMBERSHIP.value,
-        AdobeStatus.TRANSFER_INVALID_MEMBERSHIP_OR_TRANSFER_IDS.value,
+        AdobeErrorCode.INVALID_MEMBERSHIP_ID.value,
+        AdobeErrorCode.INVALID_MEMBERSHIP_OR_TRANSFER_ID.value,
     ],
 )
 def test_transfer_invalid_membership(
@@ -2156,59 +2156,6 @@ def test_transfer_membership_not_found(
         order["id"],
         parameters=order["parameters"],
         template={"id": "TPL-964-112"},
-    )
-
-
-@pytest.mark.parametrize("transfer_status", UNRECOVERABLE_TRANSFER_STATUSES)
-def test_transfer_unrecoverable_status(
-    mocker,
-    mock_adobe_client,
-    agreement,
-    order_factory,
-    transfer_order_parameters_factory,
-    adobe_api_error_factory,
-    transfer_status,
-    mock_sync_agreements_by_agreement_ids,
-    mock_mpt_client,
-):
-    mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.get_transfer_by_authorization_membership_or_customer",
-        return_value=None,
-    )
-    mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.get_gc_main_agreement",
-        return_value=None,
-    )
-    mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.get_gc_agreement_deployments_by_main_agreement",
-        return_value=None,
-    )
-    mocker.patch("adobe_vipm.flows.helpers.get_agreement", return_value=agreement)
-    adobe_error = AdobeAPIError(400, adobe_api_error_factory(transfer_status, "some error"))
-    mock_adobe_client.preview_transfer.side_effect = adobe_error
-    mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.get_adobe_client", return_value=mock_adobe_client
-    )
-    mocker.patch("adobe_vipm.flows.fulfillment.transfer.get_gc_main_agreement", return_value=None)
-    mocker.patch(
-        "adobe_vipm.flows.fulfillment.transfer.get_gc_agreement_deployments_by_main_agreement",
-        return_value=None,
-    )
-    mocked_fail_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.fail_order")
-    order = order_factory(order_parameters=transfer_order_parameters_factory())
-
-    fulfill_order(mock_mpt_client, order)  # act
-
-    authorization_id = order["authorization"]["id"]
-    mock_adobe_client.preview_transfer.assert_called_once_with(authorization_id, "a-membership-id")
-    mocked_fail_order.assert_called_once_with(
-        mock_mpt_client,
-        order["id"],
-        ERR_ADOBE_TRANSFER_PREVIEW.to_dict(error=str(adobe_error)),
-        parameters=order["parameters"],
-    )
-    mock_sync_agreements_by_agreement_ids.assert_called_once_with(
-        mock_mpt_client, mock_adobe_client, [agreement["id"]], dry_run=False, sync_prices=False
     )
 
 
@@ -2901,9 +2848,11 @@ def test_fulfill_transfer_order_already_migrated_(
     mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocker.patch("adobe_vipm.flows.fulfillment.shared.complete_order")
     transfer_items = adobe_items_factory(subscription_id="sub-id")
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value, items=transfer_items)
+    adobe_transfer = adobe_transfer_factory(
+        status=AdobeOrderStatus.OPEN.value, items=transfer_items
+    )
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.PENDING.value, current_quantity=170
+        status=AdobeSubscriptionStatus.PENDING.value, current_quantity=170
     )
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
@@ -3091,7 +3040,7 @@ def test_transfer_3yc_customer(
         return_value=None,
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id"),
     )
@@ -3772,7 +3721,7 @@ def test_transfer_3yc_customer_with_no_profile_address(
         return_value=None,
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id"),
     )
@@ -4456,11 +4405,11 @@ def test_fulfill_transfer_order_already_migrated_all_items_expired_create_new_or
     )
     transfer_items = adobe_items_factory(
         subscription_id="sub-id",
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value,
+        status=AdobeSubscriptionStatus.INACTIVE.value,
         offer_id="65304990CA",
     )
     adobe_transfer = adobe_transfer_factory(items=transfer_items)
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PENDING.value)
+    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
     adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW)
@@ -4594,7 +4543,7 @@ def test_fulfill_transfer_order_already_migrated_empty_adobe_items(
     )
     adobe_transfer = adobe_transfer_factory()
     adobe_transfer["lineItems"] = []
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PENDING.value)
+    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
     adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW)
@@ -4719,7 +4668,7 @@ def test_transfer_gc_account_all_deployments_created(
         return_value=[mocked_gc_agreement_deployments_by_main_agreement],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -4736,7 +4685,7 @@ def test_transfer_gc_account_all_deployments_created(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False
@@ -5647,7 +5596,7 @@ def test_transfer_gc_account_no_deployments(
         return_value=[],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -5664,7 +5613,7 @@ def test_transfer_gc_account_no_deployments(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False
@@ -6169,7 +6118,7 @@ def test_transfer_gc_account_create_deployments(
         return_value="link",
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -6181,7 +6130,7 @@ def test_transfer_gc_account_create_deployments(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         subscription_id="one-time-sub-id",
@@ -6301,7 +6250,7 @@ def test_transfer_gc_account_create_deployments_bulk_migrated_agreement(
         return_value="link",
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -6313,7 +6262,7 @@ def test_transfer_gc_account_create_deployments_bulk_migrated_agreement(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         subscription_id="one-time-sub-id",
@@ -6418,7 +6367,7 @@ def test_transfer_gc_account_pending_deployments(
     mocked_gc_main_agreement.main_agreement_id = "main-agreement-id"
     mocked_gc_main_agreement.status = STATUS_GC_PENDING
     mocked_gc_agreement_deployments_by_main_agreement = mocker.MagicMock()
-    mocked_gc_agreement_deployments_by_main_agreement.status = AdobeStatus.PENDING.value
+    mocked_gc_agreement_deployments_by_main_agreement.status = "1002"
     mocked_gc_agreement_deployments_by_main_agreement.deployment_id = "deployment-id"
     mocker.patch(
         "adobe_vipm.flows.fulfillment.transfer.get_gc_main_agreement",
@@ -6429,7 +6378,7 @@ def test_transfer_gc_account_pending_deployments(
         return_value=[mocked_gc_agreement_deployments_by_main_agreement],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -6491,7 +6440,7 @@ def test_transfer_gc_account_main_agreement_error_status(
         return_value=[],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -6565,7 +6514,7 @@ def test_transfer_gc_account_some_deployments_not_created(
         return_value="link",
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(
             subscription_id="a-sub-id",
@@ -6596,7 +6545,7 @@ def test_transfer_gc_account_some_deployments_not_created(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(subscription_id="one-time-sub-id")
     mock_adobe_client.preview_transfer.return_value = adobe_transfer_preview
@@ -6775,9 +6724,11 @@ def test_fulfill_transfer_gc_order_already_migrated_(
     mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocker.patch("adobe_vipm.flows.fulfillment.shared.complete_order")
     transfer_items = adobe_items_factory(subscription_id="sub-id")
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value, items=transfer_items)
+    adobe_transfer = adobe_transfer_factory(
+        status=AdobeOrderStatus.OPEN.value, items=transfer_items
+    )
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.PENDING.value, current_quantity=170
+        status=AdobeSubscriptionStatus.PENDING.value, current_quantity=170
     )
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
@@ -6926,9 +6877,13 @@ def test_fulfill_transfer_gc_order_already_migrated_no_items_without_deployment(
     mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     mocker.patch("adobe_vipm.flows.fulfillment.shared.complete_order")
     transfer_items = adobe_items_factory(subscription_id="sub-id", deployment_id="deployment-id")
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value, items=transfer_items)
+    adobe_transfer = adobe_transfer_factory(
+        status=AdobeOrderStatus.OPEN.value, items=transfer_items
+    )
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.PENDING.value, current_quantity=170, deployment_id="deployment-id"
+        status=AdobeSubscriptionStatus.PENDING.value,
+        current_quantity=170,
+        deployment_id="deployment-id",
     )
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
@@ -7045,7 +7000,7 @@ def test_transfer_gc_account_items_with_deployment_main_agreement(
         return_value=[mocked_gc_agreement_deployments_by_main_agreement],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id", deployment_id="deployment-id"),
     )
@@ -7151,7 +7106,7 @@ def test_transfer_gc_account_items_with_deployment_main_agreement_bulk_migrated(
         return_value=[mocked_gc_agreement_deployments_by_main_agreement],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id", deployment_id="deployment-id"),
     )
@@ -7238,7 +7193,7 @@ def test_transfer_not_ready_not_commercial(
     )
     agreement["product"]["id"] = "PRD-2222-2222"
     mocker.patch("adobe_vipm.flows.helpers.get_agreement", return_value=agreement)
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.PENDING.value)
+    adobe_transfer = adobe_transfer_factory(status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.create_transfer.return_value = adobe_transfer
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
@@ -7308,7 +7263,7 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
         return_value=[],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -7325,7 +7280,7 @@ def test_transfer_gc_account_no_deployments_gc_parameters_updated(
     adobe_customer = adobe_customer_factory(global_sales_enabled=True)
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False
@@ -8055,7 +8010,7 @@ def test_transfer_gc_account_items_with_and_without_deployment_main_agreement_bu
         return_value=[mocked_gc_agreement_deployments_by_main_agreement],
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(
             offer_id="65304578CACA01A12",
@@ -8225,7 +8180,7 @@ def test_fulfill_transfer_migrated_order_all_items_expired_add_new_item(
     )
     transfer_items = adobe_items_factory(
         subscription_id="inactive-sub-id",
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value,
+        status=AdobeSubscriptionStatus.INACTIVE.value,
         offer_id="65304999CA",
     ) + adobe_items_factory(
         subscription_id="one-time-sub-id",
@@ -8234,14 +8189,14 @@ def test_fulfill_transfer_migrated_order_all_items_expired_add_new_item(
     adobe_subscription = adobe_subscription_factory(offer_id="65304578CA2", current_quantity=170)
     adobe_inactive_subscription = adobe_subscription_factory(
         subscription_id="inactive-sub-id",
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value,
+        status=AdobeSubscriptionStatus.INACTIVE.value,
         offer_id="65304999CA",
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         subscription_id="one-time-sub-id", offer_id="99999999CA01A12"
     )
     adobe_transfer = adobe_transfer_factory(items=transfer_items)
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PENDING.value)
+    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.OPEN.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = adobe_customer
     mock_adobe_client.get_subscriptions.return_value = {
@@ -8322,7 +8277,7 @@ def test_fulfill_transfer_migrated_order_offer_id_expired(
     transfer_items = adobe_items_factory(subscription_id="inactive-sub-id", offer_id="65304999CA")
     adobe_subscription = adobe_subscription_factory(offer_id="65304578CA2", current_quantity=170)
     adobe_transfer = adobe_transfer_factory(items=transfer_items)
-    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeStatus.PENDING.value)
+    new_order = adobe_order_factory(order_type=ORDER_TYPE_NEW, status=AdobeOrderStatus.OPEN.value)
     adobe_preview_order = adobe_order_factory(ORDER_TYPE_PREVIEW)
     mocker.patch("adobe_vipm.flows.helpers.get_agreement", return_value=agreement)
     mocker.patch(
@@ -8549,7 +8504,7 @@ def test_transfer_lga_product_with_lga_agency_type(
         return_value=None,
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value,
+        status=AdobeOrderStatus.COMPLETE.value,
         customer_id="a-client-id",
         items=adobe_items_factory(subscription_id="a-sub-id")
         + adobe_items_factory(line_number=2, subscription_id="inactive-sub-id")
@@ -8569,7 +8524,7 @@ def test_transfer_lga_product_with_lga_agency_type(
     adobe_customer["companyProfile"]["marketSubSegments"] = ["STATE"]
     adobe_subscription = adobe_subscription_factory()
     adobe_inactive_subscription = adobe_subscription_factory(
-        subscription_id="inactive-sub-id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+        subscription_id="inactive-sub-id", status=AdobeSubscriptionStatus.INACTIVE.value
     )
     adobe_one_time_subscription = adobe_subscription_factory(
         offer_id="99999999CA01A12", subscription_id="one-time-sub-id", autorenewal_enabled=False

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -5,7 +5,11 @@ import pytest
 from freezegun import freeze_time
 
 from adobe_vipm.adobe import constants
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import (
+    AdobeDeploymentStatus,
+    AdobeErrorCode,
+    AdobeSubscriptionStatus,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AuthorizationNotFoundError
 from adobe_vipm.airtable.models import AirTableBaseInfo, get_gc_agreement_deployment_model
 from adobe_vipm.flows.constants import (
@@ -2309,7 +2313,7 @@ def test_sync_agreement_empty_discounts(
     adobe_subscription = adobe_subscription_factory(
         subscription_id="terminated-sub-id",
         offer_id="77777777CA01A12",
-        status=AdobeStatus.SUBSCRIPTION_TERMINATED,
+        status=AdobeSubscriptionStatus.INACTIVE,
     )
     mocked_agreement_syncer._adobe_subscriptions = [adobe_subscription]
     mock_adobe_client.get_subscriptions.return_value = {"items": [adobe_subscription]}
@@ -2748,7 +2752,7 @@ def test_sync_agreement_lost_customer(
     mock_mpt_get_agreement,
 ):
     mock_adobe_client.get_customer.side_effect = AdobeAPIError(
-        status_code=int(AdobeStatus.INVALID_CUSTOMER.value),
+        status_code=int(AdobeErrorCode.INVALID_CUSTOMER.value),
         payload={"code": "1116", "message": "Invalid Customer", "additionalDetails": []},
     )
     agreement = agreement_factory()
@@ -2792,7 +2796,7 @@ def test_sync_agreement_lost_customer_error(
     mock_mpt_get_agreement,
 ):
     mock_adobe_client.get_customer.side_effect = AdobeAPIError(
-        status_code=int(AdobeStatus.INVALID_CUSTOMER.value),
+        status_code=int(AdobeErrorCode.INVALID_CUSTOMER.value),
         payload={"code": "1116", "message": "Invalid Customer", "additionalDetails": []},
     )
     mock_mpt_terminate_subscription.side_effect = MPTAPIError(
@@ -2872,7 +2876,7 @@ def test_get_subscriptions_for_update_skip_adobe_inactive(
     mocked_agreement_syncer,
 ):
     mocked_agreement_syncer._adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_TERMINATED.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     ]
 
     result = mocked_agreement_syncer._get_subscriptions_for_update(agreement_factory())
@@ -2896,7 +2900,7 @@ def test_get_subscriptions_for_update_terminated(
     mocked_agreement_syncer,
 ):
     adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_TERMINATED.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     ]
     mock_mpt_get_template_by_name.return_value = {"id": "TPL-1234", "name": "Expired"}
     mocked_agreement_syncer._adobe_subscriptions = adobe_subscriptions
@@ -2941,7 +2945,7 @@ def test_get_subscriptions_for_update_terminated_with_expired_template(
     mocked_agreement_syncer,
 ):
     mocked_agreement_syncer._adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_TERMINATED.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     ]
     mock_mpt_get_template_by_name.return_value = {"id": "TPL-1234", "name": "Expired"}
 
@@ -2985,7 +2989,7 @@ def test_get_subscriptions_for_update_terminated_without_template(
     mocked_agreement_syncer,
 ):
     mocked_agreement_syncer._adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_TERMINATED.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     ]
     mock_mpt_get_template_by_name.side_effect = [{"id": "TPL-1234", "name": "Expired"}, None]
 
@@ -3023,7 +3027,7 @@ def test_get_subscriptions_for_update_terminated_with_assigned_template(
     mocked_agreement_syncer,
 ):
     mocked_agreement_syncer._adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_TERMINATED.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     ]
     mock_get_template_data_by_adobe_subscription.side_effect = [
         {"id": "TPL-1234", "name": "Expired"}
@@ -3054,7 +3058,7 @@ def test_get_subscriptions_for_update_with_no_lines(
     mock_send_warning,
 ):
     mocked_agreement_syncer._adobe_subscriptions = [
-        adobe_subscription_factory(status=AdobeStatus.SUBSCRIPTION_ACTIVE.value)
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.ACTIVE.value)
     ]
     mock_get_template_data_by_adobe_subscription.side_effect = [
         {"id": "TPL-1234", "name": "Expired"}
@@ -3093,7 +3097,7 @@ def test_add_missing_subscriptions_none(
         adobe_subscription_factory(
             subscription_id="55feb5038045e0b1ebf026e7522e17NA",
             offer_id="65304578CA01A12",
-            status=AdobeStatus.SUBSCRIPTION_TERMINATED.value,
+            status=AdobeSubscriptionStatus.INACTIVE.value,
         ),
         adobe_subscription_factory(
             subscription_id="1e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65304578CA01A12"
@@ -3128,7 +3132,7 @@ def test_add_missing_subscriptions_without_vendor_id(
         adobe_subscription_factory(
             subscription_id="55feb5038045e0b1ebf026e7522e17NA",
             offer_id="65304578CA01A12",
-            status=AdobeStatus.SUBSCRIPTION_TERMINATED.value,
+            status=AdobeSubscriptionStatus.INACTIVE.value,
         ),
         adobe_subscription_factory(
             subscription_id="1e5b9c974c4ea1bcabdb0fe697a2f1NA", offer_id="65304578CA01A12"
@@ -3704,7 +3708,7 @@ def test_process_orphaned_deployment_subscriptions_error(
 
 @pytest.mark.parametrize(
     "subscription_status",
-    [AdobeStatus.SUBSCRIPTION_TERMINATED.value, AdobeStatus.PENDING.value],
+    [AdobeSubscriptionStatus.INACTIVE.value, AdobeSubscriptionStatus.PENDING.value],
 )
 def test_process_orphaned_deployment_subscriptions_skip_on_status(
     subscription_status,
@@ -3786,7 +3790,7 @@ def test_process_orphaned_deployment_subscriptions_skip_autorenewal_false_with_l
             subscription_id="no_autorenewal_subscription_id",
             deployment_id="deployment-id",
             autorenewal_enabled=False,
-            status=AdobeStatus.PROCESSED.value,
+            status=AdobeSubscriptionStatus.ACTIVE.value,
         ),
     ]
     mocked_agreement_syncer._adobe_customer = adobe_customer_factory(global_sales_enabled=True)
@@ -4375,7 +4379,7 @@ def test_get_customer_or_process_lost_customer_error(
     adobe_customer_factory,
 ):
     mock_adobe_client.get_customer.side_effect = [
-        AdobeAPIError(400, {"code": AdobeStatus.INVALID_CUSTOMER.value, "message": "Test error"})
+        AdobeAPIError(400, {"code": AdobeErrorCode.INVALID_CUSTOMER.value, "message": "Test error"})
     ]
     mock_adobe_client.get_customer_deployments_active_status.return_value = [
         {
@@ -4411,13 +4415,13 @@ def test_get_customer_or_process_lost_customer_deployment_error(
     adobe_customer_factory,
 ):
     mock_adobe_client.get_customer.side_effect = [
-        AdobeAPIError(400, {"code": AdobeStatus.INVALID_CUSTOMER.value, "message": "Test error"})
+        AdobeAPIError(400, {"code": AdobeErrorCode.INVALID_CUSTOMER.value, "message": "Test error"})
     ]
     mock_adobe_client.get_customer_deployments_active_status.side_effect = [
         AdobeAPIError(
             500,
             {
-                "code": AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value,
+                "code": AdobeDeploymentStatus.INACTIVE.value,
                 "message": "Inactive or generic failure",
             },
         )
@@ -4443,7 +4447,7 @@ def test_get_customer_or_process_lost_customer_dry_run(
     adobe_customer_factory,
 ):
     mock_adobe_client.get_customer.side_effect = [
-        AdobeAPIError(400, {"code": AdobeStatus.INVALID_CUSTOMER.value, "message": "Test error"})
+        AdobeAPIError(400, {"code": AdobeErrorCode.INVALID_CUSTOMER.value, "message": "Test error"})
     ]
     mock_adobe_client.get_customer_deployments_active_status.return_value = [
         {

--- a/tests/flows/test_global_customer.py
+++ b/tests/flows/test_global_customer.py
@@ -2,7 +2,7 @@ import datetime as dt
 
 import pytest
 
-from adobe_vipm.adobe.constants import AdobeStatus, ThreeYearCommitmentStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus, ThreeYearCommitmentStatus
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.airtable.models import STATUS_GC_ERROR, get_sku_price
 from adobe_vipm.flows.constants import TEMPLATE_ASSET_DEFAULT, ItemTermsModel, Param
@@ -746,7 +746,7 @@ def test_check_gc_agreement_deployments_create_asset(
             adobe_subscription_factory(deployment_id="deployment_id"),
             adobe_subscription_factory(deployment_id=""),
             adobe_subscription_factory(
-                deployment_id="deployment_id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+                deployment_id="deployment_id", status=AdobeSubscriptionStatus.INACTIVE.value
             ),
         ]
     }
@@ -827,7 +827,7 @@ def test_check_gc_agreement_deployments_agreement_asset_exists(
             adobe_subscription_factory(deployment_id="deployment_id"),
             adobe_subscription_factory(deployment_id=""),
             adobe_subscription_factory(
-                deployment_id="deployment_id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+                deployment_id="deployment_id", status=AdobeSubscriptionStatus.INACTIVE.value
             ),
         ]
     }
@@ -904,7 +904,7 @@ def test_check_gc_agreement_deployments_create_agreement_subscription(
             adobe_subscription_factory(deployment_id="deployment_id"),
             adobe_subscription_factory(deployment_id=""),
             adobe_subscription_factory(
-                deployment_id="deployment_id", status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
+                deployment_id="deployment_id", status=AdobeSubscriptionStatus.INACTIVE.value
             ),
         ]
     }

--- a/tests/flows/test_helpers.py
+++ b/tests/flows/test_helpers.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from adobe_vipm.adobe.constants import (
     ORDER_TYPE_NEW,
     ORDER_TYPE_PREVIEW,
-    AdobeStatus,
+    AdobeErrorCode,
     ResellerChangeAction,
     ThreeYearCommitmentStatus,
 )
@@ -188,7 +188,7 @@ def test_setup_context_step_when_adobe_get_customer_fails_with_internal_server_e
     adobe_client, _, _ = adobe_client_factory()
     authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
     adobe_api_error = adobe_api_error_factory(
-        code=AdobeStatus.INTERNAL_SERVER_ERROR.value,
+        code=AdobeErrorCode.INTERNAL_SERVER_ERROR.value,
         message="Internal Server Error",
     )
     requests_mocker.get(
@@ -252,7 +252,7 @@ def test_setup_context_step_when_adobe_get_customer_fails_with_lost_customer(  #
     adobe_client, _, _ = adobe_client_factory()
     authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
     adobe_api_error = adobe_api_error_factory(
-        code=AdobeStatus.INVALID_CUSTOMER.value,
+        code=AdobeErrorCode.INVALID_CUSTOMER.value,
         message="Invalid Customer",
     )
     requests_mocker.get(

--- a/tests/flows/test_migration.py
+++ b/tests/flows/test_migration.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pytest
 from freezegun import freeze_time
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeErrorCode, AdobeOrderStatus, AdobeSubscriptionStatus
 from adobe_vipm.adobe.errors import (
     AdobeAPIError,
     AuthorizationNotFoundError,
@@ -101,7 +101,7 @@ def test_start_transfers_for_product_preview_already_transferred(
     mock_adobe_client.preview_transfer.side_effect = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.TRANSFER_ALREADY_TRANSFERRED.value,
+            code=AdobeErrorCode.CUSTOMER_ALREADY_TRANSFERRED.value,
             message="Already transferred",
         ),
     )
@@ -140,7 +140,7 @@ def test_start_transfers_for_product_preview_recoverable_error(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.TRANSFER_INELIGIBLE.value,
+            code=AdobeErrorCode.INELIGIBLE_TRANSFER.value,
             message="Cannot be transferred",
             details=[f"Reason: {reason}"],
         ),
@@ -154,7 +154,7 @@ def test_start_transfers_for_product_preview_recoverable_error(
         mock_transfer.membership_id,
     )
     mock_transfer.save.assert_called_once()
-    assert mock_transfer.adobe_error_code == AdobeStatus.TRANSFER_INELIGIBLE.value
+    assert mock_transfer.adobe_error_code == AdobeErrorCode.INELIGIBLE_TRANSFER.value
     assert mock_transfer.adobe_error_description == str(error)
     assert mock_transfer.status == "rescheduled"
     assert mock_transfer.migration_error_description == (
@@ -179,7 +179,7 @@ def test_start_transfers_for_product_preview_unrecoverable_error(
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.TRANSFER_INELIGIBLE.value,
+            code=AdobeErrorCode.INELIGIBLE_TRANSFER.value,
             message="Cannot be transferred",
             details=["Reason: BAD_MARKET_SEGMENT"],
         ),
@@ -192,7 +192,7 @@ def test_start_transfers_for_product_preview_unrecoverable_error(
         mock_transfer.authorization_uk, mock_transfer.membership_id
     )
     mock_transfer.save.assert_called_once()
-    assert mock_transfer.adobe_error_code == AdobeStatus.TRANSFER_INELIGIBLE.value
+    assert mock_transfer.adobe_error_code == AdobeErrorCode.INELIGIBLE_TRANSFER.value
     assert mock_transfer.adobe_error_description == str(error)
     assert mock_transfer.status == "failed"
     assert mock_transfer.migration_error_description == (
@@ -205,7 +205,11 @@ def test_start_transfers_for_product_preview_unrecoverable_error(
         "for preview of transfer for Membership **membership-id**.",
         facts=FactsSection(
             title="Last error from Adobe",
-            data={"5117": "5117 - Cannot be transferred: Reason: BAD_MARKET_SEGMENT"},
+            data={
+                AdobeErrorCode.INELIGIBLE_TRANSFER.value: (
+                    "5117 - Cannot be transferred: Reason: BAD_MARKET_SEGMENT"
+                ),
+            },
         ),
         button=Button(label="membership-id", url="https://link.to.transfer"),
     )
@@ -390,7 +394,7 @@ def test_checking_running_transfers_for_product(
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -416,7 +420,7 @@ def test_checking_running_transfers_for_product(
         }
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -482,7 +486,7 @@ def test_checking_running_transfers_for_product_with_no_profile_address(
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -499,7 +503,7 @@ def test_checking_running_transfers_for_product_with_no_profile_address(
         }
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -555,7 +559,7 @@ def test_checking_running_transfers_for_product_3yc(
     mocker.patch("adobe_vipm.flows.migration.terminate_contract", return_value=(True, ""))
     mocker.patch("adobe_vipm.flows.migration.get_transfers_to_check", return_value=[mock_transfer])
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     commitment = adobe_commitment_factory(licenses=10, consumables=30)
     customer = adobe_customer_factory(commitment=commitment)
@@ -612,7 +616,7 @@ def test_checking_running_transfers_for_product_get_customer_error_retry(
     mock_transfer.reschedule_count = 0
     mocker.patch("adobe_vipm.flows.migration.get_transfers_to_check", return_value=[mock_transfer])
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     error = AdobeAPIError(400, adobe_api_error_factory(code="9999", message="Unexpected error"))
     mock_adobe_client.get_transfer.return_value = adobe_transfer
@@ -642,7 +646,7 @@ def test_checking_running_transfers_for_product_update_subs_error_retry(
     mock_transfer.customer_benefits_3yc_status = None
     mocker.patch("adobe_vipm.flows.migration.get_transfers_to_check", return_value=[mock_transfer])
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     error = AdobeAPIError(400, adobe_api_error_factory(code="9999", message="Unexpected error"))
     customer = {
@@ -730,7 +734,7 @@ def test_checking_running_transfers_for_product_pending_retry(
     mock_transfer.reschedule_count = 0
     mocker.patch("adobe_vipm.flows.migration.get_transfers_to_check", return_value=[mock_transfer])
     mock_adobe_client.get_transfer.return_value = adobe_transfer_factory(
-        status=AdobeStatus.PENDING.value
+        status=AdobeOrderStatus.OPEN.value
     )
 
     check_running_transfers_for_product("product-id")  # act
@@ -813,7 +817,7 @@ def test_checking_running_transfers_with_gc_exists_for_product(
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -847,7 +851,7 @@ def test_checking_running_transfers_with_gc_exists_for_product(
         "error_description": "",
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -916,7 +920,7 @@ def test_checking_running_transfers_with_gc_exists_for_product_with_no_profile_a
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -941,7 +945,7 @@ def test_checking_running_transfers_with_gc_exists_for_product_with_no_profile_a
         "error_description": "",
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -1009,7 +1013,7 @@ def test_checking_running_transfers_with_gc_not_exists_for_product(
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -1043,7 +1047,7 @@ def test_checking_running_transfers_with_gc_not_exists_for_product(
         "status": STATUS_GC_PENDING,
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -1116,7 +1120,7 @@ def test_checking_running_transfers_with_gc_not_exists_for_product_with_no_profi
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -1141,7 +1145,7 @@ def test_checking_running_transfers_with_gc_not_exists_for_product_with_no_profi
         "status": STATUS_GC_PENDING,
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -1218,7 +1222,7 @@ def test_checking_running_transfers_with_gc_not_exists_and_airtable_error_for_pr
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -1252,7 +1256,7 @@ def test_checking_running_transfers_with_gc_not_exists_and_airtable_error_for_pr
         "status": STATUS_GC_PENDING,
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -1340,7 +1344,7 @@ def test_checking_running_transfers_with_gc_not_exists_no_address_and_airtable_e
         return_value=(True, '200 - {"id": "whatever"}'),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = {
         "companyProfile": {
@@ -1365,7 +1369,7 @@ def test_checking_running_transfers_with_gc_not_exists_no_address_and_airtable_e
         "status": STATUS_GC_PENDING,
     }
     sub_active = adobe_subscription_factory()
-    sub_inactive = adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+    sub_inactive = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     mock_adobe_client.get_transfer.return_value = adobe_transfer
     mock_adobe_client.get_customer.return_value = customer
     mock_adobe_client.get_subscriptions.return_value = {"items": [sub_active, sub_inactive]}
@@ -1469,7 +1473,7 @@ def test_start_transfers_for_product_preview_recoverable_error_max_reschedules_e
     error = AdobeAPIError(
         400,
         adobe_api_error_factory(
-            code=AdobeStatus.TRANSFER_INELIGIBLE.value,
+            code=AdobeErrorCode.INELIGIBLE_TRANSFER.value,
             message="Cannot be transferred",
             details=["Reason: RETURNABLE_PURCHASE"],
         ),
@@ -1482,7 +1486,7 @@ def test_start_transfers_for_product_preview_recoverable_error_max_reschedules_e
         mock_transfer.authorization_uk, mock_transfer.membership_id
     )
     mock_transfer.save.assert_called_once()
-    assert mock_transfer.adobe_error_code == AdobeStatus.TRANSFER_INELIGIBLE.value
+    assert mock_transfer.adobe_error_code == AdobeErrorCode.INELIGIBLE_TRANSFER.value
     assert mock_transfer.adobe_error_description == str(error)
     assert mock_transfer.status == "failed"
     assert mock_transfer.reschedule_count == 15
@@ -1494,7 +1498,11 @@ def test_start_transfers_for_product_preview_recoverable_error_max_reschedules_e
         button=Button(label="membership-id", url="https://link.to.transfer"),
         facts=FactsSection(
             title="Last error from Adobe",
-            data={"5117": "5117 - Cannot be transferred: Reason: RETURNABLE_PURCHASE"},
+            data={
+                AdobeErrorCode.INELIGIBLE_TRANSFER.value: (
+                    "5117 - Cannot be transferred: Reason: RETURNABLE_PURCHASE"
+                ),
+            },
         ),
     )
 
@@ -1516,7 +1524,7 @@ def test_checking_running_transfers_for_product_terminate_contract_error(
         return_value=(False, "internal server error"),
     )
     adobe_transfer = adobe_transfer_factory(
-        status=AdobeStatus.PROCESSED.value, customer_id="customer-id"
+        status=AdobeOrderStatus.COMPLETE.value, customer_id="customer-id"
     )
     customer = adobe_customer_factory()
     mock_adobe_client.get_transfer.return_value = adobe_transfer

--- a/tests/flows/utils/test_utils.py
+++ b/tests/flows/utils/test_utils.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pytest
 from freezegun import freeze_time
 
-from adobe_vipm.adobe.constants import AdobeStatus
+from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.flows.utils import (
     get_customer_consumables_discount_level,
     get_customer_licenses_discount_level,
@@ -213,14 +213,14 @@ def test_is_transferring_item_expired(adobe_subscription_factory, adobe_items_fa
     assert (
         is_transferring_item_expired(
             adobe_subscription_factory(
-                status=AdobeStatus.PROCESSED.value, renewal_date=today.isoformat()
+                status=AdobeSubscriptionStatus.ACTIVE.value, renewal_date=today.isoformat()
             )
         )
         is False
     )
     assert (
         is_transferring_item_expired(
-            adobe_subscription_factory(status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value)
+            adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
         )
         is True
     )

--- a/tests/flows/validation/test_transfer.py
+++ b/tests/flows/validation/test_transfer.py
@@ -5,7 +5,9 @@ import pytest
 from mpt_extension_sdk.mpt_http.wrap_http_error import MPTAPIError
 
 from adobe_vipm.adobe.constants import (
-    AdobeStatus,
+    AdobeErrorCode,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
     ThreeYearCommitmentStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeHttpError
@@ -147,13 +149,13 @@ def test_validate_transfer_lines_exist(
 @pytest.mark.parametrize(
     "status_code",
     [
-        AdobeStatus.TRANSFER_INVALID_MEMBERSHIP.value,
-        AdobeStatus.TRANSFER_INVALID_MEMBERSHIP_OR_TRANSFER_IDS.value,
-        AdobeStatus.TRANSFER_INELIGIBLE.value,
-        AdobeStatus.TRANSFER_ALREADY_TRANSFERRED.value,
-        AdobeStatus.TRANSFER_INACTIVE_RESELLER.value,
-        AdobeStatus.TRANSFER_NO_ADMIN_CONTACTS.value,
-        AdobeStatus.TRANSFER_IN_PROGRESS.value,
+        AdobeErrorCode.INVALID_MEMBERSHIP_ID.value,
+        AdobeErrorCode.INVALID_MEMBERSHIP_OR_TRANSFER_ID.value,
+        AdobeErrorCode.INELIGIBLE_TRANSFER.value,
+        AdobeErrorCode.CUSTOMER_ALREADY_TRANSFERRED.value,
+        AdobeErrorCode.RESELLER_INACTIVE_FOR_TRANSFER.value,
+        AdobeErrorCode.NO_ADMIN_CONTACTS_FOR_TRANSFER.value,
+        AdobeErrorCode.TRANSFER_IN_PROGRESS.value,
     ],
 )
 def test_validate_transfer_membership_error(
@@ -421,7 +423,7 @@ def test_validate_transfer_account_inactive(
     adobe_subscription_factory,
 ):
     adobe_subscription = adobe_subscription_factory()
-    adobe_transfer = adobe_transfer_factory(status=AdobeStatus.TRANSFER_INACTIVE_ACCOUNT.value)
+    adobe_transfer = adobe_transfer_factory(status=AdobeOrderStatus.FAILED_INVALID_ADDRESS.value)
     order_params = transfer_order_parameters_factory()
     order = order_factory(order_parameters=order_params)
     mocked_transfer = mocker.MagicMock(customer_id="customer-id", status="completed")
@@ -437,7 +439,7 @@ def test_validate_transfer_account_inactive(
     assert has_errors is True
     param = get_ordering_parameter(validated_order, Param.MEMBERSHIP_ID.value)
     assert param["error"] == ERR_ADOBE_MEMBERSHIP_ID_INACTIVE_ACCOUNT.to_dict(
-        status=AdobeStatus.TRANSFER_INACTIVE_ACCOUNT.value,
+        status=AdobeOrderStatus.FAILED_INVALID_ADDRESS.value,
     )
     assert param["constraints"]["hidden"] is False
     assert param["constraints"]["required"] is True
@@ -508,9 +510,7 @@ def test_validate_transfer_already_migrated_all_items_expired(
     order_params = transfer_order_parameters_factory()
     order = order_factory(order_parameters=order_params, lines=[])
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
-    adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
-    )
+    adobe_subscription = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304578CA"
     ) + items_factory(
@@ -576,9 +576,7 @@ def test_validate_transfer_already_migrated_all_items_expired_with_one_time_item
     order_params = transfer_order_parameters_factory()
     order = order_factory(order_parameters=order_params, lines=[])
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
-    adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
-    )
+    adobe_subscription = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     adobe_one_time_subscription = adobe_subscription_factory(offer_id="99999999CA")
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304578CA"
@@ -659,10 +657,10 @@ def test_validate_transfer_already_migrated_all_items_expired_delete_existing_li
     mocked_transfer = mocker.MagicMock()
     mocked_transfer.customer_id = "customer-id"
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304990CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304990CA"
     )
     adobe_subscription_2 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304990CA"
@@ -756,10 +754,10 @@ def test_validate_transfer_already_migrated_all_items_expired_update_existing_li
     order = order_factory(order_parameters=order_params, lines=order_lines)
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304990CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304990CA"
     )
     adobe_subscription_2 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304990CA"
@@ -873,10 +871,10 @@ def test_validate_transfer_already_migrated_all_items_expired_add_new_line(
     order = order_factory(order_parameters=order_params, lines=order_lines)
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
     adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304990CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304990CA"
     )
     adobe_subscription_2 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304990CA"
@@ -976,9 +974,7 @@ def test_validate_transfer_already_migrated_partial_items_expired_with_one_time_
     order_params = transfer_order_parameters_factory()
     order = order_factory(order_parameters=order_params, lines=[])
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
-    adobe_subscription = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value
-    )
+    adobe_subscription = adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value)
     adobe_subscription_1 = adobe_subscription_factory(offer_id="65304578CA")
     adobe_one_time_subscription = adobe_subscription_factory(offer_id="99999999CA")
     product_items = items_factory(
@@ -1100,7 +1096,7 @@ def test_validate_transfer_already_migrated_partial_items_expired_add_new_line_e
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
     adobe_subscription = adobe_subscription_factory(offer_id="65304990CA")
     adobe_subscription_2 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome product 1", external_vendor_id="65304990CA"
@@ -1174,7 +1170,7 @@ def test_validate_transfer_already_migrated_partial_items_expired_update_line_er
     mocked_transfer = mocker.MagicMock(customer_id="customer-id")
     adobe_subscription = adobe_subscription_factory(offer_id="65304990CA")
     adobe_subscription_2 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304990CA"
@@ -1245,7 +1241,7 @@ def test_validate_transfer_already_migrated_partial_items_expired_remove_line_er
     adobe_subscription = adobe_subscription_factory(offer_id="65304990CA")
     adobe_subscription_2 = adobe_subscription_factory(offer_id="65304991CA")
     adobe_subscription_3 = adobe_subscription_factory(
-        status=AdobeStatus.INACTIVE_OR_GENERIC_FAILURE.value, offer_id="65304991CA"
+        status=AdobeSubscriptionStatus.INACTIVE.value, offer_id="65304991CA"
     )
     product_items = items_factory(
         item_id=1, name="Awesome Expired product 1", external_vendor_id="65304990CA"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

`AdobeStatus` in `adobe_vipm/adobe/constants.py` conflated two unrelated Adobe code families in one flat enum: per-object status codes (reused with the same numeric value but a different meaning per resource type) and API error-response codes. Because several members shared the same string value, Python's `StrEnum` silently aliased them (e.g. `PROCESSED`, `SUBSCRIPTION_ACTIVE`, and `GC_DEPLOYMENT_ACTIVE` were all `"1000"`).

Split `AdobeStatus` into:
- `AdobeOrderStatus` — Order status codes. A transfer is an Order of type `TRANSFER` under the hood, so transfer status checks use this enum too, rather than a separate one.
- `AdobeSubscriptionStatus` — Subscription status codes.
- `AdobeDeploymentStatus` — Deployment status codes.
- `AdobeErrorCode` — Adobe API error-response codes.

Naming was verified directly against Adobe's VIPMP API docs (`error-handling`, `migration/get-transfer-details`, deployment/subscription resource pages) rather than assumed from the old member names.

Scoped to the `AdobeStatus` members actually referenced in the codebase today rather than transcribing Adobe's full reference tables. A few members with zero references anywhere were dropped (`ACCOUNT_ALREADY_EXISTS`, and the `UNRECOVERABLE_TRANSFER_STATUSES` tuple, which itself was only reachable from one test parametrize, not any production flow).

## Why

This is the structural fix identified while investigating [MPT-23182](https://softwareone.atlassian.net/browse/MPT-23182): the flat enum's aliasing is exactly what let an order-status value get compared against a subscription in that bug. This PR removes the aliasing at its root and fixes six more call sites carrying the same class of bug — checking a subscription's status against the generic Order-family `PROCESSED` value instead of a subscription-specific one — across `fulfillment/shared.py`, `fulfillment/transfer.py`, `global_customer.py`, `migration.py`, and `adobe/mixins/subscription.py`.

## Testing

- `make build`
- `make check-all` — 890 passed, `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` all clean

Jira: MPT-23183


[MPT-23182]: https://softwareone.atlassian.net/browse/MPT-23182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23183](https://softwareone.atlassian.net/browse/MPT-23183)

- Split the shared `AdobeStatus` enum into resource-specific order, subscription, deployment, and error-code enums.
- Updated fulfillment, transfer, migration, synchronization, and validation logic to use the appropriate enums.
- Removed obsolete status members and the unreachable `UNRECOVERABLE_TRANSFER_STATUSES` constant.
- Updated fixtures and tests to reflect Adobe VIPMP status and error-code terminology.
- Validation passed: 890 tests, formatting, linting, flake8, build, and lock checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->