### PR TITLE
MPT-23523 Solve an issue with some old agreements sync parameters

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -583,7 +583,6 @@ class AgreementSyncer:  # noqa: WPS214
         send_3yc_expiration_notification(self._mpt_client, agreement, 0, "notification_3yc_expired")
 
     def _update_3yc_commitment_parameters(self, adobe_customer: dict, parameters: dict) -> None:
-        parameters.setdefault(Param.PHASE_ORDERING.value, [])
         parameters.setdefault(Param.PHASE_FULFILLMENT.value, [])
         commitment_info = get_3yc_commitment(adobe_customer)
 
@@ -611,19 +610,11 @@ class AgreementSyncer:  # noqa: WPS214
 
         for mq in minimum_quantities:
             if mq["offerType"] == OfferType.LICENSE:
-                parameters[Param.PHASE_ORDERING.value].append({
-                    "externalId": Param.THREE_YC_LICENSES.value,
-                    "value": str(mq.get("quantity")),
-                })
                 parameters[Param.PHASE_FULFILLMENT.value].append({
                     "externalId": Param.THREE_YC_MIN_LICENSES.value,
                     "value": str(mq.get("quantity")),
                 })
             if mq["offerType"] == OfferType.CONSUMABLES:
-                parameters[Param.PHASE_ORDERING.value].append({
-                    "externalId": Param.THREE_YC_CONSUMABLES.value,
-                    "value": str(mq.get("quantity")),
-                })
                 parameters[Param.PHASE_FULFILLMENT.value].append({
                     "externalId": Param.THREE_YC_MIN_CONSUMABLES.value,
                     "value": str(mq.get("quantity")),
@@ -1268,6 +1259,7 @@ def sync_agreements_by_3yc_enroll_status(
     except Exception:
         logger.exception("Unknown exception getting agreements by 3YC enroll status.")
         raise
+
     for agreement in agreements:
         try:
             sync_agreement(mpt_client, adobe_client, agreement, dry_run=dry_run, sync_prices=True)

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -269,10 +269,6 @@ def test_sync_agreement_prices(
             agreement["id"],
             lines=expected_lines,
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -377,10 +373,6 @@ def test_sync_agreement_update_agreement_education(
             mock_mpt_client,
             mocked_agreement_syncer._agreement["id"],
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -921,10 +913,6 @@ def test_sync_agreement_prices_with_3yc(
             agreement["id"],
             lines=expected_lines,
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": "9"},
-                    {"externalId": "3YCConsumables", "value": "1220"},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": "COMMITTED"},
                     {"externalId": "3YCStartDate", "value": "2024-01-01"},
@@ -1372,10 +1360,6 @@ def test_sync_global_customer_parameter(
             agreement["id"],
             lines=expected_lines,
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -1441,10 +1425,6 @@ def test_sync_global_customer_parameter(
             deployment_agreements[0]["id"],
             lines=expected_lines,
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -2088,10 +2068,6 @@ def test_sync_global_customer_update_not_required(
             "AGR-2119-4550-8674-5962",
             lines=[],
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -2201,10 +2177,6 @@ def test_sync_global_customer_no_active_deployments(
             "AGR-2119-4550-8674-5962",
             lines=[],
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -2456,10 +2428,6 @@ def test_sync_agreement_empty_discounts(
             agreement["id"],
             lines=expected_lines,
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -2695,10 +2663,6 @@ def test_sync_agreement_prices_with_missing_prices(
                 }
             ],
             parameters={
-                "ordering": [
-                    {"externalId": "3YCLicenses", "value": ""},
-                    {"externalId": "3YCConsumables", "value": ""},
-                ],
                 "fulfillment": [
                     {"externalId": "3YCEnrollStatus", "value": None},
                     {"externalId": "3YCStartDate", "value": None},
@@ -4613,10 +4577,6 @@ def test_update_3yc_commitment_parameters_with_commitment(
     syncer._update_3yc_commitment_parameters(customer, parameters)  # act
 
     assert parameters == {
-        "ordering": [
-            {"externalId": "3YCLicenses", "value": "9"},
-            {"externalId": "3YCConsumables", "value": "1220"},
-        ],
         "fulfillment": [
             {"externalId": "3YCEnrollStatus", "value": "COMMITTED"},
             {"externalId": "3YCStartDate", "value": "2024-01-01"},
@@ -4642,10 +4602,6 @@ def test_update_3yc_commitment_parameters_without_commitment(
     syncer._update_3yc_commitment_parameters(customer, parameters)  # act
 
     assert parameters == {
-        "ordering": [
-            {"externalId": "3YCLicenses", "value": ""},
-            {"externalId": "3YCConsumables", "value": ""},
-        ],
         "fulfillment": [
             {"externalId": "3YCEnrollStatus", "value": None},
             {"externalId": "3YCStartDate", "value": None},
@@ -4678,7 +4634,6 @@ def test_update_3yc_commitment_parameters_preserves_existing_parameters(
 
     assert parameters["ordering"][0] == {"externalId": "companyName", "value": "ACME"}
     assert parameters["fulfillment"][0] == {"externalId": "cotermDate", "value": "2025-04-04"}
-    assert {"externalId": "3YCLicenses", "value": "5"} in parameters["ordering"]
     assert {"externalId": "3YCEnrollStatus", "value": "COMMITTED"} in parameters["fulfillment"]
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23523](https://softwareone.atlassian.net/browse/MPT-23523)

- Fixed synchronization of legacy 3YC agreement parameters by removing obsolete license and consumable ordering values.
- Updated agreement sync tests to reflect the corrected fulfillment-only parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23523]: https://softwareone.atlassian.net/browse/MPT-23523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ