### PR TITLE
[HF] MPT-23563 Only warn about missing discounts when active subscriptions exist

### DIFF
--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -214,11 +214,18 @@ class AgreementSyncer:  # noqa: WPS214
             )
             return False
 
-        if not self._adobe_customer.get("discounts", []):
-            # Adobe discounts are not set for the customer when the subscriptions expired.
-            # In that case we should continue the sync process to terminate the subscriptions.
-            # There is another scenario when the 3YC is only for licenses.
-            # The discounts are not correctly returned by the API for the consumables.
+        active_subscriptions = [
+            subscription
+            for subscription in self._adobe_subscriptions
+            if subscription["status"] == AdobeSubscriptionStatus.ACTIVE.value
+        ]
+        if active_subscriptions and not self._adobe_customer.get("discounts", []):
+            # Discounts only matter when there are active subscriptions to price.
+            # Adobe returns no discounts for a customer without active subscriptions
+            # (e.g. all subscriptions expired, or a 3YC commitment request still in
+            # REQUESTED status). In that case there is nothing to price-sync, so the
+            # missing discounts are expected and must not raise a warning. The sync still
+            # continues so the termination flow for expired subscriptions is unaffected.
             msg = (
                 f"Error synchronizing agreement {self.agreement_id}. Customer "
                 f"{self._adobe_customer_id} does not have discounts information."

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -2337,7 +2337,7 @@ def test_sync_agreement_updates_linked_membership_params(
 
 
 @freeze_time("2025-06-23")
-def test_sync_agreement_empty_discounts(
+def test_sync_agreement_empty_discounts_no_active_subscriptions(
     mocker,
     agreement_factory,
     subscriptions_factory,
@@ -2484,12 +2484,44 @@ def test_sync_agreement_empty_discounts(
             parameters={"fulfillment": [{"externalId": "lastSyncDate", "value": "2025-06-23"}]},
         ),
     ])
+    # No active subscriptions means there is nothing to price-sync, so empty discounts
+    # are expected and must not raise a warning, while termination still proceeds.
+    mock_send_warning.assert_not_called()
+
+
+def test_is_sync_possible_warns_on_empty_discounts_with_active_subscriptions(
+    mocked_agreement_syncer, adobe_customer_factory, mock_send_warning
+):
+    # The default fixture provides active Adobe subscriptions.
+    mocked_agreement_syncer._adobe_customer = adobe_customer_factory()
+    mocked_agreement_syncer._adobe_customer["discounts"] = []
+
+    result = mocked_agreement_syncer._is_sync_possible()  # act
+
+    assert result is True
     mock_send_warning.assert_called_once_with(
         "Customer does not have discounts information",
         "Error synchronizing agreement AGR-2119-4550-8674-5962. Customer a-client-id "
-        "does not have discounts information. Cannot proceed with price "
-        "synchronization.",
+        "does not have discounts information. Cannot proceed with price synchronization.",
     )
+
+
+def test_is_sync_possible_silent_on_empty_discounts_without_active_subscriptions(
+    mocked_agreement_syncer,
+    adobe_customer_factory,
+    adobe_subscription_factory,
+    mock_send_warning,
+):
+    mocked_agreement_syncer._adobe_subscriptions = [
+        adobe_subscription_factory(status=AdobeSubscriptionStatus.INACTIVE.value),
+    ]
+    mocked_agreement_syncer._adobe_customer = adobe_customer_factory()
+    mocked_agreement_syncer._adobe_customer["discounts"] = []
+
+    result = mocked_agreement_syncer._is_sync_possible()  # act
+
+    assert result is True
+    mock_send_warning.assert_not_called()
 
 
 @freeze_time("2025-06-19")


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix of #926 cherry-picked onto `release/5` (source commit `618973d`).

## What

Stops the recurring false-positive `"does not have discounts information"` warning alerts raised by agreement price synchronization for customers that have **no active subscriptions**.

## Why

`_is_sync_possible()` in `adobe_vipm/flows/sync/agreement.py` only skipped early when the customer had *no subscriptions at all*. Because `_adobe_subscriptions` includes subscriptions in any status (expired/terminated), a customer with only non-active subscriptions passed that guard and reached the discounts check. Since MPT-17064 that branch no longer returns `False` (so the termination flow can continue), so an empty `discounts` array caused `send_warning(...)` to fire on **every** sync run.

Representative case: a customer whose subscriptions have all expired while a 3YC commitment request is still in `REQUESTED` status — Adobe has granted no discounts yet, so `discounts` is legitimately empty and the alert is a false positive. Discounts only matter when there are active subscriptions to price.

## Change

- Gate the empty-discounts check and its `send_warning` on the customer having at least one `ACTIVE` subscription (`AdobeSubscriptionStatus.ACTIVE`).
- Sync still proceeds otherwise, leaving the termination flow for expired subscriptions unchanged.
- The warning still fires for the genuine anomaly: active subscriptions but no discounts.

## Testing

- `make check-all` on `release/5` — full suite **911 passed**, coverage 98% (ruff/format/flake8/uv-lock clean).

Jira: MPT-23563
Main PR: #926


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23563](https://softwareone.atlassian.net/browse/MPT-23563)

- Prevents false-positive missing-discount warnings for customers without active subscriptions.
- Preserves synchronization and termination handling for inactive subscriptions.
- Warns when active subscriptions lack discount information.
- Adds coverage for active and inactive subscription scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-23563]: https://softwareone.atlassian.net/browse/MPT-23563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ