### PR TITLE
MPT-23679 Switch order are failing when we use the same skus in diffe…

### DIFF
--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1329,6 +1329,13 @@ class SyncAgreement(Step):
 class ValidateDuplicateLines(Step):
     """Validates if Adobe Order contains duplicated items, with the same sku."""
 
+    def __init__(self, *, is_switch=False):
+        # Switch (mid-term upgrade) orders may legitimately target an item that already
+        # exists in the agreement (e.g. a previous switch order already switched to the
+        # same Adobe product). For those orders the "existing item" check is skipped and
+        # the existing agreement subscription is updated later instead of being failed.
+        self.is_switch = is_switch
+
     def __call__(self, client, context, next_step):
         """Validates if Adobe Order contains duplicated items, with the same sku."""
         items = [line["item"]["id"] for line in context.order["lines"]]
@@ -1341,22 +1348,23 @@ class ValidateDuplicateLines(Step):
             )
             return
 
-        items = []
-        for subscription in context.order["agreement"]["subscriptions"]:
-            for line in subscription["lines"]:
-                items.append(line["item"]["id"])
+        if not self.is_switch:
+            items = []
+            for subscription in context.order["agreement"]["subscriptions"]:
+                for line in subscription["lines"]:
+                    items.append(line["item"]["id"])
 
-        items.extend([
-            line["item"]["id"] for line in context.order["lines"] if line["oldQuantity"] == 0
-        ])
-        duplicates = [item for item, count in Counter(items).items() if count > 1]
-        if duplicates:
-            switch_order_to_failed(
-                client,
-                context.order,
-                ERR_EXISTING_ITEMS.to_dict(duplicates=",".join(duplicates)),
-            )
-            return
+            items.extend([
+                line["item"]["id"] for line in context.order["lines"] if line["oldQuantity"] == 0
+            ])
+            duplicates = [item for item, count in Counter(items).items() if count > 1]
+            if duplicates:
+                switch_order_to_failed(
+                    client,
+                    context.order,
+                    ERR_EXISTING_ITEMS.to_dict(duplicates=",".join(duplicates)),
+                )
+                return
 
         next_step(client, context)
 

--- a/adobe_vipm/flows/fulfillment/switch.py
+++ b/adobe_vipm/flows/fulfillment/switch.py
@@ -173,7 +173,7 @@ def fulfill_switch_order(client, order):
         SetupContext(),
         StartOrderProcessing(TEMPLATE_NAME_CHANGE),
         SetupDueDate(),
-        ValidateDuplicateLines(),
+        ValidateDuplicateLines(is_switch=True),
         SetOrUpdateCotermDate(),
         UpdateAgreementParamsVisibility(),
         ValidateRenewalWindow(),

--- a/tests/flows/fulfillment/test_shared.py
+++ b/tests/flows/fulfillment/test_shared.py
@@ -4043,3 +4043,56 @@ def test_submit_renewal_orders_existing_order_reused(
     mock_adobe_client.create_renewal_order.assert_not_called()
     assert context.adobe_renewal_orders == {ext_ref: existing_order}
     mocked_next_step.assert_called_once_with(mocked_client, context)
+
+
+def test_validate_duplicate_lines_step_switch_allows_existing_item(
+    mocker,
+    order_factory,
+    lines_factory,
+):
+    # A switch order targeting an item that already exists in the agreement must not be
+    # failed: the existing agreement subscription is updated later instead.
+    order = order_factory(
+        order_type="Change",
+        lines=lines_factory(line_id=2, item_id=10),
+    )
+    mocked_fail = mocker.patch(
+        "adobe_vipm.flows.fulfillment.shared.switch_order_to_failed",
+    )
+    mocked_client = mocker.MagicMock()
+    mocked_next_step = mocker.MagicMock()
+    context = Context(order=order, order_id=order["id"])
+    step = ValidateDuplicateLines(is_switch=True)
+
+    step(mocked_client, context, mocked_next_step)  # act
+
+    mocked_fail.assert_not_called()
+    mocked_next_step.assert_called_once_with(mocked_client, context)
+
+
+def test_validate_duplicate_lines_step_switch_still_fails_intra_order_duplicates(
+    mocker,
+    order_factory,
+    lines_factory,
+):
+    # The intra-order duplicate check still applies to switch orders.
+    order = order_factory(
+        order_type="Change",
+        lines=lines_factory() + lines_factory(),
+    )
+    mocked_fail = mocker.patch(
+        "adobe_vipm.flows.fulfillment.shared.switch_order_to_failed",
+    )
+    mocked_client = mocker.MagicMock()
+    mocked_next_step = mocker.MagicMock()
+    context = Context(order=order, order_id=order["id"])
+    step = ValidateDuplicateLines(is_switch=True)
+
+    step(mocked_client, context, mocked_next_step)  # act
+
+    mocked_fail.assert_called_once_with(
+        mocked_client,
+        context.order,
+        ERR_DUPLICATED_ITEMS.to_dict(duplicates="ITM-1234-1234-1234-0001"),
+    )
+    mocked_next_step.assert_not_called()


### PR DESCRIPTION
…rent switches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated switch-order validation to allow existing SKUs across different switches.
- Preserved detection of duplicate lines within the same switch order.
- Added test coverage for both scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->