### PR TITLE
MPT-23405 Route SWITCH order calls through Adobe retry session

### DIFF
--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -323,7 +323,7 @@ class OrderClientMixin:
             adobe_constants.ORDER_TYPE_PREVIEW_SWITCH,
         )
         headers = self._get_headers(authorization)
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             params={"fetch-price": "true"},
             headers=headers,
@@ -366,7 +366,7 @@ class OrderClientMixin:
         )
         correlation_id = sha256(json.dumps(payload).encode()).hexdigest()
         headers = self._get_headers(authorization, correlation_id=correlation_id)
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
             json=payload,


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

Fixes broken `main`: `ruff` reports F821 `Undefined name 'requests'` at `adobe_vipm/adobe/mixins/order.py:326` and `:369`, failing `make check-all`. These are also real runtime `NameError`s — the two SWITCH order calls (`create_preview_switch_order` / `create_switch_order`) would crash when invoked.

## Root cause — semantic merge conflict

- **#909 / MPT-23348** (retry transient 5xx) removed `import requests` and routed all its call sites through the shared retry `self._session`.
- **MPT-23300** (SWITCH change order) added two new `requests.post` call sites on a parallel branch, where `import requests` still existed.
- Both merged clean textually (import removal and new usages sit in different regions of the file), but the combination left `requests` undefined on `main`. Neither PR's CI re-ran `make check-all` on the merged result.

## Fix

Route both SWITCH calls through `self._session.post(...)`, consistent with every other Adobe call site — so they also gain the transient-5xx retry. `import requests` is intentionally **not** re-added (that would bypass the retry session #909 introduced).

## Validation (local, mirrors CI)

- `ruff check .` ✓
- `ruff format --check .` ✓
- `flake8` ✓
- `uv lock --check` ✓
- `pytest` — **918 passed** ✓

Jira: MPT-23405


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated both SWITCH order POST calls to use the shared retry-enabled session.
- Fixed undefined `requests` references and prevented runtime `NameError`s.
- Validation passed: linting, formatting, lockfile checks, and 918 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->