### PR TITLE
[HF] MPT-23921 report Adobe transport failures with request context

### DIFF
--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -9,6 +9,7 @@ from urllib3.util.retry import Retry
 
 from adobe_vipm.adobe.config import Config, get_config
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization
+from adobe_vipm.adobe.errors import wrap_http_error
 from adobe_vipm.adobe.mixins.customer import CustomerClientMixin
 from adobe_vipm.adobe.mixins.deployment import DeploymentClientMixin
 from adobe_vipm.adobe.mixins.order import OrderClientMixin
@@ -98,10 +99,13 @@ class AdobeClient(
             "x-correlation-id": correlation_id or str(uuid4()),
         }
 
+    @wrap_http_error
     def _refresh_auth_token(self, authorization: Authorization):
         """Request an authentication token for the Adobe VIPM API.
 
-        Using the credentials associated to a given the reseller.
+        Using the credentials associated to a given the reseller. Wrapped so a failure of the
+        auth endpoint is reported against the token request instead of being caught by the
+        calling method's wrapper and attributed to the Adobe API call that triggered it.
         """
         response = self._session.post(
             url=self._config.auth_endpoint_url,

--- a/adobe_vipm/adobe/errors.py
+++ b/adobe_vipm/adobe/errors.py
@@ -2,9 +2,11 @@ import json
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import ParamSpec, TypeVar
+from typing import NoReturn, ParamSpec, TypeVar
 
-from requests import HTTPError, JSONDecodeError
+from requests import HTTPError, JSONDecodeError, PreparedRequest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import RequestException, Timeout
 
 Param = ParamSpec("Param")  # noqa: WPS110
 RetType = TypeVar("RetType")
@@ -81,9 +83,68 @@ class AdobeAPIError(AdobeHttpError):
         return str(self.payload)
 
 
+class AdobeTransportError(Exception):
+    """
+    An Adobe call that failed before any HTTP response was received.
+
+    Covers dropped connections and timeouts, where Adobe returned no status code and no
+    payload, so there is nothing for `AdobeAPIError` to describe.
+
+    Deliberately outside the `AdobeError` hierarchy: flows catch `AdobeError` to fail an
+    order on a business rejection from Adobe, and a transient network fault must not take
+    that path. Keeping it separate preserves the pre-existing behaviour, where a transport
+    failure propagates for retry instead of failing the order.
+    """
+
+    def __init__(self, request_description: str, reason: str) -> None:
+        self.request_description = request_description
+        self.reason = reason
+        super().__init__(f"Adobe transport failure on {request_description}: {reason}")
+
+
+def _describe_failed_request(error: RequestException) -> str:
+    """
+    Describe the request behind a transport failure.
+
+    Args:
+        error: The requests exception raised for the failed call.
+
+    Returns:
+        str: The method, URL, and correlation id of the failed request.
+    """
+    request: PreparedRequest | None = error.request
+    if request is None:
+        return "an Adobe request"
+
+    correlation_id = request.headers.get("x-correlation-id", "unknown")
+    return f"{request.method} {request.url} (correlation id: {correlation_id})"
+
+
+def _raise_adobe_response_error(error: HTTPError) -> NoReturn:
+    """
+    Convert an error response into the matching Adobe error.
+
+    Args:
+        error: The HTTP error raised for the error response.
+
+    Raises:
+        AdobeAPIError: When the response body is the documented Adobe error JSON.
+        AdobeHttpError: When the response body is not JSON.
+    """
+    logger.error(error)
+    try:  # noqa: WPS328, WPS505
+        raise AdobeAPIError(error.response.status_code, error.response.json())
+    except JSONDecodeError:
+        raise AdobeHttpError(error.response.status_code, error.response.content.decode())
+
+
 def wrap_http_error(func: Callable[Param, RetType]) -> Callable[Param, RetType]:  # noqa: UP047
     """
-    Wrap HTTP error to Adobe API Error.
+    Wrap HTTP and transport errors into Adobe errors.
+
+    An HTTP response with an error status becomes an `AdobeAPIError` or `AdobeHttpError`. A
+    failure with no response at all becomes an `AdobeTransportError` naming the request, so
+    the caller and any alert identify the endpoint that failed.
 
     Args:
         func: function to wrap and handle exceptions
@@ -97,10 +158,10 @@ def wrap_http_error(func: Callable[Param, RetType]) -> Callable[Param, RetType]:
         try:
             return func(*args, **kwargs)
         except HTTPError as error:
-            logger.error(error)  # noqa: TRY400
-            try:  # noqa: WPS328, WPS505
-                raise AdobeAPIError(error.response.status_code, error.response.json())
-            except JSONDecodeError:
-                raise AdobeHttpError(error.response.status_code, error.response.content.decode())
+            _raise_adobe_response_error(error)
+        except (RequestsConnectionError, Timeout) as error:
+            request_description = _describe_failed_request(error)
+            logger.warning("Adobe transport failure on %s: %s", request_description, error)
+            raise AdobeTransportError(request_description, str(error)) from error
 
     return _wrapper

--- a/adobe_vipm/flows/fulfillment/base.py
+++ b/adobe_vipm/flows/fulfillment/base.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 
+from adobe_vipm.adobe.errors import AdobeTransportError
 from adobe_vipm.flows.constants import OrderType
 from adobe_vipm.flows.fulfillment.change import fulfill_change_order
 from adobe_vipm.flows.fulfillment.configuration import fulfill_configuration_order
@@ -9,6 +10,7 @@ from adobe_vipm.flows.fulfillment.reseller_transfer import fulfill_reseller_chan
 from adobe_vipm.flows.fulfillment.switch import fulfill_switch_order
 from adobe_vipm.flows.fulfillment.termination import fulfill_termination_order
 from adobe_vipm.flows.fulfillment.transfer import fulfill_transfer_order
+from adobe_vipm.flows.pipeline import get_failed_step
 from adobe_vipm.flows.utils import notify_unhandled_exception_in_teams, strip_trace_id
 from adobe_vipm.flows.utils.validation import (
     is_migrate_customer,
@@ -58,10 +60,26 @@ def fulfill_order(client, order):
             validators[order.get("type")](client, order)
         else:
             logger.info("Order %s is not a valid order type", order["id"])
-    except Exception:
+    except AdobeTransportError as error:
+        # A transport fault is transient and self-recovering: the order stays in processing
+        # and is re-dispatched, and a run of failures that outlives the due date fails the
+        # order through SetupDueDate. Log it for the dashboards instead of alerting on a
+        # network blip; the error is re-raised so the failed pass stays visible.
+        logger.warning(
+            "%s order %s: transient Adobe transport failure in %s for authorization %s: %s. "
+            "The order stays in processing and will be retried.",
+            order["type"],
+            order["id"],
+            get_failed_step(error) or "fulfillment",
+            order.get("authorization", {}).get("id", "unknown"),
+            error,
+        )
+        raise
+    except Exception as error:
         notify_unhandled_exception_in_teams(
             "fulfillment",
             order["id"],
             strip_trace_id(traceback.format_exc()),
+            step=get_failed_step(error),
         )
         raise

--- a/adobe_vipm/flows/pipeline.py
+++ b/adobe_vipm/flows/pipeline.py
@@ -24,6 +24,24 @@ def _default_error_handler(error: Exception, context: Context, next_step: NextSt
     raise error
 
 
+# Attribute used to record which step an error came from. Set on the exception instead of
+# wrapping it, so the exception type the flows and error handlers match on stays unchanged.
+FAILED_STEP_ATTRIBUTE = "mpt_failed_step"
+
+
+def get_failed_step(error: Exception) -> str | None:
+    """
+    Return the name of the pipeline step that raised the error.
+
+    Args:
+        error: An exception raised while a pipeline was running.
+
+    Returns:
+        The step class name, or None when the error did not come from a pipeline step.
+    """
+    return getattr(error, FAILED_STEP_ATTRIBUTE, None)
+
+
 class Cursor:
     def __init__(self, steps, error_handler):
         self.queue = steps
@@ -38,6 +56,10 @@ class Cursor:
         try:
             current_step(client, context, next_step)
         except Exception as error:
+            # The innermost cursor annotates first, so the step that actually raised wins
+            # over the outer steps the error propagates through.
+            if not get_failed_step(error):
+                setattr(error, FAILED_STEP_ATTRIBUTE, type(current_step).__name__)
             self.error_handler(error, context, next_step)
 
 

--- a/adobe_vipm/flows/utils/notification.py
+++ b/adobe_vipm/flows/utils/notification.py
@@ -5,7 +5,9 @@ from adobe_vipm.notifications import send_exception
 
 
 @functools.cache
-def notify_unhandled_exception_in_teams(process: str, order_id: str, traceback: str) -> None:
+def notify_unhandled_exception_in_teams(
+    process: str, order_id: str, traceback: str, step: str | None = None
+) -> None:
     """
     Notify unhandled exception when processing the order to teams channel.
 
@@ -13,11 +15,13 @@ def notify_unhandled_exception_in_teams(process: str, order_id: str, traceback: 
         process: Name of the process or action.
         order_id: MPT order id.
         traceback: Traceback to report in the notification.
+        step: Pipeline step that raised the exception, when known.
     """
+    failed_step = f" in step **{step}**" if step else ""
     send_exception(
         f"Order {process} unhandled exception!",
         f"An unhandled exception has been raised while performing {process} "
-        f"of the order **{order_id}**:\n\n"
+        f"of the order **{order_id}**{failed_step}:\n\n"
         f"```{traceback}```",
     )
 

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -21,7 +21,12 @@ from adobe_vipm.adobe.constants import (
     ResellerChangeAction,
 )
 from adobe_vipm.adobe.dataclasses import APIToken, Authorization, ReturnableOrderInfo
-from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, AdobeProductNotFoundError
+from adobe_vipm.adobe.errors import (
+    AdobeAPIError,
+    AdobeError,
+    AdobeProductNotFoundError,
+    AdobeTransportError,
+)
 from adobe_vipm.adobe.utils import join_phone_number, to_adobe_line_id
 from adobe_vipm.flows.constants import GOVERNMENT_AGENCY_TYPE_FEDERAL, Param
 from adobe_vipm.flows.context import Context
@@ -2179,11 +2184,38 @@ def test_get_auth_token_error(requests_mocker, settings, mock_adobe_config, adob
     requests_mocker.post(
         settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"],
         status=403,
+        json={"error": "invalid_client", "error_description": "Invalid credentials"},
     )
     client = adobe_client.AdobeClient()
 
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(AdobeAPIError) as cv:
         client._get_auth_token(authorization)
+
+    assert cv.value.code == "invalid_client"
+
+
+def test_get_auth_token_transport_error(
+    requests_mocker, settings, mock_adobe_config, adobe_config_file
+):
+    authorization = Authorization(
+        authorization_uk="auth_uk",
+        authorization_id="auth_id",
+        name="test",
+        client_id="client_id",
+        client_secret="client_secret",  # noqa: S106
+        currency="USD",
+        distributor_id="distributor_id",
+    )
+    requests_mocker.post(
+        settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"],
+        body=requests.ConnectionError("Connection aborted."),
+    )
+    client = adobe_client.AdobeClient()
+
+    with pytest.raises(AdobeTransportError) as cv:
+        client._get_auth_token(authorization)
+
+    assert settings.EXTENSION_CONFIG["ADOBE_AUTH_ENDPOINT_URL"] in str(cv.value)
 
 
 def test_get_adobe_client(mocker):

--- a/tests/adobe/test_errors.py
+++ b/tests/adobe/test_errors.py
@@ -1,10 +1,17 @@
 import json
+from http.client import RemoteDisconnected
 
 import pytest
-from requests import HTTPError
+from requests import ConnectTimeout, HTTPError, PreparedRequest
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.models import Response
 
-from adobe_vipm.adobe.errors import AdobeAPIError, AdobeError, wrap_http_error
+from adobe_vipm.adobe.errors import (
+    AdobeAPIError,
+    AdobeError,
+    AdobeTransportError,
+    wrap_http_error,
+)
 
 
 def test_simple_error(adobe_api_error_factory):
@@ -83,3 +90,58 @@ def test_wrap_http_error_json_decode_error():
         func()
 
     assert str(cv.value) == "500 - Internal Server Error"
+
+
+def adobe_prepared_request(url="https://partners.adobe.io/v3/customers/1005301363"):
+    request = PreparedRequest()
+    request.prepare(method="GET", url=url, headers={"x-correlation-id": "corr-id-1"})
+    return request
+
+
+def test_wrap_http_error_names_the_request_behind_a_dropped_connection():
+    @wrap_http_error
+    def func():
+        raise RequestsConnectionError(
+            ("Connection aborted.", RemoteDisconnected("Remote end closed connection")),
+            request=adobe_prepared_request(),
+        )
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert str(cv.value) == (
+        "Adobe transport failure on GET https://partners.adobe.io/v3/customers/1005301363 "
+        "(correlation id: corr-id-1): "
+        "('Connection aborted.', RemoteDisconnected('Remote end closed connection'))"
+    )
+
+
+def test_wrap_http_error_names_the_request_behind_a_timeout():
+    @wrap_http_error
+    def func():
+        raise ConnectTimeout("timed out", request=adobe_prepared_request())
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert cv.value.request_description == (
+        "GET https://partners.adobe.io/v3/customers/1005301363 (correlation id: corr-id-1)"
+    )
+
+
+def test_wrap_http_error_falls_back_when_the_request_is_unknown():
+    @wrap_http_error
+    def func():
+        raise RequestsConnectionError("Connection aborted.")
+
+    with pytest.raises(AdobeTransportError) as cv:
+        func()
+
+    assert cv.value.request_description == "an Adobe request"
+
+
+# Flows catch AdobeError to fail an order; a transient network fault must not do that.
+def test_transport_error_is_not_an_adobe_error():
+    result = issubclass(AdobeTransportError, AdobeError)
+
+    assert result is False

--- a/tests/flows/fulfillment/test_base.py
+++ b/tests/flows/fulfillment/test_base.py
@@ -1,7 +1,9 @@
 import pytest
 
+from adobe_vipm.adobe.errors import AdobeTransportError
 from adobe_vipm.flows.errors import MPTAPIError
 from adobe_vipm.flows.fulfillment.base import fulfill_order
+from adobe_vipm.flows.pipeline import FAILED_STEP_ATTRIBUTE
 from adobe_vipm.flows.utils import strip_trace_id
 
 pytestmark = pytest.mark.usefixtures("mock_adobe_config")
@@ -26,6 +28,41 @@ def test_fulfill_order_exception(mocker, mpt_error_factory, order_factory, mock_
     assert process == "fulfillment"
     assert order_id == order["id"]
     assert strip_trace_id(str(error)) in tb
+
+
+def test_fulfill_order_exception_reports_the_failed_step(
+    mocker, mpt_error_factory, order_factory, mock_mpt_client
+):
+    error = MPTAPIError(500, mpt_error_factory(500, "Internal Server Error", "Oops!"))
+    setattr(error, FAILED_STEP_ATTRIBUTE, "CompleteOrder")
+    mocked_notify = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.notify_unhandled_exception_in_teams"
+    )
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_purchase_order",
+        side_effect=error,
+    )
+
+    with pytest.raises(MPTAPIError):
+        fulfill_order(mock_mpt_client, order_factory(order_id="ORD-FFFF"))
+
+    assert mocked_notify.mock_calls[0].kwargs == {"step": "CompleteOrder"}
+
+
+def test_fulfill_order_transport_error_is_not_notified(mocker, order_factory, mock_mpt_client):
+    error = AdobeTransportError("GET https://partners.adobe.io/v3", "Connection aborted.")
+    mocked_notify = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.notify_unhandled_exception_in_teams"
+    )
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_purchase_order",
+        side_effect=error,
+    )
+
+    with pytest.raises(AdobeTransportError):
+        fulfill_order(mock_mpt_client, order_factory(order_id="ORD-FFFF"))
+
+    mocked_notify.assert_not_called()
 
 
 @pytest.mark.parametrize("order_type", ["purchase", "change", "configuration", "termination"])

--- a/tests/flows/test_pipeline.py
+++ b/tests/flows/test_pipeline.py
@@ -1,6 +1,6 @@
 import pytest
 
-from adobe_vipm.flows.pipeline import Cursor, Pipeline, Step
+from adobe_vipm.flows.pipeline import Cursor, Pipeline, Step, get_failed_step
 
 
 def test_pipeline_completes(mocker, mock_mpt_client):
@@ -65,3 +65,28 @@ def test_pipeline_exception_default_handler(mocker, mock_mpt_client):
 
     with pytest.raises(Exception, match="exception!"):
         pipeline.run(mock_mpt_client, mocked_context)
+
+
+def test_pipeline_records_the_step_that_raised(mocker, mock_mpt_client):
+    class PassingStep(Step):
+        def __call__(self, client, context, next_step):
+            next_step(client, context)
+
+    # BL
+    class FailingStep(Step):
+        def __call__(self, client, context, next_step):
+            raise ValueError("boom")
+
+    # BL
+    pipeline = Pipeline(PassingStep(), FailingStep())
+
+    with pytest.raises(ValueError) as cv:
+        pipeline.run(mock_mpt_client, mocker.MagicMock())
+
+    assert get_failed_step(cv.value) == "FailingStep"
+
+
+def test_get_failed_step_returns_none_outside_a_pipeline():
+    result = get_failed_step(ValueError("boom"))
+
+    assert result is None


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Hotfix of [MPT-23921](https://softwareone.atlassian.net/browse/MPT-23921) onto `release/5`. Cherry-pick of #935 (merged to `main`), commit `75bf35e`.

## Problem

When an Adobe call fails at the transport layer the Teams alert is ~60 lines of `urllib3`/`http.client` frames naming neither the endpoint, the authorization, the customer, nor the order. `requests.exceptions.ConnectionError` and `Timeout` are *siblings* of `HTTPError` under `RequestException`, and `wrap_http_error` caught `HTTPError` only, so transport failures escaped the Adobe error contract entirely — no wrapping, no log line, no step context.

Separately, `_refresh_auth_token` was undecorated, so an HTTP error from the token endpoint was caught by the *calling* method's wrapper and misreported as an `AdobeAPIError` of, say, `get_customer`, carrying an error code parsed from the token endpoint's payload.

## Change

- Add `AdobeTransportError` and catch `ConnectionError`/`Timeout` in `wrap_http_error`, raising with the method, URL and correlation id of the failed request.
- **`AdobeTransportError` subclasses `Exception`, not `AdobeError`, on purpose.** Seven flow handlers catch `AdobeError` and several call `switch_order_to_failed`; putting transport faults in that tree would turn one dropped connection into a permanently failed order — strictly worse than the bug being fixed. A regression test pins the class out of the `AdobeError` tree, and the reasoning is in the class docstring.
- Decorate `_refresh_auth_token` so auth-endpoint failures are attributed to the token request.
- Record the failing pipeline step on the exception as an *attribute* rather than wrapping it, so the exception type the flow handlers match on is unchanged. Innermost step wins.
- Fulfillment logs a transport failure as a warning with order id, step, authorization and endpoint and does **not** raise a Teams alert, then re-raises so the failed pass stays visible in App Insights. Persistence is still covered: `SetupDueDate` fails the order once the due date passes. Validation keeps alerting, because it is synchronous and user-facing with no retry.

## Cherry-pick notes

Single commit. Three deviations from the source, all mechanical — no behaviour difference:

1. **`adobe_vipm/adobe/errors.py`** conflicted on lint-suppression dialect only. `main` uses `# ruff:ignore[non-pep695-generic-function]`; `release/5`'s pinned ruff does not support that syntax, so this keeps `release/5`'s `# noqa: UP047`. The rest of the file is byte-identical to the source.
2. **`tests/adobe/test_client.py`** likewise: `# ruff:ignore[hardcoded-password-func-arg]` → `# noqa: S106`, matching the two existing occurrences in that same file. Left as-is it failed `make check` with RUF103 plus an unsuppressed S106.
3. **`docs/external-integrations.md` dropped.** That file does not exist on `release/5`, which predates the docs restructure on `main`, and `release/5`'s docs set (deployment, contributing, testing, migrations, documentation) has no home for an error-contract note. The doc-only hunk is therefore omitted rather than importing a new doc page into the release branch. Flag it if you would rather the note landed in `deployment.md`.

The diffs for `client.py`, `pipeline.py`, `notification.py` and `fulfillment/base.py` are identical to the source commit. No `main` merge into `release/5`, and no lockfile or dependency changes.

## Relationship to #938

[MPT-23920](https://softwareone.atlassian.net/browse/MPT-23920) is in flight for `release/5` as #938. The two are complementary — retries reduce the *volume* of these alerts, this change makes whatever still surfaces readable — and independent in git: both branch from `release/5`, they touch different regions of `client.py`, and a trial merge of the two branches is clean. Either can merge first.

## Testing

`make check` then `make check-all` on this branch: ruff format, ruff check, flake8 and `uv lock --check` pass; 936 tests pass, coverage 99%.

Tests carried over from the source cover the transport-error message and request description, the `AdobeTransportError`-is-not-an-`AdobeError` regression, token-endpoint attribution, the pipeline step attribute, and the fulfillment warning-instead-of-alert path.

## Reviewer notes

- The alert for a transport failure is now a structured warning log rather than a Teams alert. That is deliberate: these are self-recovering and were the dominant source of alert noise. A persistent failure still fails the order through the due-date path.
- "Emit a metric" from the ticket is implemented as a structured log line, not a counter — there is no metrics facility in the extension code. A real counter is separate work.


[MPT-23921]: https://softwareone.atlassian.net/browse/MPT-23921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-23920]: https://softwareone.atlassian.net/browse/MPT-23920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ