### PR TITLE
[HF] MPT-23920 retry dropped connections in the Adobe client

### DIFF
--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -22,47 +22,72 @@ logger = logging.getLogger(__name__)
 # just to be sure to refresh token in time
 EXPIRES_IN_DELAY_SECONDS = 180
 
-# Retry policy for transient Adobe API responses. Adobe documents the status
+# Retry policy for transient Adobe API failures. Adobe documents the status
 # set 200/201/202/400/401/403/404/429/500, so 429 and 500 are the only
-# transient/retryable codes; the 4xx are client errors. Retries are scoped to
-# idempotent GET requests, so non-idempotent POST/PATCH calls are never retried.
+# transient/retryable codes; the 4xx are client errors. Status and read retries
+# are scoped to idempotent GET requests, so a non-idempotent POST/PATCH that
+# already reached Adobe is never resent.
 ADOBE_RETRY_TOTAL = 3
 ADOBE_RETRY_BACKOFF_FACTOR = 1
 ADOBE_RETRY_STATUS_FORCELIST = (429, 500)
 ADOBE_RETRY_ALLOWED_METHODS = frozenset(("GET",))
+# The auth endpoint only mints a bearer token, so resending its POST has no
+# effect on customer or order data and is safe to retry.
+ADOBE_AUTH_RETRY_ALLOWED_METHODS = frozenset(("GET", "POST"))
 
 
-def _build_retrying_session() -> requests.Session:
-    """Build a requests Session that retries transient Adobe responses.
+def _build_retry(allowed_methods: frozenset[str]) -> Retry:
+    """Build the retry policy for transient Adobe failures.
 
-    Retries are limited to idempotent GET requests for HTTP 429 and 500, the
-    only transient statuses the Adobe API raises. Non-idempotent POST and PATCH
-    requests are never retried.
+    Args:
+        allowed_methods: HTTP methods eligible for status and read retries.
 
     Returns:
-        requests.Session: Session with a retrying HTTP adapter mounted.
+        Retry: urllib3 retry policy.
     """
-    retry = Retry(
+    return Retry(
         total=ADOBE_RETRY_TOTAL,
         backoff_factor=ADOBE_RETRY_BACKOFF_FACTOR,
         status_forcelist=ADOBE_RETRY_STATUS_FORCELIST,
-        allowed_methods=ADOBE_RETRY_ALLOWED_METHODS,
-        # Retry on matching HTTP statuses only. connect/read/other default to
-        # None (bounded only by total), which would also retry transport errors;
-        # pin them to 0 so the policy stays status-only as documented above.
-        connect=0,
-        read=0,
+        allowed_methods=allowed_methods,
+        # A connect error means Adobe never received the request, so urllib3
+        # retries it for any method without gating on allowed_methods.
+        connect=ADOBE_RETRY_TOTAL,
+        # A keep-alive connection closed by Adobe while idle in the pool
+        # surfaces as a read error. urllib3 gates read retries on
+        # allowed_methods, so only the methods above are resent.
+        read=ADOBE_RETRY_TOTAL,
+        # Transport errors urllib3 cannot classify stay unretried.
         other=0,
         # Return the final response once retries are exhausted instead of raising
         # urllib3's MaxRetryError, so raise_for_status/wrap_http_error still turn
         # a persistent failure into an AdobeAPIError.
         raise_on_status=False,
     )
-    adapter = HTTPAdapter(max_retries=retry)
+
+
+def _build_retrying_session(auth_endpoint_url: str) -> requests.Session:
+    """Build a requests Session that retries transient Adobe failures.
+
+    The API adapter retries idempotent GET requests only. The auth endpoint gets
+    its own adapter that also retries its token POST, which carries no
+    side effect on customer or order data.
+
+    Args:
+        auth_endpoint_url: Adobe authentication endpoint URL, mounted with its
+            own retry adapter.
+
+    Returns:
+        requests.Session: Session with the retrying HTTP adapters mounted.
+    """
     session = requests.Session()
-    # The Adobe API and auth endpoints are always HTTPS; the retry adapter is
+    # The Adobe API and auth endpoints are always HTTPS; the retry adapters are
     # only mounted on https:// so no clear-text scheme is used.
-    session.mount("https://", adapter)
+    session.mount("https://", HTTPAdapter(max_retries=_build_retry(ADOBE_RETRY_ALLOWED_METHODS)))
+    session.mount(
+        auth_endpoint_url,
+        HTTPAdapter(max_retries=_build_retry(ADOBE_AUTH_RETRY_ALLOWED_METHODS)),
+    )
     return session
 
 
@@ -85,7 +110,7 @@ class AdobeClient(
         self._token_cache: MutableMapping[Authorization, APIToken] = {}
         self._logger = logger
         self._TIMEOUT = 60
-        self._session = _build_retrying_session()
+        self._session = _build_retrying_session(self._config.auth_endpoint_url)
 
     def _get_headers(self, authorization: Authorization, correlation_id=None):
         token = self._get_auth_token(authorization).token

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,6 +55,7 @@ Repository-specific guidance:
 - prefer existing fixtures from [`tests/conftest.py`](../tests/conftest.py) and domain-specific `conftest.py` files under `tests/`
 - add or update tests next to the affected domain area instead of creating catch-all test files
 - keep external service calls mocked; do not make live Adobe, Marketplace, Airtable, NAV, or notification calls in tests
+- the `requests_mocker` fixture (backed by `responses`) emulates retries for HTTP statuses only, and re-raises a registered exception body without retry emulation; cover transport-level retry behavior such as dropped connections by asserting the adapter's `urllib3` retry policy instead of driving a live retry through the mock
 - cover action-specific behavior in the matching fulfillment or validation test module when changing those flows
 - cover command behavior in [`tests/management/commands/`](../tests/management/commands) when changing scheduled or operational commands
 

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -2,12 +2,14 @@ import copy
 import datetime as dt
 import json
 from hashlib import sha256
+from http.client import RemoteDisconnected
 from urllib.parse import urljoin
 
 import pytest
 import requests
 from freezegun import freeze_time
 from responses import matchers
+from urllib3.exceptions import ProtocolError
 
 from adobe_vipm.adobe import client as adobe_client
 from adobe_vipm.adobe.config import REQUIRED_API_SCOPES
@@ -3426,7 +3428,7 @@ def test_get_flex_discounts_follows_pagination_links(
 
 
 def test_build_session_retry_policy_scoped_to_transient_get_requests():
-    session = adobe_client._build_retrying_session()
+    session = adobe_client._build_retrying_session("https://auth.adobe.io/token")
 
     result = session.get_adapter("https://partners.adobe.io").max_retries
 
@@ -3436,12 +3438,23 @@ def test_build_session_retry_policy_scoped_to_transient_get_requests():
     # 429 and 500 are the only transient statuses Adobe raises; 4xx client
     # errors must never be retried.
     assert set(result.status_forcelist) == {429, 500}
-    # Retries are scoped to idempotent GET; POST/PATCH are never retried.
+    # Status and read retries are scoped to idempotent GET; POST/PATCH that
+    # already reached Adobe are never resent.
     assert result.allowed_methods == frozenset(("GET",))
-    # Retries are status-only: connection/read/other transport errors are not retried.
-    assert result.connect == 0
-    assert result.read == 0
+    # Dropped pooled connections are read errors and connection refusals are
+    # connect errors; both must be retried.
+    assert result.connect == 3
+    assert result.read == 3
+    # Transport errors urllib3 cannot classify stay unretried.
     assert result.other == 0
+
+
+def test_build_session_retry_policy_retries_token_post_on_auth_endpoint():
+    session = adobe_client._build_retrying_session("https://auth.adobe.io/token")
+
+    result = session.get_adapter("https://auth.adobe.io/token").max_retries
+
+    assert result.allowed_methods == frozenset(("GET", "POST"))
 
 
 def test_client_wires_retrying_session(settings, mock_adobe_config, adobe_config_file):
@@ -3452,6 +3465,52 @@ def test_client_wires_retrying_session(settings, mock_adobe_config, adobe_config
     assert isinstance(client._session, requests.Session)
     assert set(result.status_forcelist) == {429, 500}
     assert result.allowed_methods == frozenset(("GET",))
+
+
+def test_client_wires_auth_endpoint_retrying_adapter(
+    settings, mock_adobe_config, adobe_config_file
+):
+    client = adobe_client.AdobeClient()
+
+    result = client._session.get_adapter(
+        settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"]
+    ).max_retries
+
+    assert result.allowed_methods == frozenset(("GET", "POST"))
+
+
+@pytest.mark.parametrize(
+    ("adapter_url", "method"),
+    [
+        ("https://partners.adobe.io", "GET"),
+        ("https://auth.adobe.io/token", "GET"),
+        ("https://auth.adobe.io/token", "POST"),
+    ],
+)
+def test_dropped_connection_is_retried(adapter_url, method):
+    session = adobe_client._build_retrying_session("https://auth.adobe.io/token")
+    retry = session.get_adapter(adapter_url).max_retries
+
+    result = retry.increment(
+        method=method,
+        url=adapter_url,
+        error=ProtocolError("Connection aborted.", RemoteDisconnected("dropped")),
+    )
+
+    assert result.read == adobe_client.ADOBE_RETRY_TOTAL - 1
+
+
+@pytest.mark.parametrize("method", ["POST", "PATCH"])
+def test_dropped_connection_is_not_retried_for_api_write_requests(method):
+    session = adobe_client._build_retrying_session("https://auth.adobe.io/token")
+    retry = session.get_adapter("https://partners.adobe.io").max_retries
+
+    with pytest.raises(ProtocolError):
+        retry.increment(
+            method=method,
+            url="https://partners.adobe.io",
+            error=ProtocolError("Connection aborted.", RemoteDisconnected("dropped")),
+        )
 
 
 def test_get_request_retries_transient_500_then_succeeds(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix of [MPT-23920](https://softwareone.atlassian.net/browse/MPT-23920) onto `release/5`. Cherry-pick of #934 (merged to `main`), commit `a27b708`.

## Problem

Production fires frequent false unhandled-exception Teams alerts:

```
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

Two causes combine:

1. **Pooling made the failure mode possible.** `AdobeClient` is a process-wide singleton holding one `Session`, so connections are pooled and reused. A keep-alive socket can sit idle between fulfillment passes, Adobe (or its load balancer) closes it, and the next call checks out that dead socket.
2. **The retry policy excluded transport errors.** `connect=0, read=0, other=0` made the policy status-only, and urllib3 classifies `RemoteDisconnected` as a *read* error gated on `allowed_methods`. With `allowed_methods={"GET"}` and the failing request being the auth-token POST, `Retry.increment` re-raised immediately — zero attempts.

## Change

- Enable `connect` and `read` retries (`ADOBE_RETRY_TOTAL`) instead of pinning them to `0`.
  - urllib3 does not gate **connect** retries on `allowed_methods`, which is correct: a connect error means Adobe never received the request, so it is safe to retry for any method.
  - urllib3 does gate **read** retries, and the API adapter still allows GET only, so a POST/PATCH that already reached Adobe is never resent.
- Mount a dedicated adapter on the auth endpoint with `allowed_methods={"GET", "POST"}`, so the token POST is retried. That request only mints a bearer token, so resending it has no effect on customer or order data, and it is the most frequent victim because it is the call most likely to land on a cold or stale socket.
- Factor policy construction into `_build_retry(allowed_methods)` so both adapters share one definition.
- `other=0` and `raise_on_status=False` are unchanged, so a persistent failure still surfaces as `AdobeAPIError`.

## Cherry-pick notes

- Single commit, applied with no conflicts. The `adobe_vipm/adobe/client.py` diff is byte-identical to the one merged in #934; only surrounding context auto-merged.
- No `main` merge into `release/5`, and no lockfile or dependency changes.

## Testing

`make build` then `make check-all` on this branch: ruff format, ruff check, flake8 and `uv lock --check` pass; 934 tests pass, coverage 99%.

Four new tests plus an updated policy test:

- the auth adapter allows POST while the API adapter does not, asserted on the built session and on a wired client;
- parametrized: a `ProtocolError(RemoteDisconnected(...))` on an API GET, an auth GET and an auth POST decrements the read budget, so the request is retried;
- parametrized: the same error on an API POST or PATCH re-raises immediately and is never resent.

**Note on test approach:** the `requests_mocker` fixture (backed by `responses`) emulates retries for HTTP **statuses only** — `RequestsMock._on_request` gates its retry recursion on `Retry.is_retry(method, status_code, has_retry_after)`, and a registered exception body is re-raised with no retry emulation. A drop-then-success test therefore cannot be driven through that fixture, so the tests assert the retry classification directly against `Retry.increment`, which is the exact mechanism that failed in production. This limitation is recorded in `docs/testing.md`.

## Reviewer notes

- **Behaviour change:** with read retries enabled, a persistently hanging Adobe GET can now take up to 4 attempts × 60s timeout plus backoff (~4 minutes) instead of a single 60s attempt. Acceptable for asynchronous fulfillment, but it changes worst-case call duration.
- Diagnosability of whatever transport errors still surface is out of scope here and tracked in [MPT-23921](https://softwareone.atlassian.net/browse/MPT-23921).


[MPT-23920]: https://softwareone.atlassian.net/browse/MPT-23920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23921]: https://softwareone.atlassian.net/browse/MPT-23921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-23920](https://softwareone.atlassian.net/browse/MPT-23920)

- Enable connection and read retries in the Adobe client.
- Allow API retries only for `GET` requests.
- Allow authentication retries for `GET` and `POST` requests.
- Share retry policy construction through `_build_retry(allowed_methods)`.
- Preserve `AdobeAPIError` for persistent failures.
- Add tests for retry classification, adapter configuration, and dropped connections.
- Document `requests_mocker` limitations for transport-level retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->