### PR TITLE
[HF] MPT-23386 Fix TypeError reading lateRenewalsInfo as native JSON value

### DIFF
--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1499,9 +1499,14 @@ class CheckManualRenewalSubscriptions(Step):
         if not value:
             return None
 
+        # The parameter is stored as a native JSON value, so it is read back as a dict.
+        # Legacy in-flight orders may still hold a serialized string; decode those too.
+        if isinstance(value, dict):
+            return value
+
         try:
             payload = json.loads(value)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError):
             logger.warning(
                 "%s: invalid %s payload, recomputing from Adobe",
                 context,
@@ -1519,7 +1524,7 @@ class CheckManualRenewalSubscriptions(Step):
         context.order = update_ordering_parameter_value(
             context.order,
             Param.LATE_RENEWALS_INFO.value,
-            json.dumps(payload),
+            payload,
         )
         update_order(client, context.order_id, parameters=context.order["parameters"])
         logger.info(

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -2875,13 +2875,9 @@ def test_check_manual_renewal_subscriptions_upsize_line_full_renewal(
     mocked_update_order.assert_called_once_with(
         mocked_client, order["id"], parameters=context.order["parameters"]
     )
-    stored = json.loads(
-        next(
-            p
-            for p in context.order["parameters"]["ordering"]
-            if p["externalId"] == "lateRenewalsInfo"
-        )["value"]
-    )
+    stored = next(
+        p for p in context.order["parameters"]["ordering"] if p["externalId"] == "lateRenewalsInfo"
+    )["value"]
     assert stored == {
         "renewals": {
             "65304578CA": {
@@ -3357,13 +3353,9 @@ def test_check_manual_renewal_subscriptions_isolates_unsupported_offer(
         ],
     }
     # Persisted split records both renewals and diverted.
-    stored = json.loads(
-        next(
-            p
-            for p in context.order["parameters"]["ordering"]
-            if p["externalId"] == "lateRenewalsInfo"
-        )["value"]
-    )
+    stored = next(
+        p for p in context.order["parameters"]["ordering"] if p["externalId"] == "lateRenewalsInfo"
+    )["value"]
     assert set(stored["renewals"]) == {"65304578CA"}
     assert set(stored["diverted"]) == {"65304579CA"}
     mocked_update_order.assert_called_once()
@@ -3571,6 +3563,7 @@ def test_check_manual_renewal_subscriptions_restore_with_diverted(
     mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.shared.update_order")
     order = order_factory(lines=lines_factory(quantity=5))
     line = order["lines"][0]
+    # The parameter is stored as a native JSON value, so it is read back as a dict.
     stored_data = {
         "renewals": {},
         "diverted": {
@@ -3581,7 +3574,7 @@ def test_check_manual_renewal_subscriptions_restore_with_diverted(
     }
     for p in order["parameters"]["ordering"]:
         if p["externalId"] == "lateRenewalsInfo":
-            p["value"] = json.dumps(stored_data)
+            p["value"] = stored_data
     context = Context(
         order=order,
         order_id=order["id"],


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix backport of #911 to `release/5`.

## What

Fix a `TypeError` crash in `CheckManualRenewalSubscriptions` when restoring persisted manual-renewal data.

## Why

`_load_late_renewals_info` persisted the renewal/diverted split with `json.dumps` but read it back with `json.loads`. `lateRenewalsInfo` is a JSON-valued ordering parameter, so on a later run the value is returned as a native `dict`. `json.loads(dict)` raises:

```
TypeError: the JSON object must be str, bytes or bytearray, not dict
```

which was not caught and crashed the fulfilment pipeline. It surfaced in the reseller-change nested purchase-order flow (`reseller_transfer.fulfill_purchase_order`).

## How

- `_persist_late_renewals_info` now stores the raw `payload` dict instead of `json.dumps(payload)`, so persist and load agree on the native JSON representation.
- `_load_late_renewals_info` returns the value directly when it is already a `dict`, while still decoding legacy serialized strings from in-flight orders. The guard now also catches `TypeError` alongside `JSONDecodeError`.

## Backport notes

- Cherry-picked the single source commit from #911 (`7b527f5`) — applied cleanly, no conflicts.

## Testing

- `make check-all` on `release/5` — 896 passed, ruff/flake8/uv-lock clean.
