### PR TITLE
MPT-23921 report Adobe transport failures with request context

### DIFF
--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -9,6 +9,7 @@ from urllib3.util.retry import Retry
 
 from adobe_vipm.adobe.config import Config, get_config
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization
+from adobe_vipm.adobe.errors import wrap_http_error
 from adobe_vipm.adobe.mixins.customer import CustomerClientMixin
 from adobe_vipm.adobe.mixins.deployment import DeploymentClientMixin
 from adobe_vipm.adobe.mixins.order import OrderClientMixin
@@ -98,10 +99,13 @@ class AdobeClient(
             "x-correlation-id": correlation_id or str(uuid4()),
         }
 
+    @wrap_http_error
     def _refresh_auth_token(self, authorization: Authorization):
         """Request an authentication token for the Adobe VIPM API.
 
-        Using the credentials associated to a given the reseller.
+        Using the credentials associated to a given the reseller. Wrapped so a failure of the
+        auth endpoint is reported against the token request instead of being caught by the
+        calling method's wrapper and attributed to the Adobe API call that triggered it.
         """
         response = self._session.post(
             url=self._config.auth_endpoint_url,

--- a/adobe_vipm/adobe/errors.py
+++ b/adobe_vipm/adobe/errors.py
@@ -2,9 +2,11 @@ import json
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import ParamSpec, TypeVar
+from typing import NoReturn, ParamSpec, TypeVar
 
-from requests import HTTPError, JSONDecodeError
+from requests import HTTPError, JSONDecodeError, PreparedRequest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import RequestException, Timeout
 
 Param = ParamSpec("Param")  # noqa: WPS110
 RetType = TypeVar("RetType")
@@ -81,9 +83,68 @@ class AdobeAPIError(AdobeHttpError):
         return str(self.payload)
 
 
+class AdobeTransportError(Exception):
+    """
+    An Adobe call that failed before any HTTP response was received.
+
+    Covers dropped connections and timeouts, where Adobe returned no status code and no
+    payload, so there is nothing for `AdobeAPIError` to describe.
+
+    Deliberately outside the `AdobeError` hierarchy: flows catch `AdobeError` to fail an
+    order on a business rejection from Adobe, and a transient network fault must not take
+    that path. Keeping it separate preserves the pre-existing behaviour, where a transport
+    failure propagates for retry instead of failing the order.
+    """
+
+    def __init__(self, request_description: str, reason: str) -> None:
+        self.request_description = request_description
+        self.reason = reason
+        super().__init__(f"Adobe transport failure on {request_description}: {reason}")
+
+
+def _describe_failed_request(error: RequestException) -> str:
+    """
+    Describe the request behind a transport failure.
+
+    Args:
+        error: The requests exception raised for the failed call.
+
+    Returns:
+        str: The method, URL, and correlation id of the failed request.
+    """
+    request: PreparedRequest | None = error.request
+    if request is None:
+        return "an Adobe request"
+
+    correlation_id = request.headers.get("x-correlation-id", "unknown")
+    return f"{request.method} {request.url} (correlation id: {correlation_id})"
+
+
+def _raise_adobe_response_error(error: HTTPError) -> NoReturn:
+    """
+    Convert an error response into the matching Adobe error.
+
+    Args:
+        error: The HTTP error raised for the error response.
+
+    Raises:
+        AdobeAPIError: When the response body is the documented Adobe error JSON.
+        AdobeHttpError: When the response body is not JSON.
+    """
+    logger.error(error)
+    try:  # noqa: WPS328, WPS505
+        raise AdobeAPIError(error.response.status_code, error.response.json())
+    except JSONDecodeError:
+        raise AdobeHttpError(error.response.status_code, error.response.content.decode())
+
+
 def wrap_http_error(func: Callable[Param, RetType]) -> Callable[Param, RetType]:  # ruff:ignore[non-pep695-generic-function]
     """
-    Wrap HTTP error to Adobe API Error.
+    Wrap HTTP and transport errors into Adobe errors.
+
+    An HTTP response with an error status becomes an `AdobeAPIError` or `AdobeHttpError`. A
+    failure with no response at all becomes an `AdobeTransportError` naming the request, so
+    the caller and any alert identify the endpoint that failed.
 
     Args:
         func: function to wrap and handle exceptions
@@ -97,10 +158,10 @@ def wrap_http_error(func: Callable[Param, RetType]) -> Callable[Param, RetType]:
         try:
             return func(*args, **kwargs)
         except HTTPError as error:
-            logger.error(error)  # ruff:ignore[error-instead-of-exception]
-            try:  # noqa: WPS328, WPS505
-                raise AdobeAPIError(error.response.status_code, error.response.json())
-            except JSONDecodeError:
-                raise AdobeHttpError(error.response.status_code, error.response.content.decode())
+            _raise_adobe_response_error(error)
+        except (RequestsConnectionError, Timeout) as error:
+            request_description = _describe_failed_request(error)
+            logger.warning("Adobe transport failure on %s: %s", request_description, error)
+            raise AdobeTransportError(request_description, str(error)) from error
 
     return _wrapper

--- a/adobe_vipm/flows/fulfillment/base.py
+++ b/adobe_vipm/flows/fulfillment/base.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 
+from adobe_vipm.adobe.errors import AdobeTransportError
 from adobe_vipm.flows.constants import OrderType
 from adobe_vipm.flows.fulfillment.change import fulfill_change_order
 from adobe_vipm.flows.fulfillment.configuration import fulfill_configuration_order
@@ -9,6 +10,7 @@ from adobe_vipm.flows.fulfillment.reseller_transfer import fulfill_reseller_chan
 from adobe_vipm.flows.fulfillment.switch import fulfill_switch_order
 from adobe_vipm.flows.fulfillment.termination import fulfill_termination_order
 from adobe_vipm.flows.fulfillment.transfer import fulfill_transfer_order
+from adobe_vipm.flows.pipeline import get_failed_step
 from adobe_vipm.flows.utils import notify_unhandled_exception_in_teams, strip_trace_id
 from adobe_vipm.flows.utils.validation import (
     is_migrate_customer,
@@ -58,10 +60,26 @@ def fulfill_order(client, order):
             validators[order.get("type")](client, order)
         else:
             logger.info("Order %s is not a valid order type", order["id"])
-    except Exception:
+    except AdobeTransportError as error:
+        # A transport fault is transient and self-recovering: the order stays in processing
+        # and is re-dispatched, and a run of failures that outlives the due date fails the
+        # order through SetupDueDate. Log it for the dashboards instead of alerting on a
+        # network blip; the error is re-raised so the failed pass stays visible.
+        logger.warning(
+            "%s order %s: transient Adobe transport failure in %s for authorization %s: %s. "
+            "The order stays in processing and will be retried.",
+            order["type"],
+            order["id"],
+            get_failed_step(error) or "fulfillment",
+            order.get("authorization", {}).get("id", "unknown"),
+            error,
+        )
+        raise
+    except Exception as error:
         notify_unhandled_exception_in_teams(
             "fulfillment",
             order["id"],
             strip_trace_id(traceback.format_exc()),
+            step=get_failed_step(error),
         )
         raise

--- a/adobe_vipm/flows/pipeline.py
+++ b/adobe_vipm/flows/pipeline.py
@@ -24,6 +24,24 @@ def _default_error_handler(error: Exception, context: Context, next_step: NextSt
     raise error
 
 
+# Attribute used to record which step an error came from. Set on the exception instead of
+# wrapping it, so the exception type the flows and error handlers match on stays unchanged.
+FAILED_STEP_ATTRIBUTE = "mpt_failed_step"
+
+
+def get_failed_step(error: Exception) -> str | None:
+    """
+    Return the name of the pipeline step that raised the error.
+
+    Args:
+        error: An exception raised while a pipeline was running.
+
+    Returns:
+        The step class name, or None when the error did not come from a pipeline step.
+    """
+    return getattr(error, FAILED_STEP_ATTRIBUTE, None)
+
+
 class Cursor:
     def __init__(self, steps, error_handler):
         self.queue = steps
@@ -38,6 +56,10 @@ class Cursor:
         try:
             current_step(client, context, next_step)
         except Exception as error:
+            # The innermost cursor annotates first, so the step that actually raised wins
+            # over the outer steps the error propagates through.
+            if not get_failed_step(error):
+                setattr(error, FAILED_STEP_ATTRIBUTE, type(current_step).__name__)
             self.error_handler(error, context, next_step)
 
 

--- a/adobe_vipm/flows/utils/notification.py
+++ b/adobe_vipm/flows/utils/notification.py
@@ -5,7 +5,9 @@ from adobe_vipm.notifications import send_exception
 
 
 @functools.cache
-def notify_unhandled_exception_in_teams(process: str, order_id: str, traceback: str) -> None:
+def notify_unhandled_exception_in_teams(
+    process: str, order_id: str, traceback: str, step: str | None = None
+) -> None:
     """
     Notify unhandled exception when processing the order to teams channel.
 
@@ -13,11 +15,13 @@ def notify_unhandled_exception_in_teams(process: str, order_id: str, traceback: 
         process: Name of the process or action.
         order_id: MPT order id.
         traceback: Traceback to report in the notification.
+        step: Pipeline step that raised the exception, when known.
     """
+    failed_step = f" in step **{step}**" if step else ""
     send_exception(
         f"Order {process} unhandled exception!",
         f"An unhandled exception has been raised while performing {process} "
-        f"of the order **{order_id}**:\n\n"
+        f"of the order **{order_id}**{failed_step}:\n\n"
         f"```{traceback}```",
     )
 

--- a/docs/external-integrations.md
+++ b/docs/external-integrations.md
@@ -21,5 +21,12 @@ index and does not duplicate those tables.
 - Adobe credentials (`EXT_ADOBE_CREDENTIALS_FILE`) and authorizations
   (`EXT_ADOBE_AUTHORIZATIONS_FILE`) are JSON files that must stay consistent;
   their formats are documented in [deployment.md](deployment.md).
+- An Adobe call that fails before any HTTP response arrives (dropped connection,
+  timeout) raises `AdobeTransportError`, which sits outside the `AdobeError`
+  hierarchy on purpose so flows that fail an order on an Adobe business rejection
+  do not fail it on a network fault. Fulfillment logs these as warnings and does
+  not raise a Teams alert: the order stays in processing and is re-dispatched, and
+  a run of failures that outlives the order due date fails the order through the
+  normal due-date path.
 - Email notifications (AWS SES) are optional and only active when
   `EXT_EMAIL_NOTIFICATIONS_ENABLED` is set.

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -21,7 +21,12 @@ from adobe_vipm.adobe.constants import (
     ResellerChangeAction,
 )
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization, ReturnableOrderInfo
-from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeProductNotFoundError
+from adobe_vipm.adobe.errors import (
+    AdobeAPIError,
+    AdobeError,
+    AdobeProductNotFoundError,
+    AdobeTransportError,
+)
 from adobe_vipm.adobe.utils import join_phone_number, to_adobe_line_id
 from adobe_vipm.flows.constants import GOVERNMENT_AGENCY_TYPE_FEDERAL, Param
 from adobe_vipm.flows.context import Context
@@ -2179,11 +2184,38 @@ def test_get_auth_token_error(requests_mocker, settings, mock_adobe_config, adob
     requests_mocker.post(
         settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"],
         status=403,
+        json={"error": "invalid_client", "error_description": "Invalid credentials"},
     )
     client = adobe_client.AdobeClient()
 
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(AdobeAPIError) as cv:
         client._get_auth_token(authorization)
+
+    assert cv.value.code == "invalid_client"
+
+
+def test_get_auth_token_transport_error(
+    requests_mocker, settings, mock_adobe_config, adobe_config_file
+):
+    authorization = Authorization(
+        authorization_uk="auth_uk",
+        authorization_id="auth_id",
+        name="test",
+        client_id="client_id",
+        client_secret="client_secret",  # ruff:ignore[hardcoded-password-func-arg]
+        currency="USD",
+        distributor_id="distributor_id",
+    )
+    requests_mocker.post(
+        settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"],
+        body=requests.ConnectionError("Connection aborted."),
+    )
+    client = adobe_client.AdobeClient()
+
+    with pytest.raises(AdobeTransportError) as cv:
+        client._get_auth_token(authorization)
+
+    assert settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"] in str(cv.value)
 
 
 def test_get_adobe_client(mocker):

--- a/tests/adobe/test_errors.py
+++ b/tests/adobe/test_errors.py
@@ -1,10 +1,17 @@
 import json
+from http.client import RemoteDisconnected
 
 import pytest
-from requests import HTTPError
+from requests import ConnectTimeout, HTTPError, PreparedRequest
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.models import Response
 
-from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, wrap_http_error
+from adobe_vipm.adobe.errors import (
+    AdobeAPIError,
+    AdobeError,
+    AdobeTransportError,
+    wrap_http_error,
+)
 
 
 def test_simple_error(adobe_api_error_factory):
@@ -83,3 +90,58 @@ def test_wrap_http_error_json_decode_error():
         func()
 
     assert str(cv.value) == "500 - Internal Server Error"
+
+
+def adobe_prepared_request(url="https://partners.adobe.io/v3/customers/1005301363"):
+    request = PreparedRequest()
+    request.prepare(method="GET", url=url, headers={"x-correlation-id": "corr-id-1"})
+    return request
+
+
+def test_wrap_http_error_names_the_request_behind_a_dropped_connection():
+    @wrap_http_error
+    def func():
+        raise RequestsConnectionError(
+            ("Connection aborted.", RemoteDisconnected("Remote end closed connection")),
+            request=adobe_prepared_request(),
+        )
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert str(cv.value) == (
+        "Adobe transport failure on GET https://partners.adobe.io/v3/customers/1005301363 "
+        "(correlation id: corr-id-1): "
+        "('Connection aborted.', RemoteDisconnected('Remote end closed connection'))"
+    )
+
+
+def test_wrap_http_error_names_the_request_behind_a_timeout():
+    @wrap_http_error
+    def func():
+        raise ConnectTimeout("timed out", request=adobe_prepared_request())
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert cv.value.request_description == (
+        "GET https://partners.adobe.io/v3/customers/1005301363 (correlation id: corr-id-1)"
+    )
+
+
+def test_wrap_http_error_falls_back_when_the_request_is_unknown():
+    @wrap_http_error
+    def func():
+        raise RequestsConnectionError("Connection aborted.")
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert cv.value.request_description == "an Adobe request"
+
+
+# Flows catch AdobeError to fail an order; a transient network fault must not do that.
+def test_transport_error_is_not_an_adobe_error():
+    result = issubclass(AdobeTransportError, AdobeError)
+
+    assert result is False

--- a/tests/flows/fulfillment/test_base.py
+++ b/tests/flows/fulfillment/test_base.py
@@ -1,7 +1,9 @@
 import pytest
 
+from adobe_vipm.adobe.errors import AdobeTransportError
 from adobe_vipm.flows.errors import MPTAPIError
 from adobe_vipm.flows.fulfillment.base import fulfill_order
+from adobe_vipm.flows.pipeline import FAILED_STEP_ATTRIBUTE
 from adobe_vipm.flows.utils import strip_trace_id
 
 pytestmark = pytest.mark.usefixtures("mock_adobe_config")
@@ -26,6 +28,41 @@ def test_fulfill_order_exception(mocker, mpt_error_factory, order_factory, mock_
     assert process == "fulfillment"
     assert order_id == order["id"]
     assert strip_trace_id(str(error)) in tb
+
+
+def test_fulfill_order_exception_reports_the_failed_step(
+    mocker, mpt_error_factory, order_factory, mock_mpt_client
+):
+    error = MPTAPIError(500, mpt_error_factory(500, "Internal Server Error", "Oops!"))
+    setattr(error, FAILED_STEP_ATTRIBUTE, "CompleteOrder")
+    mocked_notify = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.notify_unhandled_exception_in_teams"
+    )
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_purchase_order",
+        side_effect=error,
+    )
+
+    with pytest.raises(MPTAPIError):
+        fulfill_order(mock_mpt_client, order_factory(order_id="ORD-FFFF"))
+
+    assert mocked_notify.mock_calls[0].kwargs == {"step": "CompleteOrder"}
+
+
+def test_fulfill_order_transport_error_is_not_notified(mocker, order_factory, mock_mpt_client):
+    error = AdobeTransportError("GET https://partners.adobe.io/v3", "Connection aborted.")
+    mocked_notify = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.notify_unhandled_exception_in_teams"
+    )
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_purchase_order",
+        side_effect=error,
+    )
+
+    with pytest.raises(AdobeTransportError):
+        fulfill_order(mock_mpt_client, order_factory(order_id="ORD-FFFF"))
+
+    mocked_notify.assert_not_called()
 
 
 @pytest.mark.parametrize("order_type", ["purchase", "change", "configuration", "termination"])

--- a/tests/flows/test_pipeline.py
+++ b/tests/flows/test_pipeline.py
@@ -1,6 +1,6 @@
 import pytest
 
-from adobe_vipm.flows.pipeline import Cursor, Pipeline, Step
+from adobe_vipm.flows.pipeline import Cursor, Pipeline, Step, get_failed_step
 
 
 def test_pipeline_completes(mocker, mock_mpt_client):
@@ -65,3 +65,28 @@ def test_pipeline_exception_default_handler(mocker, mock_mpt_client):
 
     with pytest.raises(Exception, match="exception!"):
         pipeline.run(mock_mpt_client, mocked_context)
+
+
+def test_pipeline_records_the_step_that_raised(mocker, mock_mpt_client):
+    class PassingStep(Step):
+        def __call__(self, client, context, next_step):
+            next_step(client, context)
+
+    # BL
+    class FailingStep(Step):
+        def __call__(self, client, context, next_step):
+            raise ValueError("boom")
+
+    # BL
+    pipeline = Pipeline(PassingStep(), FailingStep())
+
+    with pytest.raises(ValueError) as cv:
+        pipeline.run(mock_mpt_client, mocker.MagicMock())
+
+    assert get_failed_step(cv.value) == "FailingStep"
+
+
+def test_get_failed_step_returns_none_outside_a_pipeline():
+    result = get_failed_step(ValueError("boom"))
+
+    assert result is None


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Fixes [MPT-23921](https://softwareone.atlassian.net/browse/MPT-23921). Sibling of [MPT-23920](https://softwareone.atlassian.net/browse/MPT-23920) (PR #934): that one reduces how often transport failures happen, this one makes the ones that still surface readable.

## Problem

A transport-layer Adobe failure produced a Teams alert of ~60 `urllib3`/`http.client` frames naming neither the endpoint, the authorization, the order, nor the pipeline step:

```
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

`requests.exceptions.ConnectionError` and `Timeout` are **siblings** of `HTTPError` under `RequestException`, and `wrap_http_error` caught `HTTPError` only. So transport failures escaped the Adobe error contract, passed through `pipeline._default_error_handler` (a plain re-raise, no step context), and reached `base.fulfill_order`, which posted the bare traceback.

Separately, `_refresh_auth_token` was undecorated, so an HTTP error from the **token** endpoint was caught by the *calling* method's wrapper and reported as an `AdobeAPIError` of, say, `get_customer` — wrong endpoint, and an error code parsed out of a payload that never came from the VIPM API.

## Change

1. **`AdobeTransportError` + wrapper.** `wrap_http_error` now also catches `ConnectionError`/`Timeout`, raising with the method, URL and correlation id from `error.request`:
   `Adobe transport failure on GET https://partners.adobe.io/v3/customers/1005301363 (correlation id: corr-id-1): ('Connection aborted.', RemoteDisconnected(...))`
   The HTTP branch moved into `_raise_adobe_response_error` to stay under the cognitive-complexity limit.
2. **`_refresh_auth_token` decorated**, so token-endpoint failures are attributed to the token request.
3. **Pipeline step attribution.** `Cursor` records the failing step's class name on the exception and `fulfill_order` passes it to Teams, so alerts read "in step **CompleteOrder**".
4. **Alerting policy.** A transport failure logs a warning with order id, step, authorization and endpoint, raises **no** Teams alert, and re-raises so the failed pass stays visible in App Insights.

## ⚠️ Deliberate deviation from the ticket — please check this reasoning

The ticket originally specified `AdobeTransportError(AdobeError)`. **I did not implement that, because it would have been a regression.** Seven flow handlers catch `AdobeError` broadly, and several fail the order outright — `fulfillment/switch.py:78`, `fulfillment/shared.py:955` (`GetPreviewOrder`), `fulfillment/transfer.py:161`, `fulfillment/configuration.py:110` all call `switch_order_to_failed` on any `AdobeError`. Under that hierarchy one dropped connection during a preview-order call would **permanently fail a customer's order**, where today it propagates and the order retries.

`AdobeTransportError` therefore subclasses `Exception`, outside the `AdobeError` tree, so control flow is unchanged and only the message improves. `test_transport_error_is_not_an_adobe_error` pins this, and the reasoning is in the class docstring. The ticket has been corrected to match.

Related: the step is recorded as an **attribute** rather than by wrapping the exception, for the same reason — wrapping would change the type those `except AdobeError`/`except AdobeAPIError` handlers match on.

## Behaviour changes to be aware of

- **Transport failures no longer page Teams.** They are logged as warnings; the order stays in Processing and is re-dispatched, and a run of failures outliving the due date fails the order through the existing `SetupDueDate` path. If you would rather keep alerting immediately, that is a one-line change.
- **Token-endpoint HTTP errors now raise `AdobeAPIError` instead of a raw `requests.HTTPError`** out of `_get_auth_token`. `test_get_auth_token_error` was asserting the old behaviour and now asserts the real `invalid_client` code.
- `notify_unhandled_exception_in_teams` gained an optional `step` argument; the validation caller is unchanged.

## Scope notes

- **Authorization id** is in the fulfillment log line, not the wrapper message: reaching it inside the decorator would need `inspect`-based argument binding, since calls like `create_preview_order(context)` take no `authorization_id`. The alert as a whole still carries every field the ticket asked for.
- **"Emit a metric" is a structured log.** There is no metrics facility in the extension code — OpenTelemetry arrives only via the SDK's request instrumentation — so this is a log line App Insights and the dashboard-triage flow can aggregate, not a counter. A real counter is separate work.
- **Validation still alerts** on transport errors: it is synchronous and user-facing with no automatic retry, so suppressing it would hide a real failure. It gets the improved message for free.

## Testing

`make check-all` clean: ruff/flake8/uv lock pass, 936 tests pass, coverage 99% overall and 100% on `adobe/errors.py`, `adobe/client.py`, `flows/pipeline.py` and `flows/utils/notification.py`.

New coverage: transport failure names method/URL/correlation id for a dropped connection and for a timeout; fallback when the exception carries no request; `AdobeTransportError` is not an `AdobeError`; token-endpoint HTTP error and transport error surface correctly; pipeline records the failing step and `get_failed_step` returns `None` outside a pipeline; fulfillment reports the step to Teams and does **not** notify for transport errors.

Branched from `main`, so PR #934 is not included here. Both touch `adobe/client.py` but on different lines.


[MPT-23921]: https://softwareone.atlassian.net/browse/MPT-23921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23920]: https://softwareone.atlassian.net/browse/MPT-23920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23921](https://softwareone.atlassian.net/browse/MPT-23921)

- Add contextual `AdobeTransportError` handling for connection and timeout failures.
- Include the HTTP method, URL, correlation ID, and failed pipeline step in error reports.
- Attribute authentication token failures to the token endpoint.
- Log fulfillment transport failures without sending Teams alerts, while preserving retries.
- Retain Teams alerts for validation transport failures.
- Preserve existing order-failure behavior by keeping `AdobeTransportError` outside the `AdobeError` hierarchy.
- Add documentation and tests for transport errors, token failures, pipeline attribution, and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->