### PR TITLE
MPT-24204 Accept future-dated valid_until in SKU availability check

### DIFF
--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -12,6 +12,7 @@ from pyairtable.formulas import (
     BLANK,
     EQ,
     GT,
+    GTE,
     LOWER,
     LTE,
     NE,
@@ -489,6 +490,28 @@ def _get_historical_prices_for_skus_from_airtable(
     )
 
 
+def _get_current_prices_for_skus_from_airtable(
+    product_id: str, currency: str, skus: list[str], column_name: str
+) -> dict:
+    # A price is current when it has no end date (open-ended) or its end date is
+    # today or later. A future valid_until means a scheduled price change, not an
+    # expired SKU, so the row must still count as available.
+    today = dt.datetime.now(tz=dt.UTC).date()
+    pricelist_model = get_pricelist_model(AirTableBaseInfo.for_pricing(product_id))
+    return pricelist_model.all(
+        formula=AND(
+            EQ(Field("currency"), currency),
+            OR(
+                EQ(Field("valid_until"), BLANK()),
+                GTE(Field("valid_until"), today),
+            ),
+            OR(
+                *[EQ(Field(column_name), sku) for sku in skus],
+            ),
+        ),
+    )
+
+
 def get_prices_for_skus(product_id: str, currency: str, skus: list[str]) -> dict:
     """
     Given a currency and a list of SKUs it retrieves the purchase price.
@@ -525,7 +548,11 @@ def get_prices_for_skus(product_id: str, currency: str, skus: list[str]) -> dict
 
 def get_skus_with_available_prices(product_id: str, currency: str, skus: list[str]) -> set:
     """
-    Given a currency and a list of SKUs it retrieves the skus if the price is available.
+    Given a currency and a list of SKUs it retrieves the skus that have a current price.
+
+    A price is current when its pricelist row is open-ended (no valid_until) or its
+    valid_until is today or later. A future valid_until represents a scheduled price
+    change, so the SKU is still available and must not be treated as expired.
 
     Args:
         product_id: The ID of the product used to determine the AirTable base.
@@ -537,7 +564,7 @@ def get_skus_with_available_prices(product_id: str, currency: str, skus: list[st
     """
     if not skus:
         return set()
-    items = _get_prices_for_skus_from_airtable(product_id, currency, skus, "partial_sku")
+    items = _get_current_prices_for_skus_from_airtable(product_id, currency, skus, "partial_sku")
     return {item.partial_sku for item in items}
 
 

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -2,11 +2,13 @@ import datetime as dt
 from collections import defaultdict
 
 import pytest
+from freezegun import freeze_time
 from pyairtable.formulas import (
     AND,
     BLANK,
     EQ,
     GT,
+    GTE,
     LOWER,
     LTE,
     NE,
@@ -424,6 +426,7 @@ def test_get_prices_for_skus_missing_everywhere(mocker, settings):
     assert mocked_pricelist_model.all.call_count == 2
 
 
+@freeze_time("2024-06-01")
 def test_get_skus_with_available_prices(mocker, settings):
     settings.EXTENSION_CONFIG = {
         "AIRTABLE_API_TOKEN": "api_key",
@@ -442,10 +445,15 @@ def test_get_skus_with_available_prices(mocker, settings):
     result = get_skus_with_available_prices("product_id", "currency", ["sku-1", "sku-2"])
 
     assert result == {"sku-1", "sku-2"}
+    # A SKU is available when its price row is open-ended or its valid_until is
+    # today or later; a future valid_until is a scheduled change, not an expiry.
     mocked_pricelist_model.all.assert_called_once_with(
         formula=AND(
             EQ(Field("currency"), "currency"),
-            EQ(Field("valid_until"), BLANK()),
+            OR(
+                EQ(Field("valid_until"), BLANK()),
+                GTE(Field("valid_until"), dt.date(2024, 6, 1)),
+            ),
             OR(EQ(Field("partial_sku"), "sku-1"), EQ(Field("partial_sku"), "sku-2")),
         ),
     )


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Closes [MPT-24204](https://softwareone.atlassian.net/browse/MPT-24204)

## Problem

Customers were blocked in the change order wizard with:

> The following SKUs are expired: ['30012459CA']. Available SKUs: {'30017521CA'}.

even though the item was orderable. `get_skus_with_available_prices`
only matched pricelist rows whose `valid_until` was **blank**. A row
whose price is still current but carries a *scheduled future* end date
(a pre-announced price change) was dropped, so the SKU was reported as
expired — despite the fact it prices and fulfils fine (the Adobe preview
returns the current offer, and `get_prices_for_skus` resolves it via its
historical fallback).

## Change

`get_skus_with_available_prices` now queries with an inclusive
current-price predicate — `currency` match AND
`(valid_until BLANK OR valid_until >= today)` AND the SKU match — via a
new dedicated `_get_current_prices_for_skus_from_airtable` helper. The
boundary is inclusive: a row whose `valid_until` is exactly today is
still valid through today.

The shared `_get_prices_for_skus_from_airtable` is left untouched, since
`get_prices_for_skus` relies on its blank-only behaviour plus its own
historical fallback.

## Context

Follow-up to MPT-15759, which fixed the **3YC** variant of this symptom
and switched the availability match column from `sku` to `partial_sku`,
but left the non-3YC availability check on the blank-only filter.

## Testing

- `make check-all` — ruff/flake8/lock clean, full suite **979 passed**.
- Updated `test_get_skus_with_available_prices` (frozen clock) to assert
  the new `valid_until BLANK OR valid_until >= today` formula.


[MPT-24204]: https://softwareone.atlassian.net/browse/MPT-24204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update SKU availability checks to accept price rows with `valid_until` blank, today, or a future date.
- Add `_get_current_prices_for_skus_from_airtable` for current-price filtering.
- Update tests with a frozen clock for inclusive date validation.
- Confirm `make check-all` passes with 979 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->