### PR TITLE
MPT-24041 Add the fulfilment process to manage the configuration/chan…

### DIFF
--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -198,7 +198,9 @@ class CreateNetNewSubscriptions(Step):
     Runs before any auto-renewal update so the additive operations always
     precede the subtractive ones and the renewing aggregate never dips below
     the 3YC committed minimum. The step is idempotent: a scheduled (1009)
-    subscription already holding the offer is reused instead of re-created.
+    subscription already holding the offer is reused instead of re-created,
+    and its auto-renewal is restored to the plan state when a previous
+    reversal disabled it.
     """
 
     def __call__(self, client, context, next_step):
@@ -221,8 +223,9 @@ class CreateNetNewSubscriptions(Step):
                 existing["subscriptionId"],
                 offer_id,
             )
-            context.renewal_net_new_subscriptions[offer_id] = existing
-            return True
+            return self._reuse_scheduled_subscription(
+                adobe_client, client, context, net_new_item, existing
+            )
 
         try:
             subscription = adobe_client.create_customer_subscription(
@@ -255,6 +258,60 @@ class CreateNetNewSubscriptions(Step):
             context,
             subscription["subscriptionId"],
             offer_id,
+        )
+        context.renewal_net_new_subscriptions[offer_id] = subscription
+        context.renewal_created_net_new_subscriptions[offer_id] = subscription
+        return True
+
+    def _reuse_scheduled_subscription(self, adobe_client, client, context, net_new_item, existing):
+        """
+        Reuse a scheduled subscription, restoring its auto-renewal plan state when needed.
+
+        A scheduled subscription neutralized by a previous reversal (auto-renewal
+        disabled) or holding a stale renewal quantity is patched back to the plan
+        state; one already in place is reused as-is. A re-enabled subscription is
+        tracked as mutated-by-this-run so a later reversal neutralizes it again.
+        """
+        offer_id = net_new_item["offerId"]
+        auto_renewal = existing.get("autoRenewal", {})
+        quantity = net_new_item["quantity"]
+        if (
+            auto_renewal.get("enabled", False)
+            and auto_renewal.get(Param.RENEWAL_QUANTITY.value) == quantity
+        ):
+            context.renewal_net_new_subscriptions[offer_id] = existing
+            return True
+
+        try:
+            subscription = adobe_client.update_subscription(
+                context.authorization_id,
+                context.adobe_customer_id,
+                existing["subscriptionId"],
+                auto_renewal=True,
+                quantity=quantity,
+            )
+        except AdobeAPIError as error:
+            logger.warning(
+                "%s: failed to restore scheduled subscription %s for offer %s: %s",
+                context,
+                existing["subscriptionId"],
+                offer_id,
+                error,
+            )
+            disable_net_new_subscriptions(adobe_client, context)
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_NET_NEW_FAILED.to_dict(offer_id=offer_id, error=error.message),
+            )
+            return False
+
+        logger.info(
+            "%s: scheduled subscription %s re-enabled for offer %s (quantity=%s)",
+            context,
+            existing["subscriptionId"],
+            offer_id,
+            quantity,
         )
         context.renewal_net_new_subscriptions[offer_id] = subscription
         context.renewal_created_net_new_subscriptions[offer_id] = subscription
@@ -382,7 +439,7 @@ class UpdateRenewalSubscriptions(Step):
             operation["subscription_id"],
             auto_renewal=operation["enabled"],
             quantity=operation["quantity"],
-            flex_discount_codes=operation["flex_discount_codes"],
+            flex_discount_codes=operation["flex_discount_codes"] or None,
         )
         logger.info(
             "%s: auto-renewal set for subscription %s (enabled=%s, quantity=%s)",
@@ -435,10 +492,10 @@ def disable_net_new_subscriptions(adobe_client, context):
 
     A scheduled (1009) subscription cannot be deleted: disabling its
     auto-renewal prevents it from activating at the anniversary, which is the
-    documented reversal path. Only the subscriptions created during this run
-    are touched: a reused scheduled subscription was not created by this
-    reversal's mutations, so its auto-renewal is preserved. Failures are
-    logged and skipped (best effort).
+    documented reversal path. Only the subscriptions created or re-enabled
+    during this run are touched: a reused scheduled subscription whose
+    auto-renewal was already in place was not mutated by this run, so its
+    auto-renewal is preserved. Failures are logged and skipped (best effort).
     """
     for offer_id, subscription in context.renewal_created_net_new_subscriptions.items():
         try:
@@ -612,7 +669,6 @@ def fulfill_renewal_order(client, order):
         UpdateAgreementParamsVisibility(),
         ValidateRenewalWindow(),
         SetupRenewalPlan(),
-        PreviewRenewal(),
         CreateNetNewSubscriptions(),
         UpdateRenewalSubscriptions(),
         CreateNetNewMptSubscriptions(),

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -290,9 +290,89 @@ def test_create_net_new_subscriptions_step_reuses_scheduled_subscription(
     step(mock_mpt_client, renewal_context, mocked_next_step)  # act
 
     mock_adobe_client.create_customer_subscription.assert_not_called()
+    mock_adobe_client.update_subscription.assert_not_called()
     assert renewal_context.renewal_net_new_subscriptions == {"65322651CA01A12": scheduled_sub}
     assert renewal_context.renewal_created_net_new_subscriptions == {}
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_create_net_new_subscriptions_step_restores_neutralized_scheduled_subscription(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context, adobe_subscription_factory
+):
+    neutralized_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=0,
+        autorenewal_enabled=False,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    restored_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=5,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    renewal_context.adobe_customer_subscriptions = [neutralized_sub]
+    mock_adobe_client.update_subscription.return_value = restored_sub
+    mocked_next_step = mocker.MagicMock()
+    step = CreateNetNewSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_customer_subscription.assert_not_called()
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        renewal_context.authorization_id,
+        renewal_context.adobe_customer_id,
+        "net-new-sub-id",
+        auto_renewal=True,
+        quantity=5,
+    )
+    assert renewal_context.renewal_net_new_subscriptions == {"65322651CA01A12": restored_sub}
+    assert renewal_context.renewal_created_net_new_subscriptions == {
+        "65322651CA01A12": restored_sub
+    }
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_create_net_new_subscriptions_step_restore_adobe_error(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_context,
+    adobe_subscription_factory,
+    adobe_api_error_factory,
+):
+    neutralized_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=0,
+        autorenewal_enabled=False,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    renewal_context.adobe_customer_subscriptions = [neutralized_sub]
+    mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
+        400,
+        adobe_api_error_factory(
+            code=AdobeErrorCode.INVALID_FIELDS.value,
+            message="Ineligible product or orderType",
+        ),
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = CreateNetNewSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_customer_subscription.assert_not_called()
+    mocked_switch_to_failed.assert_called_once()
+    assert "65322651CA01A12" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    assert renewal_context.renewal_net_new_subscriptions == {}
+    mocked_next_step.assert_not_called()
 
 
 def test_create_net_new_subscriptions_step_no_net_new_items(
@@ -398,7 +478,7 @@ def test_update_renewal_subscriptions_step_additive_before_subtractive(
             "enable-sub-id",
             auto_renewal=True,
             quantity=5,
-            flex_discount_codes=[],
+            flex_discount_codes=None,
         ),
         mocker.call(
             renewal_context.authorization_id,
@@ -414,7 +494,7 @@ def test_update_renewal_subscriptions_step_additive_before_subtractive(
             "decrease-sub-id",
             auto_renewal=True,
             quantity=3,
-            flex_discount_codes=[],
+            flex_discount_codes=None,
         ),
         mocker.call(
             renewal_context.authorization_id,
@@ -689,7 +769,6 @@ def test_fulfill_renewal_order(mocker):
         UpdateAgreementParamsVisibility,
         ValidateRenewalWindow,
         SetupRenewalPlan,
-        PreviewRenewal,
         CreateNetNewSubscriptions,
         UpdateRenewalSubscriptions,
         CreateNetNewMptSubscriptions,
@@ -703,6 +782,6 @@ def test_fulfill_renewal_order(mocker):
     actual_steps = [type(step) for step in pipeline_args]
     assert actual_steps == expected_steps
     assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
-    assert pipeline_args[13].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[12].template_name == TEMPLATE_NAME_CHANGE
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)


### PR DESCRIPTION
…ge orders created in the EF extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Reuse existing net-new scheduled subscriptions during fulfilment.
- Restore disabled or stale auto-renewal settings when required.
- Track subscriptions created or re-enabled for reversal cleanup.
- Pass `None` when no flex discount codes are specified.
- Remove the `PreviewRenewal` pipeline step.
- Add tests for subscription restoration, renewal state updates, failure handling, and order failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->