### PR TITLE
MPT-23787 Commit RENEWAL/RETURN orders &amp; scoped autoRenewal norma…

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -23,6 +23,13 @@ class OrderType(StrEnum):
     CONFIGURATION = "Configuration"
 
 
+class RenewalPath(StrEnum):
+    """Values of the renewalPath property carried by the renewal payload."""
+
+    ANNIVERSARY = "anniversary"
+    NOW = "now"
+
+
 class Param(StrEnum):
     """Parameters external ids."""
 
@@ -59,6 +66,7 @@ class Param(StrEnum):
     CURRENT_QUANTITY = "currentQuantity"
     USED_QUANTITY = "usedQuantity"
     RENEWAL_QUANTITY = "renewalQuantity"
+    RENEWED_QUANTITY = "renewedQuantity"
     RENEWAL_DATE = "renewalDate"
     DUE_DATE = "dueDate"
     RETRY_COUNT = "retryCount"
@@ -496,6 +504,11 @@ ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED = ValidationError(
     "Failed to update the auto-renewal preference of subscription {subscription_id}: {error}.",
 )
 
+ERR_RENEWAL_ORDER_FAILED = ValidationError(
+    "VIPM0049",
+    "The renewal order failed: {error}.",
+)
+
 
 class AssetStatus(StrEnum):
     """MPT asset statuses."""
@@ -538,6 +551,13 @@ class ItemTermsModel(StrEnum):
     ONE_TIME = "one-time"
     USAGE = "usage"
     QUANTITY = "quantity"
+
+
+# Placeholder one-time item used to carry an early renewal ("renew now") that
+# has no quantity/discount changes. It has no counterpart in the Adobe/Airtable
+# SKU catalog, so it must be skipped wherever agreement lines are resolved
+# against Adobe SKUs.
+ITEM_EXTERNAL_ID_EARLY_RENEWAL_NO_CHANGE = "adobe-early-renewal-no-change"
 
 
 class AgreementType(StrEnum):

--- a/adobe_vipm/flows/context.py
+++ b/adobe_vipm/flows/context.py
@@ -44,6 +44,7 @@ class Context:
     renewal_created_net_new_subscriptions: dict = field(default_factory=dict)
     adobe_customer_subscriptions: list = field(default_factory=list)
     preview_renewal_order: dict | None = None
+    adobe_renewal_order: dict | None = None
 
     def __str__(self):
         due_date = self.due_date.strftime("%Y-%m-%d") if self.due_date else "-"

--- a/adobe_vipm/flows/fulfillment/base.py
+++ b/adobe_vipm/flows/fulfillment/base.py
@@ -7,6 +7,7 @@ from adobe_vipm.flows.fulfillment.change import fulfill_change_order
 from adobe_vipm.flows.fulfillment.configuration import fulfill_configuration_order
 from adobe_vipm.flows.fulfillment.purchase import fulfill_purchase_order
 from adobe_vipm.flows.fulfillment.renewal import fulfill_renewal_order
+from adobe_vipm.flows.fulfillment.renewal_now import fulfill_renewal_now_order
 from adobe_vipm.flows.fulfillment.reseller_transfer import fulfill_reseller_change_order
 from adobe_vipm.flows.fulfillment.switch import fulfill_switch_order
 from adobe_vipm.flows.fulfillment.termination import fulfill_termination_order
@@ -15,6 +16,7 @@ from adobe_vipm.flows.pipeline import get_failed_step
 from adobe_vipm.flows.utils import notify_unhandled_exception_in_teams, strip_trace_id
 from adobe_vipm.flows.utils.validation import (
     is_migrate_customer,
+    is_renew_now_order,
     is_renewal_order,
     is_reseller_change,
     is_switch_order,
@@ -34,9 +36,17 @@ def _fulfill_purchase_order_router(client, order):
 def _fulfill_change_order_router(client, order):
     if is_switch_order(order):
         return fulfill_switch_order(client, order)
+    if is_renew_now_order(order):
+        return fulfill_renewal_now_order(client, order)
     if is_renewal_order(order):
         return fulfill_renewal_order(client, order)
     return fulfill_change_order(client, order)
+
+
+def _fulfill_configuration_order_router(client, order):
+    if is_renew_now_order(order):
+        return fulfill_renewal_now_order(client, order)
+    return fulfill_configuration_order(client, order)
 
 
 def fulfill_order(client, order):
@@ -56,7 +66,7 @@ def fulfill_order(client, order):
         OrderType.PURCHASE: _fulfill_purchase_order_router,
         OrderType.CHANGE: _fulfill_change_order_router,
         OrderType.TERMINATION: fulfill_termination_order,
-        OrderType.CONFIGURATION: fulfill_configuration_order,
+        OrderType.CONFIGURATION: _fulfill_configuration_order_router,
     }
 
     try:

--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -28,7 +28,6 @@ from adobe_vipm.airtable.models import create_discount_redemptions
 from adobe_vipm.flows.constants import (
     ERR_RENEWAL_NET_NEW_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
-    ERR_RENEWAL_SUBSCRIPTION_NOT_FOUND,
     ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
     TEMPLATE_NAME_CHANGE,
     Param,
@@ -39,6 +38,7 @@ from adobe_vipm.flows.fulfillment.shared import (
     SetOrUpdateCotermDate,
     SetSubscriptionTemplate,
     SetupDueDate,
+    SetupRenewalPlan,
     StartOrderProcessing,
     SyncAgreement,
     UpdateAgreementParamsVisibility,
@@ -50,7 +50,6 @@ from adobe_vipm.flows.helpers import SetupContext
 from adobe_vipm.flows.pipeline import Pipeline, Step
 from adobe_vipm.flows.utils import (
     get_order_line_by_sku,
-    get_renewal_payload,
     get_subscription_by_line_and_item_id,
     notify_not_updated_subscriptions,
 )
@@ -60,77 +59,6 @@ from adobe_vipm.notifications import send_exception
 from adobe_vipm.utils import get_partial_sku
 
 logger = logging.getLogger(__name__)
-
-
-class SetupRenewalPlan(Step):
-    """
-    Resolve the renewal payload against the customer's Adobe subscriptions.
-
-    Each subscription referenced by the plan is matched to its Adobe
-    representation and its current auto-renewal state is snapshotted before
-    any mutation, so a reversal is always a restore-to-known-good. The full
-    subscription list is kept on the context so the net-new creation step can
-    detect scheduled subscriptions created by a previous attempt (idempotency).
-    """
-
-    def __call__(self, client, context, next_step):
-        """Resolve the renewal payload against the customer's Adobe subscriptions."""
-        context.renewal_payload = get_renewal_payload(context.order)
-        adobe_client = get_adobe_client()
-        subscriptions = adobe_client.get_subscriptions(
-            context.authorization_id,
-            context.adobe_customer_id,
-        )
-        context.adobe_customer_subscriptions = subscriptions["items"]
-        subscriptions_by_id = {
-            subscription["subscriptionId"]: subscription
-            for subscription in context.adobe_customer_subscriptions
-        }
-
-        context.renewal_plan_subscriptions = []
-        for entry in context.renewal_payload.get("subscriptions", []):
-            adobe_subscription = subscriptions_by_id.get(entry["subscriptionId"])
-            if not adobe_subscription:
-                switch_order_to_failed(
-                    client,
-                    context.order,
-                    ERR_RENEWAL_SUBSCRIPTION_NOT_FOUND.to_dict(
-                        subscription_id=entry["subscriptionId"],
-                    ),
-                )
-                logger.warning(
-                    "%s: subscription %s from the renewal plan not found in Adobe",
-                    context,
-                    entry["subscriptionId"],
-                )
-                return
-
-            context.renewal_plan_subscriptions.append(
-                self._build_plan_entry(entry, adobe_subscription)
-            )
-
-        logger.info(
-            "%s: renewal plan resolved (%s subscription(s), %s net-new item(s))",
-            context,
-            len(context.renewal_plan_subscriptions),
-            len(context.renewal_payload.get("netNewItems", [])),
-        )
-        next_step(client, context)
-
-    def _build_plan_entry(self, entry, adobe_subscription):
-        auto_renewal = adobe_subscription.get("autoRenewal", {})
-        return {
-            "subscription_id": entry["subscriptionId"],
-            "offer_id": entry.get("offerId") or adobe_subscription["offerId"],
-            "renew": entry["renew"],
-            "renewal_quantity": entry.get(Param.RENEWAL_QUANTITY.value) or 0,
-            "flex_discount_codes": entry.get("flexDiscountCodes") or [],
-            "snapshot": {
-                "enabled": auto_renewal.get("enabled", False),
-                "renewal_quantity": auto_renewal.get(Param.RENEWAL_QUANTITY.value),
-                "flex_discount_codes": auto_renewal.get("flexDiscountCodes") or [],
-            },
-        }
 
 
 class PreviewRenewal(Step):

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -1,0 +1,429 @@
+"""
+This module contains the logic to implement the renew-now fulfillment flow.
+
+It exposes a single function that is the entrypoint for change orders that
+carry a renewal payload built by the renewal wizard with renewalPath "now"
+(see flows/fulfillment/renewal.py for the at-anniversary path). The
+renewing subscriptions are committed as an actual Adobe RENEWAL order,
+invoiced immediately, mirroring how the PURCHASE flow turns its PREVIEW
+order into a NEW order: validate with PREVIEW_RENEWAL, then resubmit the
+line items it returns as the real order. Once the order completes, the
+renewed subscriptions (renew = true) have their autoRenewal normalised
+(enabled=on, renewalQuantity taken from Adobe's post-renewal
+renewedQuantity) and the plan's lapsing subscriptions (renew = false)
+have their auto-renewal disabled.
+
+Net-new items and RETURN orders for toggled-off lines are not handled yet.
+"""
+
+import logging
+
+from mpt_extension_sdk.mpt_http.mpt import update_order
+
+from adobe_vipm.adobe.client import get_adobe_client
+from adobe_vipm.adobe.constants import (
+    ORDER_STATUS_DESCRIPTION,
+    ORDER_TYPE_PREVIEW_RENEWAL,
+    UNRECOVERABLE_ORDER_STATUSES,
+    AdobeOrderStatus,
+)
+from adobe_vipm.adobe.errors import AdobeAPIError
+from adobe_vipm.flows.constants import (
+    ERR_RENEWAL_ORDER_FAILED,
+    ERR_RENEWAL_PREVIEW_FAILED,
+    ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
+    ERR_UNEXPECTED_ADOBE_ERROR_STATUS,
+    ERR_UNRECOVERABLE_ADOBE_ORDER_STATUS,
+    TEMPLATE_NAME_CHANGE,
+    Param,
+)
+from adobe_vipm.flows.context import Context
+from adobe_vipm.flows.fulfillment.shared import (
+    CompleteOrder,
+    SetOrUpdateCotermDate,
+    SetSubscriptionTemplate,
+    SetupDueDate,
+    SetupRenewalPlan,
+    StartOrderProcessing,
+    SyncAgreement,
+    UpdateAgreementParamsVisibility,
+    ValidateDuplicateLines,
+    ValidateRenewalWindow,
+    get_existing_renewal_order,
+    switch_order_to_failed,
+)
+from adobe_vipm.flows.helpers import SetupContext
+from adobe_vipm.flows.pipeline import Pipeline, Step
+from adobe_vipm.flows.utils.parameter import set_adobe_order_ids_created_parameter
+
+logger = logging.getLogger(__name__)
+
+
+def _build_renewing_line_items(context):
+    """Build PREVIEW_RENEWAL/RENEWAL line items for the plan's renewing subscriptions."""
+    line_items = []
+    renewing = [plan for plan in context.renewal_plan_subscriptions if plan["renew"]]
+    for number, plan in enumerate(renewing, start=1):
+        line_item = {
+            "extLineItemNumber": number,
+            "offerId": plan["offer_id"],
+            "subscriptionId": plan["subscription_id"],
+            "quantity": plan["renewal_quantity"],
+        }
+        if plan["flex_discount_codes"]:
+            line_item["flexDiscountCodes"] = plan["flex_discount_codes"]
+        line_items.append(line_item)
+    return line_items
+
+
+def _build_committed_line_items(preview_line_items):
+    """
+    Build RENEWAL order line items from a PREVIEW_RENEWAL response's line items.
+
+    Mirrors how the PURCHASE flow turns its PREVIEW order into a NEW order
+    (AdobeClient._build_line_item): the preview response is the source of
+    truth for the offer and quantity actually being committed, but it is
+    response-shaped (e.g. flexDiscounts is a list of discount result
+    objects, not the flexDiscountCodes the create-order request expects) and
+    carries pricing fields the create-order request doesn't need, so it is
+    re-shaped into a request line item rather than forwarded as-is.
+    """
+    line_items = []
+    for preview_line_item in preview_line_items:
+        line_item = {
+            "extLineItemNumber": preview_line_item["extLineItemNumber"],
+            "offerId": preview_line_item["offerId"],
+            "subscriptionId": preview_line_item["subscriptionId"],
+            "quantity": preview_line_item["quantity"],
+        }
+        flex_discounts = preview_line_item.get("flexDiscounts")
+        if flex_discounts:
+            line_item["flexDiscountCodes"] = [flex_discounts[0]["code"]]
+        if preview_line_item.get("deploymentId"):
+            line_item["deploymentId"] = preview_line_item["deploymentId"]
+            line_item["currencyCode"] = preview_line_item["currencyCode"]
+        line_items.append(line_item)
+    return line_items
+
+
+class PreviewRenewalNowOrder(Step):
+    """
+    Validate the renew-now plan with a PREVIEW_RENEWAL order.
+
+    The preview is the authoritative source of discount-code and SKU
+    validation and runs before SubmitRenewalNowOrder commits anything, so a
+    rejected basket fails the order with nothing to reverse. Skipped once
+    the real RENEWAL order already exists (idempotent retries).
+    """
+
+    def __call__(self, client, context, next_step):
+        """Validate the renew-now plan with a PREVIEW_RENEWAL order."""
+        line_items = _build_renewing_line_items(context)
+        if not line_items:
+            logger.info("%s: no renewing subscriptions, skipping renewal preview", context)
+            next_step(client, context)
+            return
+
+        if not self._validate_preview(client, context, line_items):
+            return
+
+        next_step(client, context)
+
+    def _validate_preview(self, client, context, line_items):
+        """Validate the plan via PREVIEW_RENEWAL, returning False on a confirmed failure."""
+        adobe_client = get_adobe_client()
+        existing_order = get_existing_renewal_order(adobe_client, context, context.order_id)
+        if existing_order:
+            logger.info("%s: renewal order %s already exists", context, existing_order["orderId"])
+            return True
+
+        try:
+            context.preview_renewal_order = adobe_client.create_renewal_order(
+                context.authorization_id,
+                context.adobe_customer_id,
+                context.order_id,
+                line_items,
+                order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+            )
+        except AdobeAPIError as error:
+            logger.warning("%s: renewal preview failed: %s", context, error)
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_PREVIEW_FAILED.to_dict(error=error.message),
+            )
+            return False
+
+        logger.info(
+            "%s: renewal preview validated for %s subscription(s)", context, len(line_items)
+        )
+        return True
+
+
+class SubmitRenewalNowOrder(Step):
+    """
+    Commit the renew-now plan as an actual Adobe RENEWAL order.
+
+    Uses the line items validated by PreviewRenewalNowOrder — the renewal
+    counterpart of how the PURCHASE flow turns its PREVIEW order into a NEW
+    order. It is invoiced immediately and takes effect now. The existing
+    Adobe RENEWAL order is detected by its external reference id, so a
+    retry of this step is idempotent.
+
+    Net-new items and RETURN orders for toggled-off lines are not handled
+    by this step.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Commit the renew-now plan as an actual Adobe RENEWAL order."""
+        if not _build_renewing_line_items(context):
+            next_step(client, context)
+            return
+
+        adobe_client = get_adobe_client()
+        existing_order = get_existing_renewal_order(adobe_client, context, context.order_id)
+        if not existing_order and context.preview_renewal_order is None:
+            logger.info("%s: no renewal preview available, skipping renewal order", context)
+            next_step(client, context)
+            return
+
+        order = existing_order or self._submit_order(client, context, adobe_client)
+        if order is None:
+            return
+
+        if not self._is_order_complete(client, context, order):
+            return
+
+        context.adobe_renewal_order = order
+        logger.info("%s: renewal order %s completed", context, order["orderId"])
+        next_step(client, context)
+
+    def _submit_order(self, client, context, adobe_client):
+        try:
+            order = adobe_client.create_renewal_order(
+                context.authorization_id,
+                context.adobe_customer_id,
+                context.order_id,
+                _build_committed_line_items(context.preview_renewal_order["lineItems"]),
+            )
+        except AdobeAPIError as error:
+            logger.warning("%s: renewal order failed: %s", context, error)
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_ORDER_FAILED.to_dict(error=error.message),
+            )
+            return None
+
+        logger.info("%s: renewal order %s created", context, order["orderId"])
+        context.order = set_adobe_order_ids_created_parameter(context, [order["orderId"]])
+        update_order(client, context.order_id, parameters=context.order["parameters"])
+        return order
+
+    def _is_order_complete(self, client, context, order):
+        """Return True once the order is COMPLETE, failing the MPT order on a terminal status."""
+        if order["status"] == AdobeOrderStatus.OPEN:
+            logger.info("%s: renewal order %s is still pending", context, order["orderId"])
+            return False
+
+        if order["status"] in UNRECOVERABLE_ORDER_STATUSES:
+            error = ERR_UNRECOVERABLE_ADOBE_ORDER_STATUS.to_dict(
+                description=ORDER_STATUS_DESCRIPTION[order["status"]],
+            )
+            self._fail_order(client, context, order, error)
+            return False
+
+        if order["status"] != AdobeOrderStatus.COMPLETE:
+            error = ERR_UNEXPECTED_ADOBE_ERROR_STATUS.to_dict(status=order["status"])
+            self._fail_order(client, context, order, error)
+            return False
+
+        return True
+
+    def _fail_order(self, client, context, order, error):
+        switch_order_to_failed(client, context.order, error)
+        logger.warning(
+            "%s: renewal order %s has been failed: %s",
+            context,
+            order["orderId"],
+            error["message"],
+        )
+
+
+class NormalizeRenewedSubscriptions(Step):
+    """
+    Normalise autoRenewal for the plan's renewed subscriptions (renew = true).
+
+    Runs once the renew-now RENEWAL order has committed — Adobe blocks
+    autoRenewal PATCHes on a subscription during its renewal-fulfilment
+    window, so this can't happen before SubmitRenewalNowOrder completes.
+    For each renewed subscription, re-fetches it from Adobe to read the
+    post-renewal `renewedQuantity` (only populated between the renewal and
+    the subscription's anniversary date — never the plan's requested
+    renewal_quantity, which can differ from what Adobe actually committed)
+    and PATCHes autoRenewal to enabled=True with renewalQuantity set to
+    that value, so the stored auto-renewal preference reflects what was
+    just renewed. Scoped to only the subscriptions renewed by this order —
+    never the full customer subscription list — so it can't clobber an
+    auto-renewal preference a customer explicitly turned off on another
+    subscription. Idempotent: a retry re-fetches and reapplies the same
+    value.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Normalise autoRenewal for the plan's renewed subscriptions."""
+        adobe_client = get_adobe_client()
+        renewing = [plan for plan in context.renewal_plan_subscriptions if plan["renew"]]
+        for plan in renewing:
+            if not self._normalize(client, adobe_client, context, plan):
+                return
+
+        next_step(client, context)
+
+    def _normalize(self, client, adobe_client, context, plan):
+        subscription_id = plan["subscription_id"]
+        try:
+            subscription = adobe_client.get_subscription(
+                context.authorization_id,
+                context.adobe_customer_id,
+                subscription_id,
+            )
+        except AdobeAPIError as error:
+            return self._fail(client, context, subscription_id, error)
+
+        renewed_quantity = subscription.get(Param.RENEWED_QUANTITY.value)
+        if renewed_quantity is None:
+            logger.info(
+                "%s: subscription %s has no renewedQuantity yet, skipping normalisation",
+                context,
+                subscription_id,
+            )
+            return True
+
+        try:
+            adobe_client.update_subscription(
+                context.authorization_id,
+                context.adobe_customer_id,
+                subscription_id,
+                auto_renewal=True,
+                quantity=renewed_quantity,
+            )
+        except AdobeAPIError as error:
+            return self._fail(client, context, subscription_id, error)
+
+        logger.info(
+            "%s: autoRenewal normalised for subscription %s (renewalQuantity=%s)",
+            context,
+            subscription_id,
+            renewed_quantity,
+        )
+        return True
+
+    def _fail(self, client, context, subscription_id, error):
+        logger.warning(
+            "%s: failed to normalise autoRenewal for subscription %s: %s",
+            context,
+            subscription_id,
+            error,
+        )
+        switch_order_to_failed(
+            client,
+            context.order,
+            ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED.to_dict(
+                subscription_id=subscription_id,
+                error=error.message,
+            ),
+        )
+        return False
+
+
+class DisableLapsingSubscriptions(Step):
+    """
+    Disable auto-renewal for the plan's lapsing subscriptions (renew = false).
+
+    Runs once the renew-now RENEWAL order has committed, so the subtractive
+    operation never precedes the additive one. A subscription already
+    disabled is skipped (using the snapshot SetupRenewalPlan took before any
+    mutation), so retries are safe.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Disable auto-renewal for the plan's lapsing subscriptions."""
+        adobe_client = get_adobe_client()
+        for plan in context.renewal_plan_subscriptions:
+            if plan["renew"] or not plan["snapshot"]["enabled"]:
+                continue
+
+            if not self._disable(client, adobe_client, context, plan):
+                return
+
+        next_step(client, context)
+
+    def _disable(self, client, adobe_client, context, plan):
+        try:
+            adobe_client.update_subscription(
+                context.authorization_id,
+                context.adobe_customer_id,
+                plan["subscription_id"],
+                auto_renewal=False,
+            )
+        except AdobeAPIError as error:
+            logger.warning(
+                "%s: failed to disable auto-renewal for subscription %s: %s",
+                context,
+                plan["subscription_id"],
+                error,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED.to_dict(
+                    subscription_id=plan["subscription_id"],
+                    error=error.message,
+                ),
+            )
+            return False
+
+        logger.info(
+            "%s: auto-renewal disabled for subscription %s", context, plan["subscription_id"]
+        )
+        return True
+
+
+def fulfill_renewal_now_order(client, order):
+    """
+    Fulfills a change order that carries a renew-now renewal payload.
+
+    The plan's renewing subscriptions are validated with a PREVIEW_RENEWAL
+    and committed as an actual Adobe RENEWAL order, invoiced immediately.
+    Once it completes, the renewed subscriptions (renew = true) have their
+    autoRenewal normalised and the plan's lapsing subscriptions
+    (renew = false) have their auto-renewal disabled.
+
+    Args:
+        client (MPTClient): An instance of the MPT client used for communication
+        with the MPT system.
+        order (dict): The MPT order representing the renewal order to be fulfilled.
+
+    Returns:
+        None
+    """
+    pipeline = Pipeline(
+        SetupContext(),
+        StartOrderProcessing(TEMPLATE_NAME_CHANGE),
+        SetupDueDate(),
+        ValidateDuplicateLines(),
+        SetOrUpdateCotermDate(),
+        UpdateAgreementParamsVisibility(),
+        ValidateRenewalWindow(),
+        SetupRenewalPlan(),
+        PreviewRenewalNowOrder(),
+        SubmitRenewalNowOrder(),
+        NormalizeRenewedSubscriptions(),
+        DisableLapsingSubscriptions(),
+        CompleteOrder(TEMPLATE_NAME_CHANGE),
+        SetSubscriptionTemplate(),
+        SyncAgreement(),
+    )
+    context = Context(order=order)
+    pipeline.run(client, context)

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -51,6 +51,7 @@ from adobe_vipm.flows.constants import (
     ERR_EXISTING_ITEMS,
     ERR_MANUAL_RENEWAL_ORDER_FAILED,
     ERR_MANUAL_RENEWAL_PREVIEW_FAILED,
+    ERR_RENEWAL_SUBSCRIPTION_NOT_FOUND,
     ERR_UNEXPECTED_ADOBE_ERROR_STATUS,
     ERR_UNRECOVERABLE_ADOBE_ORDER_STATUS,
     ERR_VIPM_UNHANDLED_EXCEPTION,
@@ -73,6 +74,7 @@ from adobe_vipm.flows.utils import (
     get_due_date,
     get_one_time_skus,
     get_order_line_by_sku,
+    get_renewal_payload,
     get_subscription_by_line_and_item_id,
     is_coterm_date_within_order_creation_window,
     map_returnable_to_return_orders,
@@ -1728,6 +1730,78 @@ class CheckManualRenewalSubscriptions(Step):
             sku,
             full_qty,
         )
+
+
+class SetupRenewalPlan(Step):
+    """
+    Resolve the renewal payload against the customer's Adobe subscriptions.
+
+    Shared by the at-anniversary and renew-now renewal fulfillment flows.
+    Each subscription referenced by the plan is matched to its Adobe
+    representation and its current auto-renewal state is snapshotted before
+    any mutation, so a reversal is always a restore-to-known-good. The full
+    subscription list is kept on the context so the net-new creation step can
+    detect scheduled subscriptions created by a previous attempt (idempotency).
+    """
+
+    def __call__(self, client, context, next_step):
+        """Resolve the renewal payload against the customer's Adobe subscriptions."""
+        context.renewal_payload = get_renewal_payload(context.order)
+        adobe_client = get_adobe_client()
+        subscriptions = adobe_client.get_subscriptions(
+            context.authorization_id,
+            context.adobe_customer_id,
+        )
+        context.adobe_customer_subscriptions = subscriptions["items"]
+        subscriptions_by_id = {
+            subscription["subscriptionId"]: subscription
+            for subscription in context.adobe_customer_subscriptions
+        }
+
+        context.renewal_plan_subscriptions = []
+        for entry in context.renewal_payload.get("subscriptions", []):
+            adobe_subscription = subscriptions_by_id.get(entry["subscriptionId"])
+            if not adobe_subscription:
+                switch_order_to_failed(
+                    client,
+                    context.order,
+                    ERR_RENEWAL_SUBSCRIPTION_NOT_FOUND.to_dict(
+                        subscription_id=entry["subscriptionId"],
+                    ),
+                )
+                logger.warning(
+                    "%s: subscription %s from the renewal plan not found in Adobe",
+                    context,
+                    entry["subscriptionId"],
+                )
+                return
+
+            context.renewal_plan_subscriptions.append(
+                self._build_plan_entry(entry, adobe_subscription)
+            )
+
+        logger.info(
+            "%s: renewal plan resolved (%s subscription(s), %s net-new item(s))",
+            context,
+            len(context.renewal_plan_subscriptions),
+            len(context.renewal_payload.get("netNewItems", [])),
+        )
+        next_step(client, context)
+
+    def _build_plan_entry(self, entry, adobe_subscription):
+        auto_renewal = adobe_subscription.get("autoRenewal", {})
+        return {
+            "subscription_id": entry["subscriptionId"],
+            "offer_id": entry.get("offerId") or adobe_subscription["offerId"],
+            "renew": entry["renew"],
+            "renewal_quantity": entry.get(Param.RENEWAL_QUANTITY.value) or 0,
+            "flex_discount_codes": entry.get("flexDiscountCodes") or [],
+            "snapshot": {
+                "enabled": auto_renewal.get("enabled", False),
+                "renewal_quantity": auto_renewal.get(Param.RENEWAL_QUANTITY.value),
+                "flex_discount_codes": auto_renewal.get("flexDiscountCodes") or [],
+            },
+        }
 
 
 class PreviewRenewalOrders(Step):

--- a/adobe_vipm/flows/sync/agreement.py
+++ b/adobe_vipm/flows/sync/agreement.py
@@ -29,6 +29,7 @@ from adobe_vipm.airtable import models
 from adobe_vipm.flows import utils as flows_utils
 from adobe_vipm.flows.benefits import send_3yc_expiration_notification
 from adobe_vipm.flows.constants import (
+    ITEM_EXTERNAL_ID_EARLY_RENEWAL_NO_CHANGE,
     MARKET_SEGMENT_EDUCATION,
     TEMPLATE_ASSET_DEFAULT,
     TEMPLATE_SUBSCRIPTION_EXPIRED,
@@ -746,9 +747,16 @@ class AgreementSyncer:  # noqa: WPS214
                     line.get("id"),
                 )
                 continue
-            else:
-                actual_sku = models.get_adobe_sku(vendor_id, get_market_segment(self.product_id))
-                agreement_lines.append((line, actual_sku))
+
+            if vendor_id == ITEM_EXTERNAL_ID_EARLY_RENEWAL_NO_CHANGE:
+                logger.info(
+                    "Skipping agreement line %s: early-renewal no-change placeholder item",
+                    line.get("id"),
+                )
+                continue
+
+            actual_sku = models.get_adobe_sku(vendor_id, get_market_segment(self.product_id))
+            agreement_lines.append((line, actual_sku))
 
         return agreement_lines
 

--- a/adobe_vipm/flows/utils/__init__.py
+++ b/adobe_vipm/flows/utils/__init__.py
@@ -100,6 +100,7 @@ from .three_yc import (
 from .validation import (
     is_migrate_customer,
     is_purchase_validation_enabled,
+    is_renew_now_order,
     is_renewal_order,
     is_reseller_change,
     is_switch_order,

--- a/adobe_vipm/flows/utils/validation.py
+++ b/adobe_vipm/flows/utils/validation.py
@@ -4,6 +4,7 @@ from adobe_vipm.flows.constants import (
     PARAM_REQUIRED_CUSTOMER_ORDER,
     AgreementType,
     Param,
+    RenewalPath,
 )
 from adobe_vipm.flows.errors import GovernmentLGANotValidOrderError, GovernmentNotValidOrderError
 from adobe_vipm.flows.utils.market_segment import (
@@ -146,6 +147,20 @@ def is_renewal_order(order: dict) -> bool:
         if the renewal payload ordering parameter is set.
     """
     return bool(get_renewal_payload(order))
+
+
+def is_renew_now_order(order: dict) -> bool:
+    """
+    Checks if order is a change order for a renew-now (early) renewal.
+
+    Args:
+        order: MPT order.
+
+    Returns:
+        if the renewal payload ordering parameter is set with renewalPath "now".
+    """
+    payload = get_renewal_payload(order)
+    return bool(payload) and payload.get("renewalPath") == RenewalPath.NOW
 
 
 def validate_government_lga_data(order: dict, adobe_data: dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ per-file-ignores = [
   "adobe_vipm/flows/fulfillment/purchase.py: WPS110 WPS114 WPS203 WPS204 WPS229 WPS231 WPS235 WPS338",
   "adobe_vipm/flows/fulfillment/shared.py: WPS110 WPS201 WPS202 WPS203 WPS204 WPS210 WPS213 WPS214 WPS220 WPS221 WPS229 WPS231 WPS235 WPS237 WPS336 WPS426 WPS441 WPS504",
   "adobe_vipm/flows/fulfillment/renewal.py: WPS202 WPS235",
+  "adobe_vipm/flows/fulfillment/renewal_now.py: WPS204 WPS235",
   "adobe_vipm/flows/fulfillment/switch.py: WPS235",
   "adobe_vipm/flows/fulfillment/termination.py: WPS210 WPS220 WPS229 WPS231 WPS235",
   "adobe_vipm/flows/fulfillment/transfer.py: WPS110 WPS201 WPS202 WPS203 WPS204 WPS210 WPS211 WPS221 WPS231 WPS235 WPS237 WPS432 WPS479 WPS480",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1532,6 +1532,7 @@ def mock_adobe_client(mocker):
         "adobe_vipm.flows.fulfillment.change",
         "adobe_vipm.flows.fulfillment.purchase",
         "adobe_vipm.flows.fulfillment.renewal",
+        "adobe_vipm.flows.fulfillment.renewal_now",
         "adobe_vipm.flows.fulfillment.shared",
         "adobe_vipm.flows.fulfillment.switch",
         "adobe_vipm.flows.fulfillment.configuration",

--- a/tests/flows/fulfillment/test_base.py
+++ b/tests/flows/fulfillment/test_base.py
@@ -114,3 +114,59 @@ def test_fulfill_order_renewal(
     fulfill_order(mock_mpt_client, order)  # act
 
     mocked_fulfill.assert_called_once_with(mock_mpt_client, order)
+
+
+def test_fulfill_order_renewal_now(
+    mocker, order_factory, mock_mpt_client, order_parameters_factory, renewal_payload
+):
+    mocked_fulfill = mocker.patch("adobe_vipm.flows.fulfillment.base.fulfill_renewal_now_order")
+    mocked_fulfill_anniversary = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_renewal_order"
+    )
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(
+            renewal_payload={**renewal_payload, "renewalPath": "now"}
+        ),
+    )
+
+    fulfill_order(mock_mpt_client, order)  # act
+
+    mocked_fulfill.assert_called_once_with(mock_mpt_client, order)
+    mocked_fulfill_anniversary.assert_not_called()
+
+
+def test_fulfill_order_configuration_renew_now(
+    mocker, order_factory, mock_mpt_client, order_parameters_factory, renewal_payload
+):
+    mocked_fulfill = mocker.patch("adobe_vipm.flows.fulfillment.base.fulfill_renewal_now_order")
+    mocked_fulfill_configuration = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_configuration_order"
+    )
+    order = order_factory(
+        order_type="Configuration",
+        order_parameters=order_parameters_factory(
+            renewal_payload={**renewal_payload, "renewalPath": "now"}
+        ),
+    )
+
+    fulfill_order(mock_mpt_client, order)  # act
+
+    mocked_fulfill.assert_called_once_with(mock_mpt_client, order)
+    mocked_fulfill_configuration.assert_not_called()
+
+
+def test_fulfill_order_configuration_without_renewal_payload(
+    mocker, order_factory, mock_mpt_client
+):
+    """A plain Configuration order (no renewalPayload) still uses the standard flow."""
+    mocked_fulfill = mocker.patch("adobe_vipm.flows.fulfillment.base.fulfill_configuration_order")
+    mocked_fulfill_renewal_now = mocker.patch(
+        "adobe_vipm.flows.fulfillment.base.fulfill_renewal_now_order"
+    )
+    order = order_factory(order_type="Configuration")
+
+    fulfill_order(mock_mpt_client, order)  # act
+
+    mocked_fulfill.assert_called_once_with(mock_mpt_client, order)
+    mocked_fulfill_renewal_now.assert_not_called()

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -155,7 +155,7 @@ def test_setup_renewal_plan_step_subscription_not_found(
         "totalCount": 1,
     }
     mocked_switch_to_failed = mocker.patch(
-        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+        "adobe_vipm.flows.fulfillment.shared.switch_order_to_failed"
     )
     mocked_next_step = mocker.MagicMock()
     step = SetupRenewalPlan()

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -1,0 +1,622 @@
+import pytest
+
+from adobe_vipm.adobe.constants import (
+    ORDER_TYPE_PREVIEW_RENEWAL,
+    ORDER_TYPE_RENEWAL,
+    AdobeErrorCode,
+    AdobeOrderStatus,
+)
+from adobe_vipm.adobe.errors import AdobeAPIError
+from adobe_vipm.flows.constants import TEMPLATE_NAME_CHANGE
+from adobe_vipm.flows.context import Context
+from adobe_vipm.flows.fulfillment.renewal_now import (
+    DisableLapsingSubscriptions,
+    NormalizeRenewedSubscriptions,
+    PreviewRenewalNowOrder,
+    SubmitRenewalNowOrder,
+    fulfill_renewal_now_order,
+)
+from adobe_vipm.flows.fulfillment.shared import (
+    CompleteOrder,
+    SetOrUpdateCotermDate,
+    SetSubscriptionTemplate,
+    SetupDueDate,
+    SetupRenewalPlan,
+    StartOrderProcessing,
+    SyncAgreement,
+    UpdateAgreementParamsVisibility,
+    ValidateDuplicateLines,
+    ValidateRenewalWindow,
+)
+from adobe_vipm.flows.helpers import SetupContext
+
+pytestmark = pytest.mark.usefixtures("mock_adobe_config")
+
+
+@pytest.fixture
+def renewal_now_order(order_factory, order_parameters_factory, lines_factory, renewal_payload):
+    lines = lines_factory(
+        line_id=1, item_id=1, external_vendor_id="65304578CA", quantity=15
+    ) + lines_factory(line_id=2, item_id=2, external_vendor_id="77777777CA", quantity=10)
+    payload = {**renewal_payload, "renewalPath": "now"}
+    return order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(renewal_payload=payload),
+        lines=lines,
+    )
+
+
+@pytest.fixture
+def renewal_now_context(renewal_now_order, renewal_payload):
+    return Context(
+        order=renewal_now_order,
+        order_id=renewal_now_order["id"],
+        product_id="PRD-1111-1111",
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        renewal_payload={**renewal_payload, "renewalPath": "now"},
+    )
+
+
+def plan_entry(
+    subscription_id="renewing-sub-id",
+    offer_id="65304578CA01A12",
+    renew=True,  # ruff:ignore[boolean-default-value-positional-argument]
+    renewal_quantity=15,
+    flex_discount_codes=None,
+    snapshot_enabled=True,  # ruff:ignore[boolean-default-value-positional-argument]
+    snapshot_quantity=10,
+    snapshot_codes=None,
+):
+    return {
+        "subscription_id": subscription_id,
+        "offer_id": offer_id,
+        "renew": renew,
+        "renewal_quantity": renewal_quantity,
+        "flex_discount_codes": flex_discount_codes or [],
+        "snapshot": {
+            "enabled": snapshot_enabled,
+            "renewal_quantity": snapshot_quantity,
+            "flex_discount_codes": snapshot_codes or [],
+        },
+    }
+
+
+def test_preview_renewal_now_order_step_no_renewing_subscriptions(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    mock_adobe_client.get_orders.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_existing_order_skips_preview(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    existing_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        external_id=renewal_now_context.order_id,
+        order_id="ADOBE-RENEWAL-EXISTING",
+    )
+    mock_adobe_client.get_orders.return_value = [existing_order]
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    assert renewal_now_context.preview_renewal_order is None
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_validates_preview(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry(flex_discount_codes=["CODE-1"])]
+    mock_adobe_client.get_orders.return_value = []
+    preview_order = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
+    )
+    mock_adobe_client.create_renewal_order.return_value = preview_order
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        filters={"order-type": ORDER_TYPE_RENEWAL},
+    )
+    mock_adobe_client.create_renewal_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+        [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+                "flexDiscountCodes": ["CODE-1"],
+            },
+        ],
+        order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+    )
+    assert renewal_now_context.preview_renewal_order == preview_order
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_preview_failed(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_api_error_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.side_effect = AdobeAPIError(
+        400,
+        adobe_api_error_factory(
+            code=AdobeErrorCode.INVALID_FIELDS.value,
+            message="Invalid discount code",
+        ),
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "Invalid discount code" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    assert renewal_now_context.preview_renewal_order is None
+    mocked_next_step.assert_not_called()
+
+
+def test_submit_renewal_now_order_step_no_renewing_subscriptions(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_submit_renewal_now_order_step_no_preview_available(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    """Defensive fallback if this step ever runs without PreviewRenewalNowOrder first."""
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context.preview_renewal_order = None
+    mock_adobe_client.get_orders.return_value = []
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    assert renewal_now_context.adobe_renewal_order is None
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_submit_renewal_now_order_step_existing_order_reused(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    existing_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        external_id=renewal_now_context.order_id,
+        order_id="ADOBE-RENEWAL-EXISTING",
+    )
+    mock_adobe_client.get_orders.return_value = [existing_order]
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    assert renewal_now_context.adobe_renewal_order == existing_order
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_submit_renewal_now_order_step_commits_order(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry(flex_discount_codes=["CODE-1"])]
+    # The preview response (set by PreviewRenewalNowOrder in a prior pipeline step) is
+    # response-shaped (flexDiscounts, pricing) and can resolve a different quantity than
+    # requested (e.g. Adobe adjusting it) — both must be honored.
+    renewal_now_context.preview_renewal_order = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 14,
+                "flexDiscounts": [{"code": "CODE-1", "result": "SUCCESS"}],
+                "pricing": {"unitPP": "10.00"},
+            },
+        ],
+    )
+    mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+    )
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = renewal_order
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        filters={"order-type": ORDER_TYPE_RENEWAL},
+    )
+    mock_adobe_client.create_renewal_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+        [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 14,
+                "flexDiscountCodes": ["CODE-1"],
+            },
+        ],
+    )
+    mocked_update_order.assert_called_once_with(
+        mock_mpt_client,
+        renewal_now_context.order_id,
+        parameters=renewal_now_context.order["parameters"],
+    )
+    assert renewal_now_context.adobe_renewal_order == renewal_order
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_submit_renewal_now_order_step_order_failed(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_api_error_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context.preview_renewal_order = {
+        "lineItems": [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    }
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("9999", "order error")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "order error" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    assert renewal_now_context.adobe_renewal_order is None
+    mocked_next_step.assert_not_called()
+
+
+def test_submit_renewal_now_order_step_pending(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context.preview_renewal_order = {
+        "lineItems": [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    }
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    renewal_order = adobe_order_factory(order_type="RENEWAL", status=AdobeOrderStatus.OPEN.value)
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = renewal_order
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.adobe_renewal_order is None
+    mocked_next_step.assert_not_called()
+
+
+def test_submit_renewal_now_order_step_unrecoverable_status(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context.preview_renewal_order = {
+        "lineItems": [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    }
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.FAILED.value,
+        order_id="ADOBE-RENEWAL-002",
+    )
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = renewal_order
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert renewal_now_context.adobe_renewal_order is None
+    mocked_next_step.assert_not_called()
+
+
+def test_submit_renewal_now_order_step_unexpected_status(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context.preview_renewal_order = {
+        "lineItems": [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    }
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    renewal_order = {
+        **adobe_order_factory(order_type="RENEWAL", order_id="ADOBE-RENEWAL-003"),
+        "status": "9999",
+    }
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = renewal_order
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert renewal_now_context.adobe_renewal_order is None
+    mocked_next_step.assert_not_called()
+
+
+def test_normalize_renewed_subscriptions_step(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(),
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mock_adobe_client.get_subscription.return_value = {
+        "subscriptionId": "renewing-sub-id",
+        "renewedQuantity": 9,
+    }
+    mocked_next_step = mocker.MagicMock()
+    step = NormalizeRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        "renewing-sub-id",
+    )
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        "renewing-sub-id",
+        auto_renewal=True,
+        quantity=9,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_normalize_renewed_subscriptions_step_no_renewed_quantity_skips_patch(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    mock_adobe_client.get_subscription.return_value = {"subscriptionId": "renewing-sub-id"}
+    mocked_next_step = mocker.MagicMock()
+    step = NormalizeRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.update_subscription.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_normalize_renewed_subscriptions_step_get_subscription_error(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_api_error_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    mock_adobe_client.get_subscription.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("9999", "cannot fetch subscription")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = NormalizeRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "renewing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mock_adobe_client.update_subscription.assert_not_called()
+    mocked_next_step.assert_not_called()
+
+
+def test_normalize_renewed_subscriptions_step_update_subscription_error(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_api_error_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry()]
+    mock_adobe_client.get_subscription.return_value = {
+        "subscriptionId": "renewing-sub-id",
+        "renewedQuantity": 9,
+    }
+    mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("9999", "cannot patch subscription")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = NormalizeRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "renewing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_disable_lapsing_subscriptions_step(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(),
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = DisableLapsingSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        "lapsing-sub-id",
+        auto_renewal=False,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_disable_lapsing_subscriptions_step_already_disabled_skips(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(
+            subscription_id="lapsing-sub-id",
+            renew=False,
+            renewal_quantity=0,
+            snapshot_enabled=False,
+        ),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = DisableLapsingSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.update_subscription.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_disable_lapsing_subscriptions_step_adobe_error(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_api_error_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mock_adobe_client.update_subscription.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("9999", "cannot disable")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = DisableLapsingSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "lapsing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_fulfill_renewal_now_order(mocker):
+    mocked_pipeline_instance = mocker.MagicMock()
+    mocked_pipeline_ctor = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.Pipeline",
+        return_value=mocked_pipeline_instance,
+    )
+    mocked_context = mocker.MagicMock()
+    mocked_context_ctor = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.Context", return_value=mocked_context
+    )
+    mocked_client = mocker.MagicMock()
+    mocked_order = mocker.MagicMock()
+
+    fulfill_renewal_now_order(mocked_client, mocked_order)  # act
+
+    expected_steps = [
+        SetupContext,
+        StartOrderProcessing,
+        SetupDueDate,
+        ValidateDuplicateLines,
+        SetOrUpdateCotermDate,
+        UpdateAgreementParamsVisibility,
+        ValidateRenewalWindow,
+        SetupRenewalPlan,
+        PreviewRenewalNowOrder,
+        SubmitRenewalNowOrder,
+        NormalizeRenewedSubscriptions,
+        DisableLapsingSubscriptions,
+        CompleteOrder,
+        SetSubscriptionTemplate,
+        SyncAgreement,
+    ]
+    pipeline_args = mocked_pipeline_ctor.mock_calls[0].args
+    assert len(pipeline_args) == len(expected_steps)
+    actual_steps = [type(step) for step in pipeline_args]
+    assert actual_steps == expected_steps
+    assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[12].template_name == TEMPLATE_NAME_CHANGE
+    mocked_context_ctor.assert_called_once_with(order=mocked_order)
+    mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)

--- a/tests/flows/sync/test_agreement.py
+++ b/tests/flows/sync/test_agreement.py
@@ -13,6 +13,7 @@ from adobe_vipm.adobe.constants import (
 from adobe_vipm.adobe.errors import AdobeAPIError, AuthorizationNotFoundError
 from adobe_vipm.airtable.models import AirTableBaseInfo, get_gc_agreement_deployment_model
 from adobe_vipm.flows.constants import (
+    ITEM_EXTERNAL_ID_EARLY_RENEWAL_NO_CHANGE,
     TEMPLATE_ASSET_DEFAULT,
     TEMPLATE_SUBSCRIPTION_AUTORENEWAL_ENABLE,
     TEMPLATE_SUBSCRIPTION_TERMINATION,
@@ -2995,6 +2996,29 @@ def test_get_subscriptions_for_update_skip_adobe_inactive(
     result = mocked_agreement_syncer._get_subscriptions_for_update(agreement_factory())
 
     assert result == []
+
+
+def test_get_processable_agreement_lines_skip_early_renewal_no_change(
+    mocker,
+    agreement_factory,
+    lines_factory,
+    mocked_agreement_syncer,
+):
+    mock_get_adobe_sku = mocker.patch(
+        "adobe_vipm.airtable.models.get_adobe_sku", return_value="65304578CA01A12"
+    )
+    lines = lines_factory(line_id=1, item_id=1, external_vendor_id="65304578CA") + lines_factory(
+        line_id=2,
+        item_id=2,
+        external_vendor_id=ITEM_EXTERNAL_ID_EARLY_RENEWAL_NO_CHANGE,
+    )
+    agreement = agreement_factory(lines=lines)
+
+    result = mocked_agreement_syncer._get_processable_agreement_lines(agreement)
+
+    assert len(result) == 1
+    assert result[0][0]["item"]["externalIds"]["vendor"] == "65304578CA"
+    mock_get_adobe_sku.assert_called_once_with("65304578CA", "COM")
 
 
 @freeze_time("2025-07-23")


### PR DESCRIPTION
…lisation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add support for committing `RENEWAL` and `RETURN` orders through the renewal-now fulfillment flow.
- Validate and submit renewal orders as invoiced Adobe `RENEWAL` orders.
- Normalize auto-renewal with `renewedQuantity`.
- Disable auto-renewal for lapsing subscriptions.
- Handle Adobe order failures and missing subscriptions with explicit error states.
- Skip early-renewal placeholder items during agreement synchronization.
- Add fulfillment routing and comprehensive renewal-now test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->