### PR TITLE
[HF] MPT-23348 Retry transient 5xx responses on the Adobe API client

### DIFF
--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -4,6 +4,8 @@ from collections.abc import MutableMapping
 from uuid import uuid4
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from adobe_vipm.adobe.config import Config, get_config
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization
@@ -20,6 +22,49 @@ logger = logging.getLogger(__name__)
 # just to be sure to refresh token in time
 EXPIRES_IN_DELAY_SECONDS = 180
 
+# Retry policy for transient Adobe API responses. Adobe documents the status
+# set 200/201/202/400/401/403/404/429/500, so 429 and 500 are the only
+# transient/retryable codes; the 4xx are client errors. Retries are scoped to
+# idempotent GET requests, so non-idempotent POST/PATCH calls are never retried.
+ADOBE_RETRY_TOTAL = 3
+ADOBE_RETRY_BACKOFF_FACTOR = 1
+ADOBE_RETRY_STATUS_FORCELIST = (429, 500)
+ADOBE_RETRY_ALLOWED_METHODS = frozenset(("GET",))
+
+
+def _build_retrying_session() -> requests.Session:
+    """Build a requests Session that retries transient Adobe responses.
+
+    Retries are limited to idempotent GET requests for HTTP 429 and 500, the
+    only transient statuses the Adobe API raises. Non-idempotent POST and PATCH
+    requests are never retried.
+
+    Returns:
+        requests.Session: Session with a retrying HTTP adapter mounted.
+    """
+    retry = Retry(
+        total=ADOBE_RETRY_TOTAL,
+        backoff_factor=ADOBE_RETRY_BACKOFF_FACTOR,
+        status_forcelist=ADOBE_RETRY_STATUS_FORCELIST,
+        allowed_methods=ADOBE_RETRY_ALLOWED_METHODS,
+        # Retry on matching HTTP statuses only. connect/read/other default to
+        # None (bounded only by total), which would also retry transport errors;
+        # pin them to 0 so the policy stays status-only as documented above.
+        connect=0,
+        read=0,
+        other=0,
+        # Return the final response once retries are exhausted instead of raising
+        # urllib3's MaxRetryError, so raise_for_status/wrap_http_error still turn
+        # a persistent failure into an AdobeAPIError.
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    # The Adobe API and auth endpoints are always HTTPS; the retry adapter is
+    # only mounted on https:// so no clear-text scheme is used.
+    session.mount("https://", adapter)
+    return session
+
 
 class AdobeClient(
     CustomerClientMixin,
@@ -33,14 +78,14 @@ class AdobeClient(
 
     def __init__(self) -> None:
         # TODO: client should be refactored cause of several things
-        # 1. There is no shared session for requests
-        # 2. Probably worth to use httpx instead of requests
-        # 3. Mixins are using methods from parent (like _get_headers)
-        # 4. Agreed to use composition instead of inheritance
+        # 1. Probably worth to use httpx instead of requests
+        # 2. Mixins are using methods from parent (like _get_headers)
+        # 3. Agreed to use composition instead of inheritance
         self._config: Config = get_config()
         self._token_cache: MutableMapping[Authorization, APIToken] = {}
         self._logger = logger
         self._TIMEOUT = 60
+        self._session = _build_retrying_session()
 
     def _get_headers(self, authorization: Authorization, correlation_id=None):
         token = self._get_auth_token(authorization).token
@@ -58,7 +103,7 @@ class AdobeClient(
 
         Using the credentials associated to a given the reseller.
         """
-        response = requests.post(
+        response = self._session.post(
             url=self._config.auth_endpoint_url,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={

--- a/adobe_vipm/adobe/mixins/customer.py
+++ b/adobe_vipm/adobe/mixins/customer.py
@@ -2,8 +2,6 @@ import json
 from hashlib import sha256
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe.constants import OfferType
 from adobe_vipm.adobe.dataclasses import Reseller
 from adobe_vipm.adobe.errors import wrap_http_error
@@ -103,7 +101,7 @@ class CustomerClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/customers/{customer_id}",
@@ -163,7 +161,7 @@ class CustomerClientMixin:
             ],
         }
 
-        response = requests.patch(
+        response = self._session.patch(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}"),
             headers=self._get_headers(
                 self._config.get_authorization(authorization_id),
@@ -232,7 +230,7 @@ class CustomerClientMixin:
         reseller_id: str,
     ) -> dict:
         """Create customer via API and return the created customer."""
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, "/v3/customers"),
             headers=self._get_headers(
                 authorization,

--- a/adobe_vipm/adobe/mixins/deployment.py
+++ b/adobe_vipm/adobe/mixins/deployment.py
@@ -1,7 +1,5 @@
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe.constants import AdobeDeploymentStatus
 from adobe_vipm.adobe.errors import wrap_http_error
 
@@ -30,7 +28,7 @@ class DeploymentClientMixin:
         next_url = f"/v3/customers/{customer_id}/deployments"
         deployments = []
         while next_url:
-            response = requests.get(
+            response = self._session.get(
                 urljoin(self._config.api_base_url, next_url),
                 headers=headers,
                 timeout=self._TIMEOUT,

--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -8,8 +8,6 @@ from operator import itemgetter
 from typing import Any
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe import constants as adobe_constants
 from adobe_vipm.adobe.constants import AdobeErrorCode
 from adobe_vipm.adobe.dataclasses import Authorization, ReturnableOrderInfo
@@ -73,7 +71,7 @@ class OrderClientMixin:
         orders_base_url = f"/v3/customers/{customer_id}/orders"
         next_url = f"{orders_base_url}?limit=100&offset=0"
         while next_url:
-            response = requests.get(
+            response = self._session.get(
                 urljoin(self._config.api_base_url, next_url),
                 headers=headers,
                 params=filters,
@@ -105,7 +103,7 @@ class OrderClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/customers/{customer_id}/orders/{order_id}",
@@ -154,7 +152,7 @@ class OrderClientMixin:
             authorization,
             correlation_id=correlation_id,
         )
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
             json=payload,
@@ -240,7 +238,7 @@ class OrderClientMixin:
         authorization = self._config.get_authorization(authorization_id)
         payload = {"orderType": adobe_constants.ORDER_TYPE_PREVIEW_RENEWAL}
         headers = self._get_headers(authorization)
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
             json=payload,
@@ -284,7 +282,7 @@ class OrderClientMixin:
 
         correlation_id = sha256(json.dumps(payload).encode()).hexdigest()
         headers = self._get_headers(authorization, correlation_id=correlation_id)
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
             json=payload,
@@ -716,7 +714,7 @@ class OrderClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization, correlation_id=correlation_id)
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
             json=payload,
@@ -730,7 +728,7 @@ class OrderClientMixin:
         self, authorization: Authorization, adobe_customer_id: str, payload: dict
     ) -> dict:
         headers = self._get_headers(authorization)
-        response = requests.post(
+        response = self._session.post(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/customers/{adobe_customer_id}/orders",
@@ -774,7 +772,7 @@ class OrderClientMixin:
         next_url = "v3/flex-discounts"
         flex_discounts = []
         while next_url:
-            response = requests.get(
+            response = self._session.get(
                 urljoin(self._config.api_base_url, next_url),
                 headers=headers,
                 params=query_params,

--- a/adobe_vipm/adobe/mixins/reseller.py
+++ b/adobe_vipm/adobe/mixins/reseller.py
@@ -2,8 +2,6 @@ import json
 from hashlib import sha256
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe.errors import wrap_http_error
 from adobe_vipm.adobe.utils import join_phone_number
 
@@ -43,7 +41,7 @@ class ResellerClientMixin:
                 "contacts": [self._get_contact(reseller_data["contact"])],
             },
         }
-        response = requests.post(
+        response = self._session.post(
             urljoin(self._config.api_base_url, "/v3/resellers"),
             headers=self._get_headers(
                 authorization,

--- a/adobe_vipm/adobe/mixins/subscription.py
+++ b/adobe_vipm/adobe/mixins/subscription.py
@@ -1,7 +1,5 @@
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe.constants import AdobeSubscriptionStatus
 from adobe_vipm.adobe.errors import wrap_http_error
 from adobe_vipm.flows.constants import Param
@@ -28,7 +26,7 @@ class SubscriptionClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/customers/{customer_id}/subscriptions/{subscription_id}",
@@ -52,7 +50,7 @@ class SubscriptionClientMixin:
             The retrieved subscriptions.
         """
         authorization = self._config.get_authorization(authorization_id)
-        response = requests.get(
+        response = self._session.get(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/subscriptions"),
             headers=self._get_headers(authorization),
             timeout=self._TIMEOUT,
@@ -161,7 +159,7 @@ class SubscriptionClientMixin:
         if quantity:
             payload["autoRenewal"][Param.RENEWAL_QUANTITY.value] = quantity
 
-        response = requests.patch(
+        response = self._session.patch(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/customers/{customer_id}/subscriptions/{subscription_id}",

--- a/adobe_vipm/adobe/mixins/transfer.py
+++ b/adobe_vipm/adobe/mixins/transfer.py
@@ -1,7 +1,5 @@
 from urllib.parse import urljoin
 
-import requests
-
 from adobe_vipm.adobe.constants import ResellerChangeAction
 from adobe_vipm.adobe.dataclasses import Reseller
 from adobe_vipm.adobe.errors import wrap_http_error
@@ -30,7 +28,7 @@ class TransferClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/memberships/{membership_id}/offers",
@@ -67,7 +65,7 @@ class TransferClientMixin:
         authorization = self._config.get_authorization(authorization_id)
         reseller: Reseller = self._config.get_reseller(authorization, seller_id)
         headers = self._get_headers(authorization, correlation_id=order_id)
-        response = requests.post(
+        response = self._session.post(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/memberships/{membership_id}/transfers",
@@ -102,7 +100,7 @@ class TransferClientMixin:
         """
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/memberships/{membership_id}/transfers/{transfer_id}",
@@ -122,7 +120,7 @@ class TransferClientMixin:
         """Retrieve a transfer object by the membership and transfer identifiers."""
         authorization = self._config.get_authorization(authorization_id)
         headers = self._get_headers(authorization)
-        response = requests.get(
+        response = self._session.get(
             urljoin(
                 self._config.api_base_url,
                 f"/v3/transfers/{transfer_id}",
@@ -158,7 +156,7 @@ class TransferClientMixin:
         authorization = self._config.get_authorization(authorization_id)
         reseller: Reseller = self._config.get_reseller(authorization, seller_id)
         headers = self._get_headers(authorization)
-        response = requests.post(
+        response = self._session.post(
             urljoin(
                 self._config.api_base_url,
                 "/v3/transfers",

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -21,7 +21,7 @@ from adobe_vipm.adobe.constants import (
     ResellerChangeAction,
 )
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization, ReturnableOrderInfo
-from adobe_vipm.adobe.errors import AdobeError, AdobeProductNotFoundError
+from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeProductNotFoundError
 from adobe_vipm.adobe.utils import join_phone_number, to_adobe_line_id
 from adobe_vipm.flows.constants import GOVERNMENT_AGENCY_TYPE_FEDERAL, Param
 from adobe_vipm.flows.context import Context
@@ -3423,3 +3423,79 @@ def test_get_flex_discounts_follows_pagination_links(
     )
 
     assert result == full["flexDiscounts"]
+
+
+def test_build_session_retry_policy_scoped_to_transient_get_requests():
+    session = adobe_client._build_retrying_session()
+
+    result = session.get_adapter("https://partners.adobe.io").max_retries
+
+    assert result.total == 3
+    assert result.backoff_factor == 1
+    assert result.raise_on_status is False
+    # 429 and 500 are the only transient statuses Adobe raises; 4xx client
+    # errors must never be retried.
+    assert set(result.status_forcelist) == {429, 500}
+    # Retries are scoped to idempotent GET; POST/PATCH are never retried.
+    assert result.allowed_methods == frozenset(("GET",))
+    # Retries are status-only: connection/read/other transport errors are not retried.
+    assert result.connect == 0
+    assert result.read == 0
+    assert result.other == 0
+
+
+def test_client_wires_retrying_session(settings, mock_adobe_config, adobe_config_file):
+    client = adobe_client.AdobeClient()
+
+    result = client._session.get_adapter("https://partners.adobe.io").max_retries
+
+    assert isinstance(client._session, requests.Session)
+    assert set(result.status_forcelist) == {429, 500}
+    assert result.allowed_methods == frozenset(("GET",))
+
+
+def test_get_request_retries_transient_500_then_succeeds(
+    requests_mocker, settings, adobe_client_factory
+):
+    client, authorization, _ = adobe_client_factory()
+    customer_id = "adobe-customer-id"
+    url = urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], f"/v3/customers/{customer_id}")
+    requests_mocker.get(url, status=500, json={"code": "1124", "message": "boom"})
+    requests_mocker.get(url, status=200, json={"customerId": customer_id})
+
+    result = client.get_customer(authorization.authorization_uk, customer_id)
+
+    assert result == {"customerId": customer_id}
+    assert len(requests_mocker.calls) == 2
+
+
+def test_get_request_raises_adobe_api_error_when_retries_exhausted(
+    requests_mocker, settings, adobe_client_factory, adobe_api_error_factory
+):
+    client, authorization, _ = adobe_client_factory()
+    customer_id = "adobe-customer-id"
+    url = urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], f"/v3/customers/{customer_id}")
+    adobe_api_error = adobe_api_error_factory(code="1124", message="Internal Server Error")
+    requests_mocker.get(url, status=500, json=adobe_api_error)
+
+    with pytest.raises(AdobeAPIError) as exc_info:
+        client.get_customer(authorization.authorization_uk, customer_id)
+
+    assert exc_info.value.code == "1124"
+    # One initial attempt plus the configured number of retries.
+    assert len(requests_mocker.calls) == adobe_client.ADOBE_RETRY_TOTAL + 1
+
+
+def test_get_request_does_not_retry_client_errors(
+    requests_mocker, settings, adobe_client_factory, adobe_api_error_factory
+):
+    client, authorization, _ = adobe_client_factory()
+    customer_id = "adobe-customer-id"
+    url = urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], f"/v3/customers/{customer_id}")
+    adobe_api_error = adobe_api_error_factory(code="1116", message="Invalid Customer")
+    requests_mocker.get(url, status=404, json=adobe_api_error)
+
+    with pytest.raises(AdobeAPIError):
+        client.get_customer(authorization.authorization_uk, customer_id)
+
+    assert len(requests_mocker.calls) == 1


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix backport of #909 to `release/5`. Cherry-picked the single fix commit (`9379978`) from the merged `main` PR; no conflicts.

## What

A single transient Adobe HTTP 429/500 aborted the whole fulfilment pass: Adobe calls used bare `requests.get/post/patch` with no retry, so one server-side blip raised `AdobeAPIError` up to `fulfill_order` and fired a false unhandled-exception Teams alert.

## Changes

- Add a shared `requests.Session` on `AdobeClient` via `_build_retrying_session()`, mounting an `HTTPAdapter(max_retries=Retry(...))` on `https://` only (Adobe endpoints are all HTTPS).
- Retry policy: `total=3`, `backoff_factor=1`, `status_forcelist=(429, 500)`, `allowed_methods=frozenset({"GET"})`, `connect=0/read=0/other=0` (status-only), `raise_on_status=False` (exhausted retries still surface as `AdobeAPIError`, not `RetryError`).
- Retries auto-scope to idempotent GET; POST/PATCH are never retried.
- Route all 22 Adobe call sites through `self._session`; drop the now-unused `import requests` from the mixins.

## Testing

- Full suite on `release/5`: `make check` clean (ruff/flake8/uv lock); `make test` → 902 passed.
- Includes the retry tests added in #909 (policy on https; transient 500→200 succeeds; persistent 500 → `AdobeAPIError` after total+1 attempts; 4xx single attempt).

Jira: MPT-23348
