### PR TITLE
MPT-24432 Fulfilment process for multiple renew orders and returns

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -509,6 +509,11 @@ ERR_RENEWAL_ORDER_FAILED = ValidationError(
     "The renewal order failed: {error}.",
 )
 
+ERR_RENEWAL_RETURN_FAILED = ValidationError(
+    "VIPM0050",
+    "Failed to return the previous renewal order for subscription {subscription_id}: {error}.",
+)
+
 
 class AssetStatus(StrEnum):
     """MPT asset statuses."""

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -7,16 +7,23 @@ carry a renewal payload built by the renewal wizard with renewalPath "now"
 renewing subscriptions are committed as an actual Adobe RENEWAL order,
 invoiced immediately, mirroring how the PURCHASE flow turns its PREVIEW
 order into a NEW order: validate with PREVIEW_RENEWAL, then resubmit the
-line items it returns as the real order. Once the order completes, the
+line items it returns as the real order. A renewing subscription already
+committed in a previous renewal order (renewedQuantity populated) with no
+requested quantity change is excluded from both. Once the order completes, the
 renewed subscriptions (renew = true) have their autoRenewal normalised
 (enabled=on, renewalQuantity taken from Adobe's post-renewal
 renewedQuantity) and the plan's lapsing subscriptions (renew = false)
-have their auto-renewal disabled.
+have their auto-renewal disabled. A lapsing subscription that was already
+committed in a previous RENEWAL order (its pre-mutation snapshot carries a
+renewedQuantity) additionally has that order's line returned via a RETURN
+order, so the customer is not left paying for a renewal that is being
+toggled off.
 
-Net-new items and RETURN orders for toggled-off lines are not handled yet.
+Net-new items are not handled yet.
 """
 
 import logging
+from operator import itemgetter
 
 from mpt_extension_sdk.mpt_http.mpt import update_order
 
@@ -24,6 +31,7 @@ from adobe_vipm.adobe.client import get_adobe_client
 from adobe_vipm.adobe.constants import (
     ORDER_STATUS_DESCRIPTION,
     ORDER_TYPE_PREVIEW_RENEWAL,
+    ORDER_TYPE_RENEWAL,
     UNRECOVERABLE_ORDER_STATUSES,
     AdobeOrderStatus,
 )
@@ -31,6 +39,7 @@ from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
     ERR_RENEWAL_ORDER_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
+    ERR_RENEWAL_RETURN_FAILED,
     ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
     ERR_UNEXPECTED_ADOBE_ERROR_STATUS,
     ERR_UNRECOVERABLE_ADOBE_ORDER_STATUS,
@@ -55,14 +64,37 @@ from adobe_vipm.flows.fulfillment.shared import (
 from adobe_vipm.flows.helpers import SetupContext
 from adobe_vipm.flows.pipeline import Pipeline, Step
 from adobe_vipm.flows.utils.parameter import set_adobe_order_ids_created_parameter
+from adobe_vipm.utils import get_partial_sku
 
 logger = logging.getLogger(__name__)
 
 
+def _is_already_renewed(plan):
+    """
+    Return True for a renewing entry already committed in a previous renewal order.
+
+    A plan entry with renew=true but no requested renewal quantity whose
+    Adobe subscription already carries a renewedQuantity (snapshotted by
+    SetupRenewalPlan before any mutation) was committed by a previous
+    RENEWAL order and requests no change, so there is nothing to submit
+    for it.
+    """
+    return not plan["renewal_quantity"] and plan["snapshot"]["renewed_quantity"] is not None
+
+
 def _build_renewing_line_items(context):
-    """Build PREVIEW_RENEWAL/RENEWAL line items for the plan's renewing subscriptions."""
+    """
+    Build PREVIEW_RENEWAL/RENEWAL line items for the plan's renewing subscriptions.
+
+    Renewing subscriptions already committed in a previous renewal order
+    with no requested quantity change are excluded — see _is_already_renewed.
+    """
     line_items = []
-    renewing = [plan for plan in context.renewal_plan_subscriptions if plan["renew"]]
+    renewing = [
+        plan
+        for plan in context.renewal_plan_subscriptions
+        if plan["renew"] and not _is_already_renewed(plan)
+    ]
     for number, plan in enumerate(renewing, start=1):
         line_item = {
             "extLineItemNumber": number,
@@ -170,8 +202,7 @@ class SubmitRenewalNowOrder(Step):
     Adobe RENEWAL order is detected by its external reference id, so a
     retry of this step is idempotent.
 
-    Net-new items and RETURN orders for toggled-off lines are not handled
-    by this step.
+    Net-new items are not handled by this step.
     """
 
     def __call__(self, client, context, next_step):
@@ -250,6 +281,173 @@ class SubmitRenewalNowOrder(Step):
         )
 
 
+class ReturnPreviousRenewalOrders(Step):
+    """
+    Return the previous RENEWAL order lines of the plan's lapsing subscriptions.
+
+    A lapsing subscription (renew = false) whose pre-mutation snapshot
+    (taken by SetupRenewalPlan, before this order commits anything) carries
+    a renewedQuantity was already committed in a previous RENEWAL order
+    placed within the renewal window. Disabling its auto-renewal is not
+    enough — the already-paid renewal must be undone, so this step submits
+    a RETURN order referencing that previous RENEWAL order, returning only
+    the lapsing subscription's line (other lines of that order stay
+    renewed). Runs after SubmitRenewalNowOrder so the additive operation
+    always precedes the subtractive one.
+
+    Idempotent: RETURN orders created by this MPT order are detected by
+    their external reference prefix and reused instead of re-submitted. A
+    RETURN order still pending on Adobe's side keeps the MPT order in
+    Processing to be retried on the next fulfillment attempt.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Return the previous RENEWAL order lines of the plan's lapsing subscriptions."""
+        lapsing_renewed = [
+            plan
+            for plan in context.renewal_plan_subscriptions
+            if not plan["renew"] and plan["snapshot"]["renewed_quantity"] is not None
+        ]
+        if not lapsing_renewed:
+            next_step(client, context)
+            return
+
+        adobe_client = get_adobe_client()
+        renewal_orders = self._get_completed_renewal_orders(adobe_client, context)
+        existing_return_orders = adobe_client.get_return_orders_by_external_reference(
+            context.authorization_id,
+            context.adobe_customer_id,
+            context.order_id,
+        )
+
+        return_orders = []
+        for plan in lapsing_renewed:
+            return_order = self._return_previous_renewal(
+                client, adobe_client, context, plan, renewal_orders, existing_return_orders
+            )
+            if return_order is None:
+                return
+            return_orders.append(return_order)
+
+        if not self._ensure_not_pending_return_orders(context, return_orders):
+            return
+
+        next_step(client, context)
+
+    def _get_completed_renewal_orders(self, adobe_client, context):
+        orders = adobe_client.get_orders(
+            context.authorization_id,
+            context.adobe_customer_id,
+            filters={
+                "order-type": ORDER_TYPE_RENEWAL,
+                "status": AdobeOrderStatus.COMPLETE,
+            },
+        )
+        return sorted(orders, key=itemgetter("creationDate"), reverse=True)
+
+    def _return_previous_renewal(  # noqa: WPS211
+        self, client, adobe_client, context, plan, renewal_orders, existing_return_orders
+    ):
+        subscription_id = plan["subscription_id"]
+        existing_returns = existing_return_orders.get(get_partial_sku(plan["offer_id"]))
+        if existing_returns:
+            logger.info(
+                "%s: return order %s already exists for subscription %s",
+                context,
+                existing_returns[0]["orderId"],
+                subscription_id,
+            )
+            return existing_returns[0]
+
+        returning_order, returning_line = self._find_previous_renewal_line(
+            context, renewal_orders, subscription_id
+        )
+        if returning_order is None:
+            logger.warning(
+                "%s: no previous renewal order found for subscription %s",
+                context,
+                subscription_id,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_RETURN_FAILED.to_dict(
+                    subscription_id=subscription_id,
+                    error="previous renewal order not found",
+                ),
+            )
+            return None
+
+        return self._create_return_order(
+            client, adobe_client, context, subscription_id, returning_order, returning_line
+        )
+
+    def _find_previous_renewal_line(self, context, renewal_orders, subscription_id):
+        for order in renewal_orders:
+            if order["externalReferenceId"] == context.order_id:
+                continue
+            for line_item in order["lineItems"]:
+                if line_item.get("subscriptionId") == subscription_id:
+                    return order, line_item
+        return None, None
+
+    def _create_return_order(  # noqa: WPS211
+        self, client, adobe_client, context, subscription_id, returning_order, returning_line
+    ):
+        try:
+            return_order = adobe_client.create_return_order(
+                context.authorization_id,
+                context.adobe_customer_id,
+                returning_order,
+                returning_line,
+                context.order_id,
+                returning_line.get("deploymentId"),
+            )
+        except AdobeAPIError as error:
+            logger.warning(
+                "%s: failed to return renewal order %s for subscription %s: %s",
+                context,
+                returning_order["orderId"],
+                subscription_id,
+                error,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_RETURN_FAILED.to_dict(
+                    subscription_id=subscription_id,
+                    error=error.message,
+                ),
+            )
+            return None
+
+        logger.info(
+            "%s: return order %s created for subscription %s against renewal order %s",
+            context,
+            return_order["orderId"],
+            subscription_id,
+            returning_order["orderId"],
+        )
+        context.order = set_adobe_order_ids_created_parameter(context, [return_order["orderId"]])
+        update_order(client, context.order_id, parameters=context.order["parameters"])
+        return return_order
+
+    def _ensure_not_pending_return_orders(self, context, return_orders):
+        pending_orders = [
+            return_order["orderId"]
+            for return_order in return_orders
+            if return_order["status"] != AdobeOrderStatus.COMPLETE
+        ]
+        if pending_orders:
+            logger.info(
+                "%s: return order(s) %s still pending",
+                context,
+                ", ".join(pending_orders),
+            )
+            return False
+        return True
+
+
 class NormalizeRenewedSubscriptions(Step):
     """
     Normalise autoRenewal for the plan's renewed subscriptions (renew = true).
@@ -268,12 +466,21 @@ class NormalizeRenewedSubscriptions(Step):
     auto-renewal preference a customer explicitly turned off on another
     subscription. Idempotent: a retry re-fetches and reapplies the same
     value.
+
+    Renewing subscriptions already committed in a previous renewal order
+    with no requested quantity change (see _is_already_renewed) are
+    excluded: this order did not renew them, so they keep whatever that
+    previous renewal order set.
     """
 
     def __call__(self, client, context, next_step):
         """Normalise autoRenewal for the plan's renewed subscriptions."""
         adobe_client = get_adobe_client()
-        renewing = [plan for plan in context.renewal_plan_subscriptions if plan["renew"]]
+        renewing = [
+            plan
+            for plan in context.renewal_plan_subscriptions
+            if plan["renew"] and not _is_already_renewed(plan)
+        ]
         for plan in renewing:
             if not self._normalize(client, adobe_client, context, plan):
                 return
@@ -396,9 +603,11 @@ def fulfill_renewal_now_order(client, order):
 
     The plan's renewing subscriptions are validated with a PREVIEW_RENEWAL
     and committed as an actual Adobe RENEWAL order, invoiced immediately.
-    Once it completes, the renewed subscriptions (renew = true) have their
-    autoRenewal normalised and the plan's lapsing subscriptions
-    (renew = false) have their auto-renewal disabled.
+    Once it completes, lapsing subscriptions that were already committed in
+    a previous RENEWAL order have that order's line returned, the renewed
+    subscriptions (renew = true) have their autoRenewal normalised and the
+    plan's lapsing subscriptions (renew = false) have their auto-renewal
+    disabled.
 
     Args:
         client (MPTClient): An instance of the MPT client used for communication
@@ -419,6 +628,7 @@ def fulfill_renewal_now_order(client, order):
         SetupRenewalPlan(),
         PreviewRenewalNowOrder(),
         SubmitRenewalNowOrder(),
+        ReturnPreviousRenewalOrders(),
         NormalizeRenewedSubscriptions(),
         DisableLapsingSubscriptions(),
         CompleteOrder(TEMPLATE_NAME_CHANGE),

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1800,6 +1800,7 @@ class SetupRenewalPlan(Step):
                 "enabled": auto_renewal.get("enabled", False),
                 "renewal_quantity": auto_renewal.get(Param.RENEWAL_QUANTITY.value),
                 "flex_discount_codes": auto_renewal.get("flexDiscountCodes") or [],
+                "renewed_quantity": adobe_subscription.get(Param.RENEWED_QUANTITY.value),
             },
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ per-file-ignores = [
   "adobe_vipm/flows/fulfillment/purchase.py: WPS110 WPS114 WPS203 WPS204 WPS229 WPS231 WPS235 WPS338",
   "adobe_vipm/flows/fulfillment/shared.py: WPS110 WPS201 WPS202 WPS203 WPS204 WPS210 WPS213 WPS214 WPS220 WPS221 WPS229 WPS231 WPS235 WPS237 WPS336 WPS426 WPS441 WPS504",
   "adobe_vipm/flows/fulfillment/renewal.py: WPS202 WPS235",
-  "adobe_vipm/flows/fulfillment/renewal_now.py: WPS204 WPS235",
+  "adobe_vipm/flows/fulfillment/renewal_now.py: WPS202 WPS204 WPS210 WPS235",
   "adobe_vipm/flows/fulfillment/switch.py: WPS235",
   "adobe_vipm/flows/fulfillment/termination.py: WPS210 WPS220 WPS229 WPS231 WPS235",
   "adobe_vipm/flows/fulfillment/transfer.py: WPS110 WPS201 WPS202 WPS203 WPS204 WPS210 WPS211 WPS221 WPS231 WPS235 WPS237 WPS432 WPS479 WPS480",

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -96,11 +96,15 @@ def test_setup_renewal_plan_step(
         offer_id="65304578CA01A12",
         renewal_quantity=10,
     )
-    lapsing_sub = adobe_subscription_factory(
-        subscription_id="lapsing-sub-id",
-        offer_id="77777777CA01A12",
-        renewal_quantity=10,
-    )
+    # Already committed in a previous renewal order: renewedQuantity is populated.
+    lapsing_sub = {
+        **adobe_subscription_factory(
+            subscription_id="lapsing-sub-id",
+            offer_id="77777777CA01A12",
+            renewal_quantity=10,
+        ),
+        "renewedQuantity": 8,
+    }
     mock_adobe_client.get_subscriptions.return_value = {
         "items": [renewing_sub, lapsing_sub],
         "totalCount": 2,
@@ -124,6 +128,7 @@ def test_setup_renewal_plan_step(
                 "enabled": True,
                 "renewal_quantity": 10,
                 "flex_discount_codes": [],
+                "renewed_quantity": None,
             },
         },
         {
@@ -136,6 +141,7 @@ def test_setup_renewal_plan_step(
                 "enabled": True,
                 "renewal_quantity": 10,
                 "flex_discount_codes": [],
+                "renewed_quantity": 8,
             },
         },
     ]

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -13,6 +13,7 @@ from adobe_vipm.flows.fulfillment.renewal_now import (
     DisableLapsingSubscriptions,
     NormalizeRenewedSubscriptions,
     PreviewRenewalNowOrder,
+    ReturnPreviousRenewalOrders,
     SubmitRenewalNowOrder,
     fulfill_renewal_now_order,
 )
@@ -67,6 +68,7 @@ def plan_entry(
     snapshot_enabled=True,  # ruff:ignore[boolean-default-value-positional-argument]
     snapshot_quantity=10,
     snapshot_codes=None,
+    snapshot_renewed_quantity=None,
 ):
     return {
         "subscription_id": subscription_id,
@@ -78,6 +80,7 @@ def plan_entry(
             "enabled": snapshot_enabled,
             "renewal_quantity": snapshot_quantity,
             "flex_discount_codes": snapshot_codes or [],
+            "renewed_quantity": snapshot_renewed_quantity,
         },
     }
 
@@ -154,6 +157,108 @@ def test_preview_renewal_now_order_step_validates_preview(
         order_type=ORDER_TYPE_PREVIEW_RENEWAL,
     )
     assert renewal_now_context.preview_renewal_order == preview_order
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_includes_already_renewed_subscription(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    """A renewing sub already committed in a previous renewal order is re-submitted normally."""
+    renewal_now_context.renewal_plan_subscriptions = [plan_entry(snapshot_renewed_quantity=9)]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+        [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+        order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_excludes_already_renewed_without_change(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    """A renewing sub already renewed with no requested quantity is left out of the preview."""
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(
+            subscription_id="already-renewed-sub-id",
+            offer_id="77777777CA01A12",
+            renewal_quantity=0,
+            snapshot_renewed_quantity=9,
+        ),
+        plan_entry(),
+    ]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL", status=AdobeOrderStatus.COMPLETE.value
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_renewal_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+        [
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+        order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_preview_renewal_now_order_step_all_already_renewed_skips_preview(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(renewal_quantity=0, snapshot_renewed_quantity=9),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_adobe_client.create_renewal_order.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_submit_renewal_now_order_step_all_already_renewed_skips_order(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(renewal_quantity=0, snapshot_renewed_quantity=9),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_adobe_client.create_renewal_order.assert_not_called()
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
 
@@ -458,6 +563,23 @@ def test_normalize_renewed_subscriptions_step(
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
 
+def test_normalize_renewed_subscriptions_step_already_renewed_excluded(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    """A sub renewed by a PREVIOUS order keeps what that order set — no re-fetch, no PATCH."""
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(renewal_quantity=0, snapshot_renewed_quantity=9),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = NormalizeRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_not_called()
+    mock_adobe_client.update_subscription.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
 def test_normalize_renewed_subscriptions_step_no_renewed_quantity_skips_patch(
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
 ):
@@ -580,6 +702,270 @@ def test_disable_lapsing_subscriptions_step_adobe_error(
     mocked_next_step.assert_not_called()
 
 
+def lapsing_renewed_plan_entry(renewed_quantity=10):
+    return plan_entry(
+        subscription_id="lapsing-sub-id",
+        offer_id="77777777CA01A12",
+        renew=False,
+        renewal_quantity=0,
+        snapshot_renewed_quantity=renewed_quantity,
+    )
+
+
+def previous_renewal_order_factory(
+    adobe_order_factory,
+    order_id="ADOBE-RENEWAL-PREV",
+    external_id="ORD-PREVIOUS",
+    creation_date="2026-08-01T10:00:00Z",
+    subscription_id="lapsing-sub-id",
+    deployment_id=None,
+):
+    line_item = {
+        "extLineItemNumber": 1,
+        "offerId": "77777777CA01A12",
+        "subscriptionId": subscription_id,
+        "quantity": 10,
+    }
+    if deployment_id:
+        line_item["deploymentId"] = deployment_id
+    return adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        external_id=external_id,
+        order_id=order_id,
+        creation_date=creation_date,
+        items=[line_item],
+    )
+
+
+def test_return_previous_renewal_orders_step_no_candidates(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        # Renewing sub already renewed: handled by the RENEWAL order, not returned.
+        plan_entry(snapshot_renewed_quantity=9),
+        # Lapsing sub never committed in a previous renewal order: nothing to return.
+        plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_adobe_client.get_return_orders_by_external_reference.assert_not_called()
+    mock_adobe_client.create_return_order.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_return_previous_renewal_orders_step_creates_return(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    previous_renewal = previous_renewal_order_factory(adobe_order_factory)
+    mock_adobe_client.get_orders.return_value = [previous_renewal]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    return_order = adobe_order_factory(
+        order_type="RETURN",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RETURN-001",
+        reference_order_id="ADOBE-RENEWAL-PREV",
+    )
+    mock_adobe_client.create_return_order.return_value = return_order
+    mocked_update_order = mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_orders.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        filters={
+            "order-type": ORDER_TYPE_RENEWAL,
+            "status": AdobeOrderStatus.COMPLETE,
+        },
+    )
+    mock_adobe_client.get_return_orders_by_external_reference.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+    )
+    mock_adobe_client.create_return_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        previous_renewal,
+        previous_renewal["lineItems"][0],
+        renewal_now_context.order_id,
+        None,
+    )
+    mocked_update_order.assert_called_once_with(
+        mock_mpt_client,
+        renewal_now_context.order_id,
+        parameters=renewal_now_context.order["parameters"],
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_return_previous_renewal_orders_step_existing_return_reused(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [
+        previous_renewal_order_factory(adobe_order_factory)
+    ]
+    existing_return = adobe_order_factory(
+        order_type="RETURN",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RETURN-EXISTING",
+    )
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {
+        "77777777CA": [existing_return],
+    }
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_return_order.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_return_previous_renewal_orders_step_pending_return(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [
+        previous_renewal_order_factory(adobe_order_factory)
+    ]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mock_adobe_client.create_return_order.return_value = adobe_order_factory(
+        order_type="RETURN",
+        status=AdobeOrderStatus.OPEN.value,
+        order_id="ADOBE-RETURN-PENDING",
+    )
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_not_called()
+
+
+def test_return_previous_renewal_orders_step_previous_order_not_found(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_return_order.assert_not_called()
+    mocked_switch_to_failed.assert_called_once()
+    assert "lapsing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_return_previous_renewal_orders_step_return_failed(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context,
+    adobe_order_factory,
+    adobe_api_error_factory,
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [
+        previous_renewal_order_factory(adobe_order_factory)
+    ]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mock_adobe_client.create_return_order.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory("9999", "cannot return")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "cannot return" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_return_previous_renewal_orders_step_picks_most_recent_order(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    older_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-OLDER",
+        external_id="ORD-OLDER",
+        creation_date="2026-07-01T10:00:00Z",
+    )
+    newer_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-NEWER",
+        external_id="ORD-NEWER",
+        creation_date="2026-08-01T10:00:00Z",
+    )
+    # The renewal order committed by this very MPT order never contains lapsing
+    # subscriptions, but it is excluded defensively even if it did.
+    own_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-OWN",
+        external_id=renewal_now_context.order_id,
+        creation_date="2026-08-10T10:00:00Z",
+    )
+    unrelated_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-UNRELATED",
+        external_id="ORD-UNRELATED",
+        creation_date="2026-08-05T10:00:00Z",
+        subscription_id="other-sub-id",
+    )
+    mock_adobe_client.get_orders.return_value = [
+        older_renewal,
+        own_renewal,
+        unrelated_renewal,
+        newer_renewal,
+    ]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mock_adobe_client.create_return_order.return_value = adobe_order_factory(
+        order_type="RETURN",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RETURN-001",
+    )
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    mocked_next_step = mocker.MagicMock()
+    step = ReturnPreviousRenewalOrders()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_return_order.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        newer_renewal,
+        newer_renewal["lineItems"][0],
+        renewal_now_context.order_id,
+        None,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
 def test_fulfill_renewal_now_order(mocker):
     mocked_pipeline_instance = mocker.MagicMock()
     mocked_pipeline_ctor = mocker.patch(
@@ -606,6 +992,7 @@ def test_fulfill_renewal_now_order(mocker):
         SetupRenewalPlan,
         PreviewRenewalNowOrder,
         SubmitRenewalNowOrder,
+        ReturnPreviousRenewalOrders,
         NormalizeRenewedSubscriptions,
         DisableLapsingSubscriptions,
         CompleteOrder,
@@ -617,6 +1004,6 @@ def test_fulfill_renewal_now_order(mocker):
     actual_steps = [type(step) for step in pipeline_args]
     assert actual_steps == expected_steps
     assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
-    assert pipeline_args[12].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[13].template_name == TEMPLATE_NAME_CHANGE
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-24432](https://softwareone.atlassian.net/browse/MPT-24432)

- Support fulfilment for multiple renewal orders and returns.
- Exclude subscriptions already renewed by a previous order when no quantity change is requested.
- Return previous renewal orders and handle created, reused, pending, failed, and missing return orders.
- Preserve `renewedQuantity` in renewal plan entries.
- Add error `VIPM0050` for failed previous renewal returns.
- Add comprehensive tests for renewal state, order returns, and pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24432]: https://softwareone.atlassian.net/browse/MPT-24432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ