### PR TITLE
MPT-24750 Mid-term upgrade: x-recommendation-tracker-id not sent as h…

### DIFF
--- a/adobe_vipm/adobe/client.py
+++ b/adobe_vipm/adobe/client.py
@@ -113,9 +113,11 @@ class AdobeClient(
         self._TIMEOUT = 60
         self._session = _build_retrying_session(self._config.auth_endpoint_url)
 
-    def _get_headers(self, authorization: Authorization, correlation_id=None):
+    def _get_headers(
+        self, authorization: Authorization, correlation_id=None, recommendation_tracker_id=None
+    ):
         token = self._get_auth_token(authorization).token
-        return {
+        headers = {
             "X-Api-Key": authorization.client_id,
             "Authorization": f"Bearer {token}",
             "Accept": "application/json",
@@ -123,6 +125,9 @@ class AdobeClient(
             "X-Request-Id": str(uuid4()),
             "x-correlation-id": correlation_id or str(uuid4()),
         }
+        if recommendation_tracker_id:
+            headers["x-recommendation-tracker-id"] = recommendation_tracker_id
+        return headers
 
     @wrap_http_error
     def _refresh_auth_token(self, authorization: Authorization):

--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -255,6 +255,7 @@ class OrderClientMixin:
         external_reference_id: str,
         line_items: list[dict],
         order_type: str = adobe_constants.ORDER_TYPE_RENEWAL,
+        recommendation_tracker_id: str | None = None,
     ) -> dict:
         """
         Create a RENEWAL order for specific subscriptions.
@@ -267,6 +268,8 @@ class OrderClientMixin:
             external_reference_id: External reference ID for the order.
             line_items: List of line items with offerId, quantity, and subscriptionId.
             order_type: Type of the order.
+            recommendation_tracker_id: The tracker id captured from the Adobe
+            recommendations call, replayed so Adobe can attribute the outcome.
 
         Returns:
             dict: The Renewal order.
@@ -281,7 +284,11 @@ class OrderClientMixin:
             payload["currencyCode"] = authorization.currency
 
         correlation_id = sha256(json.dumps(payload).encode()).hexdigest()
-        headers = self._get_headers(authorization, correlation_id=correlation_id)
+        headers = self._get_headers(
+            authorization,
+            correlation_id=correlation_id,
+            recommendation_tracker_id=recommendation_tracker_id,
+        )
         response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
@@ -322,7 +329,10 @@ class OrderClientMixin:
             switch_payload,
             adobe_constants.ORDER_TYPE_PREVIEW_SWITCH,
         )
-        headers = self._get_headers(authorization)
+        headers = self._get_headers(
+            authorization,
+            recommendation_tracker_id=switch_payload.get("recommendationTrackerId"),
+        )
         response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             params={"fetch-price": "true"},
@@ -365,7 +375,11 @@ class OrderClientMixin:
             adobe_constants.ORDER_TYPE_SWITCH,
         )
         correlation_id = sha256(json.dumps(payload).encode()).hexdigest()
-        headers = self._get_headers(authorization, correlation_id=correlation_id)
+        headers = self._get_headers(
+            authorization,
+            correlation_id=correlation_id,
+            recommendation_tracker_id=switch_payload.get("recommendationTrackerId"),
+        )
         response = self._session.post(
             urljoin(self._config.api_base_url, f"/v3/customers/{customer_id}/orders"),
             headers=headers,
@@ -775,6 +789,9 @@ class OrderClientMixin:
             "externalReferenceId": external_reference_id,
             "orderType": order_type,
         }
+        # Adobe expects the tracker id of the originating recommendation as the
+        # x-recommendation-tracker-id header, not as an order body field.
+        payload.pop("recommendationTrackerId", None)
         if not payload.get("currencyCode"):
             payload["currencyCode"] = authorization.currency
         return payload

--- a/adobe_vipm/adobe/mixins/subscription.py
+++ b/adobe_vipm/adobe/mixins/subscription.py
@@ -211,9 +211,9 @@ class SubscriptionClientMixin:
             dict: The created subscription.
         """
         authorization = self._config.get_authorization(authorization_id)
-        headers = self._get_headers(authorization)
-        if recommendation_tracker_id:
-            headers["x-recommendation-tracker-id"] = recommendation_tracker_id
+        headers = self._get_headers(
+            authorization, recommendation_tracker_id=recommendation_tracker_id
+        )
         payload = {
             "offerId": offer_id,
             "autoRenewal": {

--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -89,6 +89,9 @@ class PreviewRenewal(Step):
                 context.order_id,
                 line_items,
                 order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+                recommendation_tracker_id=(
+                    context.renewal_payload.get("recommendationTrackerId") or None
+                ),
             )
         except AdobeAPIError as error:
             logger.warning("%s: renewal preview failed: %s", context, error)

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -178,6 +178,9 @@ class PreviewRenewalNowOrder(Step):
                 context.order_id,
                 line_items,
                 order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+                recommendation_tracker_id=(
+                    context.renewal_payload.get("recommendationTrackerId") or None
+                ),
             )
         except AdobeAPIError as error:
             logger.warning("%s: renewal preview failed: %s", context, error)
@@ -238,6 +241,9 @@ class SubmitRenewalNowOrder(Step):
                 context.adobe_customer_id,
                 context.order_id,
                 _build_committed_line_items(context.preview_renewal_order["lineItems"]),
+                recommendation_tracker_id=(
+                    context.renewal_payload.get("recommendationTrackerId") or None
+                ),
             )
         except AdobeAPIError as error:
             logger.warning("%s: renewal order failed: %s", context, error)

--- a/tests/adobe/mixins/test_order.py
+++ b/tests/adobe/mixins/test_order.py
@@ -537,6 +537,12 @@ def test_create_switch_preview_order(
     authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
     mocked_client, _, _ = adobe_client_factory()
     adobe_preview_order = adobe_order_factory(order_type=ORDER_TYPE_PREVIEW_SWITCH)
+    expected_payload = {
+        **switch_payload,
+        "externalReferenceId": "mpt-order-id",
+        "orderType": ORDER_TYPE_PREVIEW_SWITCH,
+    }
+    expected_payload.pop("recommendationTrackerId")
     requests_mocker.post(
         urljoin(
             settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
@@ -545,11 +551,10 @@ def test_create_switch_preview_order(
         status=200,
         json=adobe_preview_order,
         match=[
-            matchers.json_params_matcher({
-                **switch_payload,
-                "externalReferenceId": "mpt-order-id",
-                "orderType": ORDER_TYPE_PREVIEW_SWITCH,
+            matchers.header_matcher({
+                "x-recommendation-tracker-id": switch_payload["recommendationTrackerId"],
             }),
+            matchers.json_params_matcher(expected_payload),
             matchers.query_param_matcher({"fetch-price": "true"}),
         ],
     )
@@ -580,6 +585,7 @@ def test_create_switch_order(
         "externalReferenceId": "mpt-order-id",
         "orderType": ORDER_TYPE_SWITCH,
     }
+    expected_payload.pop("recommendationTrackerId")
     correlation_id = sha256(json.dumps(expected_payload).encode()).hexdigest()
     requests_mocker.post(
         urljoin(
@@ -589,7 +595,10 @@ def test_create_switch_order(
         status=202,
         json=adobe_order,
         match=[
-            matchers.header_matcher({"x-correlation-id": correlation_id}),
+            matchers.header_matcher({
+                "x-correlation-id": correlation_id,
+                "x-recommendation-tracker-id": switch_payload["recommendationTrackerId"],
+            }),
             matchers.json_params_matcher(expected_payload),
         ],
     )
@@ -622,6 +631,7 @@ def test_create_switch_order_without_currency_code(
         "orderType": ORDER_TYPE_SWITCH,
         "currencyCode": authorization.currency,
     }
+    expected_payload.pop("recommendationTrackerId")
     requests_mocker.post(
         urljoin(
             settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
@@ -629,7 +639,57 @@ def test_create_switch_order_without_currency_code(
         ),
         status=202,
         json=adobe_order,
-        match=[matchers.json_params_matcher(expected_payload)],
+        match=[
+            matchers.header_matcher({
+                "x-recommendation-tracker-id": switch_payload["recommendationTrackerId"],
+            }),
+            matchers.json_params_matcher(expected_payload),
+        ],
+    )
+
+    result = mocked_client.create_switch_order(
+        authorization_uk,
+        "a-customer",
+        "mpt-order-id",
+        switch_payload,
+    )  # act
+
+    assert result == adobe_order
+
+
+def _without_tracker_header(request):
+    absent = "x-recommendation-tracker-id" not in request.headers
+    return absent, "x-recommendation-tracker-id header must not be sent"
+
+
+def test_create_switch_order_without_recommendation_tracker_id(
+    adobe_client_factory,
+    adobe_authorizations_file,
+    adobe_order_factory,
+    requests_mocker,
+    settings,
+    switch_payload,
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    mocked_client, _, _ = adobe_client_factory()
+    adobe_order = adobe_order_factory(order_type=ORDER_TYPE_SWITCH, order_id="an-order-id")
+    del switch_payload["recommendationTrackerId"]
+    expected_payload = {
+        **switch_payload,
+        "externalReferenceId": "mpt-order-id",
+        "orderType": ORDER_TYPE_SWITCH,
+    }
+    requests_mocker.post(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            "/v3/customers/a-customer/orders",
+        ),
+        status=202,
+        json=adobe_order,
+        match=[
+            _without_tracker_header,
+            matchers.json_params_matcher(expected_payload),
+        ],
     )
 
     result = mocked_client.create_switch_order(

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -1360,6 +1360,7 @@ def test_create_renewal_order(
                     "Content-Type": "application/json",
                     "X-Request-Id": "uuid-1",
                     "x-correlation-id": correlation_id,
+                    "x-recommendation-tracker-id": "a-tracker-id",
                 },
             ),
             matchers.json_params_matcher(expected_payload),
@@ -1371,6 +1372,7 @@ def test_create_renewal_order(
         customer_id,
         external_reference_id,
         line_items,
+        recommendation_tracker_id="a-tracker-id",
     )
 
     assert result == adobe_order

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -204,6 +204,7 @@ def test_preview_renewal_step(mocker, mock_adobe_client, mock_mpt_client, renewa
             },
         ],
         order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+        recommendation_tracker_id=renewal_context.renewal_payload["recommendationTrackerId"],
     )
     assert renewal_context.preview_renewal_order == preview
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -159,6 +159,7 @@ def test_preview_renewal_now_order_step_validates_preview(
             },
         ],
         order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+        recommendation_tracker_id=renewal_now_context.renewal_payload["recommendationTrackerId"],
     )
     assert renewal_now_context.preview_renewal_order == preview_order
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
@@ -191,6 +192,7 @@ def test_preview_renewal_now_order_step_includes_already_renewed_subscription(
             },
         ],
         order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+        recommendation_tracker_id=renewal_now_context.renewal_payload["recommendationTrackerId"],
     )
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
@@ -230,6 +232,7 @@ def test_preview_renewal_now_order_step_excludes_already_renewed_without_change(
             },
         ],
         order_type=ORDER_TYPE_PREVIEW_RENEWAL,
+        recommendation_tracker_id=renewal_now_context.renewal_payload["recommendationTrackerId"],
     )
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
@@ -398,6 +401,7 @@ def test_submit_renewal_now_order_step_commits_order(
                 "flexDiscountCodes": ["CODE-1"],
             },
         ],
+        recommendation_tracker_id=renewal_now_context.renewal_payload["recommendationTrackerId"],
     )
     mocked_update_order.assert_called_once_with(
         mock_mpt_client,


### PR DESCRIPTION
…eader on Adobe SWITCH call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-24750](https://softwareone.atlassian.net/browse/MPT-24750)

- Send `x-recommendation-tracker-id` as a header on Adobe SWITCH calls.
- Forward recommendation tracker IDs for renewal, switch preview, and switch orders.
- Remove the tracker ID from switch request bodies.
- Add test coverage for present and absent tracker IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24750]: https://softwareone.atlassian.net/browse/MPT-24750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ