### PR TITLE
MPT-24778 Renewals: block native Change / Configuration / Termination…

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -126,6 +126,7 @@ GOVERNMENT_AGENCY_TYPE_STATE = "STATE"
 VALID_GOVERNMENT_AGENCY_TYPES = {GOVERNMENT_AGENCY_TYPE_FEDERAL, GOVERNMENT_AGENCY_TYPE_STATE}
 
 CANCELLATION_WINDOW_DAYS = 14
+EARLY_RENEWAL_LOOKBACK_DAYS = 30
 GLOBAL_SUFFIX = "_global"
 LAST_TWO_WEEKS_DAYS = 13
 NUMBER_OF_DAYS_ALLOW_DOWNSIZE_IF_3YC = 365
@@ -512,6 +513,14 @@ ERR_RENEWAL_ORDER_FAILED = ValidationError(
 ERR_RENEWAL_RETURN_FAILED = ValidationError(
     "VIPM0050",
     "Failed to return the previous renewal order for subscription {subscription_id}: {error}.",
+)
+
+ERR_EARLY_RENEWAL_IN_PROGRESS = ValidationError(
+    "VIPM0051",
+    "An early renewal has already been placed for this agreement, so Change, "
+    "Configuration and Termination orders are locked until it takes effect at "
+    "the anniversary date. Please re-open the renewal wizard to make "
+    "renewal-affecting changes.",
 )
 
 

--- a/adobe_vipm/flows/validation/base.py
+++ b/adobe_vipm/flows/validation/base.py
@@ -15,6 +15,7 @@ from adobe_vipm.flows.utils.order import reset_order_error
 from adobe_vipm.flows.utils.parameter import reset_ordering_parameters_error
 from adobe_vipm.flows.utils.validation import is_migrate_customer, is_reseller_change
 from adobe_vipm.flows.validation.change import validate_change_order
+from adobe_vipm.flows.validation.configuration import validate_configuration_order
 from adobe_vipm.flows.validation.purchase import validate_purchase_order
 from adobe_vipm.flows.validation.termination import validate_termination_order
 from adobe_vipm.flows.validation.transfer import validate_reseller_change, validate_transfer
@@ -71,6 +72,8 @@ def get_validator_by_order_type(order: dict[str, Any]) -> Callable | None:
             return validate_change_order
         case OrderType.TERMINATION:
             return validate_termination_order
+        case OrderType.CONFIGURATION:
+            return validate_configuration_order
         case _:
             return None
 

--- a/adobe_vipm/flows/validation/change.py
+++ b/adobe_vipm/flows/validation/change.py
@@ -28,6 +28,7 @@ from adobe_vipm.flows.utils.subscription import get_subscription_by_line_subs_id
 from adobe_vipm.flows.validation.shared import (
     GetPreviewOrder,
     ValidateDuplicateLines,
+    ValidateNoEarlyRenewal,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,6 +126,7 @@ def validate_change_order(client, order):
         ValidateDuplicateLines(),
         SetOrUpdateCotermDate(),
         ValidateRenewalWindow(is_validation=True),
+        ValidateNoEarlyRenewal(),
         ValidateSkuAvailability(is_validation=True),
         ValidateDownsizes(),
         Validate3YCCommitment(is_validation=True),

--- a/adobe_vipm/flows/validation/configuration.py
+++ b/adobe_vipm/flows/validation/configuration.py
@@ -1,0 +1,20 @@
+import logging
+
+from adobe_vipm.flows.context import Context
+from adobe_vipm.flows.helpers import SetupContext
+from adobe_vipm.flows.pipeline import Pipeline
+from adobe_vipm.flows.validation.shared import ValidateNoEarlyRenewal
+
+logger = logging.getLogger(__name__)
+
+
+def validate_configuration_order(client, order):
+    """Validate configuration order pipeline."""
+    pipeline = Pipeline(
+        SetupContext(),
+        ValidateNoEarlyRenewal(),
+    )
+    context = Context(order=order)
+    pipeline.run(client, context)
+
+    return not context.validation_succeeded, context.order

--- a/adobe_vipm/flows/validation/shared.py
+++ b/adobe_vipm/flows/validation/shared.py
@@ -1,20 +1,27 @@
+import datetime as dt
 import logging
 from collections import Counter
 
 from adobe_vipm.adobe.client import get_adobe_client
+from adobe_vipm.adobe.constants import ORDER_TYPE_RENEWAL, AdobeOrderStatus
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeProductNotFoundError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
 from adobe_vipm.flows.constants import (
+    EARLY_RENEWAL_LOOKBACK_DAYS,
     ERR_ADOBE_ERROR,
     ERR_DUPLICATED_ITEMS,
+    ERR_EARLY_RENEWAL_IN_PROGRESS,
     ERR_EXISTING_ITEMS,
 )
 from adobe_vipm.flows.pipeline import Step
 from adobe_vipm.flows.utils import (
     set_order_error,
 )
+from adobe_vipm.flows.utils.validation import is_renewal_order
 
 logger = logging.getLogger(__name__)
+
+LAST_DAY_OF_FEBRUARY_NON_LEAP = 28
 
 
 class ValidateDuplicateLines(Step):
@@ -59,6 +66,82 @@ class ValidateDuplicateLines(Step):
             context.validation_succeeded = False
             return
         next_step(client, context)
+
+
+class ValidateNoEarlyRenewal(Step):
+    """
+    Reject native orders while an early renewal placed for the agreement is pending effect.
+
+    An early ("renew now") renewal commits an Adobe RENEWAL order before the
+    anniversary date and rolls the customer cotermDate forward immediately, so
+    a native Change / Configuration / Termination order processed before the
+    original anniversary would silently fork the already renewed term. Such an
+    order is recognized because it was created strictly before the anniversary
+    of the term it renews (the current cotermDate minus one year): the RENEWAL
+    orders Adobe itself generates at the anniversary are created on that very
+    day, and the late/manual ones after it. An OPEN RENEWAL order blocks too:
+    the commit is in flight and the cotermDate has not rolled forward yet.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Reject the order when an early renewal is pending effect for the agreement."""
+        if is_renewal_order(context.order):
+            next_step(client, context)
+            return
+
+        coterm_date = (context.adobe_customer or {}).get("cotermDate")
+        if not context.adobe_customer_id or not coterm_date:
+            next_step(client, context)
+            return
+
+        early_renewal = self._get_pending_early_renewal(context, dt.date.fromisoformat(coterm_date))
+        if early_renewal:
+            logger.info(
+                "%s: the early renewal order %s placed on %s is pending effect",
+                context,
+                early_renewal["orderId"],
+                early_renewal["creationDate"],
+            )
+            context.validation_succeeded = False
+            context.order = set_order_error(
+                context.order,
+                ERR_EARLY_RENEWAL_IN_PROGRESS.to_dict(),
+            )
+            return
+
+        next_step(client, context)
+
+    def _get_pending_early_renewal(self, context, coterm_date):
+        anniversary = self._previous_anniversary(coterm_date)
+        today = dt.datetime.now(tz=dt.UTC).date()
+        adobe_client = get_adobe_client()
+        renewal_orders = adobe_client.get_orders(
+            context.authorization_id,
+            context.adobe_customer_id,
+            filters={"order-type": ORDER_TYPE_RENEWAL},
+        )
+        for order in renewal_orders:
+            creation_date = (
+                dt.datetime.fromisoformat(order["creationDate"]).replace(tzinfo=dt.UTC).date()
+            )
+            if creation_date < today - dt.timedelta(days=EARLY_RENEWAL_LOOKBACK_DAYS):
+                continue
+            if order["status"] == AdobeOrderStatus.OPEN:
+                return order
+            is_pending_early_renewal = (
+                order["status"] == AdobeOrderStatus.COMPLETE
+                and creation_date < anniversary
+                and today <= anniversary
+            )
+            if is_pending_early_renewal:
+                return order
+        return None
+
+    def _previous_anniversary(self, coterm_date):
+        try:
+            return coterm_date.replace(year=coterm_date.year - 1)
+        except ValueError:  # Feb 29 on a non-leap target year
+            return coterm_date.replace(year=coterm_date.year - 1, day=LAST_DAY_OF_FEBRUARY_NON_LEAP)
 
 
 class GetPreviewOrder(Step):

--- a/adobe_vipm/flows/validation/termination.py
+++ b/adobe_vipm/flows/validation/termination.py
@@ -14,7 +14,7 @@ from adobe_vipm.flows.utils import (
     validate_subscription_and_returnable_orders,
 )
 from adobe_vipm.flows.utils.subscription import get_subscription_by_line_subs_id
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines
+from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,7 @@ def validate_termination_order(client, order):
         ValidateDuplicateLines(),
         SetOrUpdateCotermDate(),
         ValidateRenewalWindow(is_validation=True),
+        ValidateNoEarlyRenewal(),
         ValidateDownsizes(),
         Validate3YCCommitment(is_validation=True),
     )

--- a/tests/flows/validation/test_base.py
+++ b/tests/flows/validation/test_base.py
@@ -10,6 +10,7 @@ from adobe_vipm.flows.validation.base import (
     validate_order,
 )
 from adobe_vipm.flows.validation.change import validate_change_order
+from adobe_vipm.flows.validation.configuration import validate_configuration_order
 from adobe_vipm.flows.validation.purchase import validate_purchase_order
 from adobe_vipm.flows.validation.termination import validate_termination_order
 from adobe_vipm.flows.validation.transfer import validate_reseller_change, validate_transfer
@@ -81,6 +82,7 @@ def test_get_purchase_order_validator_validate_purchase_order(mocker, mock_order
     [
         (OrderType.CHANGE, validate_change_order),
         (OrderType.TERMINATION, validate_termination_order),
+        (OrderType.CONFIGURATION, validate_configuration_order),
         ("no_type", None),
     ],
 )

--- a/tests/flows/validation/test_change.py
+++ b/tests/flows/validation/test_change.py
@@ -14,7 +14,7 @@ from adobe_vipm.flows.validation.change import (
     ValidateDownsizes,
     validate_change_order,
 )
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines
+from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
 
 
 @freeze_time("2024-11-09 12:30:00")
@@ -283,18 +283,19 @@ def test_validate_change_order(mocker):
 
     validate_change_order(mocked_client, mocked_order)  # act
 
-    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 9
+    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 10
     expected_steps = [
         SetupContext,
         ValidateDuplicateLines,
         SetOrUpdateCotermDate,
         ValidateRenewalWindow,
+        ValidateNoEarlyRenewal,
         ValidateSkuAvailability,
         ValidateDownsizes,
         Validate3YCCommitment,
         GetPreviewOrder,
     ]
-    actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args[:8]]
+    actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args[:9]]
     assert actual_steps == expected_steps
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)

--- a/tests/flows/validation/test_configuration.py
+++ b/tests/flows/validation/test_configuration.py
@@ -1,0 +1,28 @@
+from adobe_vipm.flows.helpers import SetupContext
+from adobe_vipm.flows.validation.configuration import validate_configuration_order
+from adobe_vipm.flows.validation.shared import ValidateNoEarlyRenewal
+
+
+def test_validate_configuration_order(mocker):
+    mocked_pipeline_instance = mocker.MagicMock()
+    mocked_pipeline_ctor = mocker.patch(
+        "adobe_vipm.flows.validation.configuration.Pipeline",
+        return_value=mocked_pipeline_instance,
+    )
+    mocked_context = mocker.MagicMock()
+    mocked_context_ctor = mocker.patch(
+        "adobe_vipm.flows.validation.configuration.Context", return_value=mocked_context
+    )
+    mocked_client = mocker.MagicMock()
+    mocked_order = mocker.MagicMock()
+
+    validate_configuration_order(mocked_client, mocked_order)  # act
+
+    expected_steps = [
+        SetupContext,
+        ValidateNoEarlyRenewal,
+    ]
+    actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args]
+    assert actual_steps == expected_steps
+    mocked_context_ctor.assert_called_once_with(order=mocked_order)
+    mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)

--- a/tests/flows/validation/test_shared.py
+++ b/tests/flows/validation/test_shared.py
@@ -1,11 +1,17 @@
 import pytest
+from freezegun import freeze_time
 
-from adobe_vipm.adobe.constants import ORDER_TYPE_PREVIEW
+from adobe_vipm.adobe.constants import (
+    ORDER_TYPE_PREVIEW,
+    ORDER_TYPE_RENEWAL,
+    AdobeOrderStatus,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeProductNotFoundError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
 from adobe_vipm.flows.constants import (
     ERR_ADOBE_ERROR,
     ERR_DUPLICATED_ITEMS,
+    ERR_EARLY_RENEWAL_IN_PROGRESS,
     ERR_EXISTING_ITEMS,
     MARKET_SEGMENT_COMMERCIAL,
     MARKET_SEGMENT_EDUCATION,
@@ -15,6 +21,7 @@ from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.validation.shared import (
     GetPreviewOrder,
     ValidateDuplicateLines,
+    ValidateNoEarlyRenewal,
 )
 
 
@@ -217,3 +224,178 @@ def test_get_preview_order_step_adobe_create_preview_order_error(
     assert context.validation_succeeded is False
     assert context.order["error"] == ERR_ADOBE_ERROR.to_dict(details="error message")
     assert context.adobe_preview_order is None
+
+
+@pytest.fixture
+def early_renewal_context(order_factory):
+    return Context(
+        order=order_factory(),
+        authorization_id="AUT-1234-5678",
+        adobe_customer_id="a-client-id",
+        adobe_customer={"cotermDate": "2027-09-25"},
+    )
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_blocks_pending_early_renewal(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.COMPLETE.value,
+            creation_date="2026-09-05T10:00:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is False
+    assert early_renewal_context.order["error"] == ERR_EARLY_RENEWAL_IN_PROGRESS.to_dict()
+    mock_adobe_client.get_orders.assert_called_once_with(
+        "AUT-1234-5678",
+        "a-client-id",
+        filters={"order-type": ORDER_TYPE_RENEWAL},
+    )
+    mock_next_step.assert_not_called()
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_blocks_open_renewal_order(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    early_renewal_context.adobe_customer = {"cotermDate": "2026-09-25"}
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.OPEN.value,
+            creation_date="2026-09-08T10:00:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is False
+    assert early_renewal_context.order["error"] == ERR_EARLY_RENEWAL_IN_PROGRESS.to_dict()
+    mock_next_step.assert_not_called()
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_ignores_anniversary_auto_renewal(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    early_renewal_context.adobe_customer = {"cotermDate": "2027-09-01"}
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.COMPLETE.value,
+            creation_date="2026-09-01T00:10:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is True
+    mock_next_step.assert_called_once_with(mock_mpt_client, early_renewal_context)
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_ignores_orders_outside_lookback(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.COMPLETE.value,
+            creation_date="2026-07-01T10:00:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is True
+    mock_next_step.assert_called_once_with(mock_mpt_client, early_renewal_context)
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_unlocks_after_the_anniversary(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    early_renewal_context.adobe_customer = {"cotermDate": "2027-09-05"}
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.COMPLETE.value,
+            creation_date="2026-08-20T10:00:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is True
+    mock_next_step.assert_called_once_with(mock_mpt_client, early_renewal_context)
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_early_renewal_skips_renewal_orders(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    order_factory,
+    order_parameters_factory,
+    renewal_payload,
+):
+    context = Context(
+        order=order_factory(
+            order_parameters=order_parameters_factory(renewal_payload=renewal_payload)
+        ),
+        authorization_id="AUT-1234-5678",
+        adobe_customer_id="a-client-id",
+        adobe_customer={"cotermDate": "2027-09-25"},
+    )
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, context, mock_next_step)  # act
+
+    assert context.validation_succeeded is True
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_next_step.assert_called_once_with(mock_mpt_client, context)
+
+
+def test_validate_no_early_renewal_skips_without_adobe_customer(
+    mock_adobe_client, mock_mpt_client, mock_next_step, order_factory
+):
+    context = Context(order=order_factory())
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, context, mock_next_step)  # act
+
+    assert context.validation_succeeded is True
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_next_step.assert_called_once_with(mock_mpt_client, context)
+
+
+@freeze_time("2027-02-20 12:30:00")
+def test_validate_no_early_renewal_handles_leap_day_coterm(
+    mock_adobe_client, mock_mpt_client, mock_next_step, adobe_order_factory, early_renewal_context
+):
+    early_renewal_context.adobe_customer = {"cotermDate": "2028-02-29"}
+    mock_adobe_client.get_orders.return_value = [
+        adobe_order_factory(
+            ORDER_TYPE_RENEWAL,
+            status=AdobeOrderStatus.COMPLETE.value,
+            creation_date="2027-02-15T10:00:00Z",
+        )
+    ]
+    step = ValidateNoEarlyRenewal()
+
+    step(mock_mpt_client, early_renewal_context, mock_next_step)  # act
+
+    assert early_renewal_context.validation_succeeded is False
+    assert early_renewal_context.order["error"] == ERR_EARLY_RENEWAL_IN_PROGRESS.to_dict()
+    mock_next_step.assert_not_called()

--- a/tests/flows/validation/test_termination.py
+++ b/tests/flows/validation/test_termination.py
@@ -8,7 +8,7 @@ from adobe_vipm.flows.fulfillment.shared import (
     ValidateRenewalWindow,
 )
 from adobe_vipm.flows.helpers import SetupContext, Validate3YCCommitment
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines
+from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
 from adobe_vipm.flows.validation.termination import (
     ValidateDownsizes,
     validate_termination_order,
@@ -234,12 +234,13 @@ def test_validate_termination_order(mocker):
 
     validate_termination_order(mocked_client, mocked_order)  # act
 
-    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 6
+    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 7
     expected_steps = [
         SetupContext,
         ValidateDuplicateLines,
         SetOrUpdateCotermDate,
         ValidateRenewalWindow,
+        ValidateNoEarlyRenewal,
         ValidateDownsizes,
         Validate3YCCommitment,
     ]


### PR DESCRIPTION
… orders while a renewal is staged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds early-renewal validation for Adobe VIP Marketplace subscriptions.
- Blocks native Change, Configuration, and Termination orders when an early renewal is open or pending.
- Adds a 30-day renewal lookback period and validation error `VIPM0051`.
- Handles renewal-order exclusions and leap-day coterm dates.
- Adds configuration-order validation and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->