### PR TITLE
MPT-24772 handle net-new items on renew-now with flex-discount parity

### DIFF
--- a/adobe_vipm/adobe/mixins/subscription.py
+++ b/adobe_vipm/adobe/mixins/subscription.py
@@ -132,6 +132,7 @@ class SubscriptionClientMixin:
         auto_renewal: bool = True,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
         quantity: int | None = None,
         flex_discount_codes: list[str] | None = None,
+        reset_flex_discount_codes: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
     ) -> dict:
         """
         Update a subscription.
@@ -148,6 +149,9 @@ class SubscriptionClientMixin:
             Default to None mean to leave it unchanged.
             flex_discount_codes: Flexible discount codes to apply at the renewal. Default
             to None mean to leave them unchanged.
+            reset_flex_discount_codes: When True, sends the `reset-flex-discount-codes=true`
+            query parameter so Adobe clears any stored flexible discount codes; sending an
+            empty list or omitting the field does not clear them. Default False.
 
         Returns:
             dict: The updated subscription.
@@ -166,6 +170,7 @@ class SubscriptionClientMixin:
         if flex_discount_codes is not None:
             payload["autoRenewal"]["flexDiscountCodes"] = flex_discount_codes
 
+        query_params = {"reset-flex-discount-codes": "true"} if reset_flex_discount_codes else None
         response = self._session.patch(
             urljoin(
                 self._config.api_base_url,
@@ -173,6 +178,7 @@ class SubscriptionClientMixin:
             ),
             headers=headers,
             json=payload,
+            params=query_params,
             timeout=self._TIMEOUT,
         )
         response.raise_for_status()
@@ -189,6 +195,7 @@ class SubscriptionClientMixin:
         renewal_quantity: int,
         deployment_id: str | None = None,
         recommendation_tracker_id: str | None = None,
+        flex_discount_codes: list[str] | None = None,
     ) -> dict:
         """
         Create a scheduled subscription for a product the customer does not currently hold.
@@ -206,6 +213,9 @@ class SubscriptionClientMixin:
             deployment_id: Identifier of the deployment to which the subscription belongs to.
             recommendation_tracker_id: The tracker id captured from the Adobe
             recommendations call, replayed so Adobe can attribute the outcome.
+            flex_discount_codes: The flexible discount codes selected for the net-new
+            offer, stored on the scheduled subscription's autoRenewal so they apply at
+            the anniversary renewal. None leaves the field off the request entirely.
 
         Returns:
             dict: The created subscription.
@@ -222,6 +232,8 @@ class SubscriptionClientMixin:
             },
             "currencyCode": authorization.currency,
         }
+        if flex_discount_codes is not None:
+            payload["autoRenewal"]["flexDiscountCodes"] = flex_discount_codes
         if deployment_id:
             payload["deploymentId"] = deployment_id
 

--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -339,6 +339,7 @@ class CreateNetNewSubscriptions(Step):
                 recommendation_tracker_id=(
                     context.renewal_payload.get("recommendationTrackerId") or None
                 ),
+                flex_discount_codes=net_new_item.get("flexDiscountCodes"),
             )
         except AdobeAPIError as error:
             logger.warning(
@@ -376,21 +377,24 @@ class CreateNetNewSubscriptions(Step):
         """
         offer_id = net_new_item["offerId"]
         auto_renewal = existing.get("autoRenewal", {})
-        quantity = net_new_item["quantity"]
-        if (
-            auto_renewal.get("enabled", False)
-            and auto_renewal.get(Param.RENEWAL_QUANTITY.value) == quantity
-        ):
+        if self._scheduled_matches_plan(net_new_item, auto_renewal):
             context.renewal_net_new_subscriptions[offer_id] = existing
             return True
 
+        requested_codes = net_new_item.get("flexDiscountCodes") or []
         try:
             subscription = adobe_client.update_subscription(
                 context.authorization_id,
                 context.adobe_customer_id,
                 existing["subscriptionId"],
                 auto_renewal=True,
-                quantity=quantity,
+                quantity=net_new_item["quantity"],
+                flex_discount_codes=requested_codes or None,
+                # An empty list does not clear a stored code; Adobe needs the reset flag
+                # when the plan drops a code the reused subscription still carries.
+                reset_flex_discount_codes=(
+                    not requested_codes and bool(auto_renewal.get("flexDiscountCodes"))
+                ),
             )
         except AdobeAPIError as error:
             logger.warning(
@@ -413,11 +417,20 @@ class CreateNetNewSubscriptions(Step):
             context,
             existing["subscriptionId"],
             offer_id,
-            quantity,
+            net_new_item["quantity"],
         )
         context.renewal_net_new_subscriptions[offer_id] = subscription
         context.renewal_created_net_new_subscriptions[offer_id] = subscription
         return True
+
+    def _scheduled_matches_plan(self, net_new_item, auto_renewal):
+        """True when the scheduled subscription already matches the plan (reuse as-is)."""
+        return (
+            auto_renewal.get("enabled", False)
+            and auto_renewal.get(Param.RENEWAL_QUANTITY.value) == net_new_item["quantity"]
+            and (net_new_item.get("flexDiscountCodes") or [])
+            == (auto_renewal.get("flexDiscountCodes") or [])
+        )
 
     def _find_scheduled_subscription(self, context, offer_id):
         return find_scheduled_subscription(context.adobe_customer_subscriptions, offer_id)
@@ -776,13 +789,11 @@ class RecordDiscountRedemptions(Step):
 
     def _get_redeemed_codes(self, context):
         """Return the unique codes newly applied by the plan, skipping inherited ones."""
-        redeemed_codes, inherited_codes = [], []
-        for plan in context.renewal_plan_subscriptions:
-            if not plan["renew"]:
-                continue
-            for code in plan["flex_discount_codes"]:
-                is_inherited = code in plan["snapshot"]["flex_discount_codes"]
-                (inherited_codes if is_inherited else redeemed_codes).append(code)
+        redeemed_codes, inherited_codes = self._split_plan_codes(context)
+        # Net-new items create a brand-new subscription, so they can hold no inherited
+        # code: every code on a net-new item is a fresh redemption by this order.
+        for net_new_item in (context.renewal_payload or {}).get("netNewItems", []):
+            redeemed_codes.extend(net_new_item.get("flexDiscountCodes") or [])
         if inherited_codes:
             logger.info(
                 "%s: skipping inherited flex discount code(s) already held by the "
@@ -791,6 +802,17 @@ class RecordDiscountRedemptions(Step):
                 ", ".join(dict.fromkeys(inherited_codes)),
             )
         return list(dict.fromkeys(redeemed_codes))
+
+    def _split_plan_codes(self, context):
+        """Split the renewing plan's codes into (redeemed, inherited)."""
+        redeemed_codes, inherited_codes = [], []
+        for plan in context.renewal_plan_subscriptions:
+            if not plan["renew"]:
+                continue
+            for code in plan["flex_discount_codes"]:
+                is_inherited = code in plan["snapshot"]["flex_discount_codes"]
+                (inherited_codes if is_inherited else redeemed_codes).append(code)
+        return redeemed_codes, inherited_codes
 
     def _record_redemptions(self, context, redeemed_codes):
         logger.info(

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -28,7 +28,12 @@ redemptions table. Before anything is committed, the resulting renewing
 aggregate is validated against the 3YC committed minimum
 (Validate3YCRenewalFloor, shared with the at-anniversary flow).
 
-Net-new items are not handled yet.
+Net-new items (products the customer does not yet hold) are submitted as
+additional lines on the same RENEWAL order, carrying offerId + quantity and no
+subscriptionId: Adobe creates-and-renews the new subscription in one shot,
+invoiced immediately, and returns its new subscriptionId on the committed order.
+Their MPT subscriptions are created after the order commits
+(ResolveNetNewRenewedSubscriptions then CreateNetNewMptSubscriptions).
 """
 
 import datetime as dt
@@ -48,6 +53,7 @@ from adobe_vipm.adobe.constants import (
 )
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import (
+    ERR_RENEWAL_NET_NEW_FAILED,
     ERR_RENEWAL_ORDER_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
     ERR_RENEWAL_RETURN_FAILED,
@@ -60,6 +66,7 @@ from adobe_vipm.flows.constants import (
 )
 from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.fulfillment.renewal import (
+    CreateNetNewMptSubscriptions,
     RecordDiscountRedemptions,
     Validate3YCRenewalFloor,
 )
@@ -80,6 +87,8 @@ from adobe_vipm.flows.fulfillment.shared import (
 )
 from adobe_vipm.flows.helpers import SetupContext
 from adobe_vipm.flows.pipeline import Pipeline, Step
+from adobe_vipm.flows.utils import get_order_line_by_sku
+from adobe_vipm.flows.utils.deployment import get_deployment_id
 from adobe_vipm.flows.utils.parameter import set_adobe_order_ids_created_parameter
 from adobe_vipm.utils import get_partial_sku
 
@@ -99,20 +108,73 @@ def _is_already_renewed(plan):
     return not plan["renewal_quantity"] and plan["snapshot"]["renewed_quantity"] is not None
 
 
-def _build_renewing_line_items(context):
+def _get_renewing_plans(context):
     """
-    Build PREVIEW_RENEWAL/RENEWAL line items for the plan's renewing subscriptions.
+    Return the plan's renewing subscriptions that still need a line submitted.
 
-    Renewing subscriptions already committed in a previous renewal order
-    with no requested quantity change are excluded — see _is_already_renewed.
+    Renewing subscriptions already committed in a previous renewal order with no
+    requested quantity change are excluded — see _is_already_renewed.
     """
-    line_items = []
-    renewing = [
+    return [
         plan
         for plan in context.renewal_plan_subscriptions
         if plan["renew"] and not _is_already_renewed(plan)
     ]
-    for number, plan in enumerate(renewing, start=1):
+
+
+def _iter_net_new_lines(context):
+    """
+    Yield (extLineItemNumber, net_new_item) for the plan's net-new items.
+
+    extLineItemNumber is a stable join key from the payload item to the committed
+    RENEWAL line (whose offerId can differ from the ordered one across the renewal
+    offer-type shift). The offset counts every renewing plan entry, not only the
+    ones _get_renewing_plans currently submits: after this order's first commit a
+    renewing entry can start matching _is_already_renewed (its renewedQuantity is
+    now populated) and drop out of the submitted set, and on a retry that would
+    shift the net-new numbers and misalign them against the existing committed
+    order. Counting all renew=True entries keeps the numbering identical across
+    retries.
+    """
+    offset = sum(1 for plan in context.renewal_plan_subscriptions if plan["renew"])
+    net_new_items = (
+        context.renewal_payload.get("netNewItems", []) if context.renewal_payload else []
+    )
+    for index, net_new_item in enumerate(net_new_items):
+        yield offset + 1 + index, net_new_item
+
+
+def _get_net_new_line_map(context):
+    """Map extLineItemNumber -> net_new_item, matching the numbering used to build lines."""
+    return dict(_iter_net_new_lines(context))
+
+
+def _missing_net_new_offers(context, present_line_numbers):
+    """
+    Return the offerIds of expected net-new lines absent from present_line_numbers.
+
+    The result is a comma-joined string (empty when every net-new line is present),
+    ready for a user-facing error message.
+    """
+    net_new_by_line = _get_net_new_line_map(context)
+    missing_numbers = sorted(set(net_new_by_line) - set(present_line_numbers))
+    missing = [net_new_by_line[number] for number in missing_numbers]
+    return ", ".join(net_new["offerId"] for net_new in missing)
+
+
+def _build_renewing_line_items(context):
+    """
+    Build PREVIEW_RENEWAL/RENEWAL line items for the renewing subscriptions and net-new items.
+
+    Renewing subscriptions already committed in a previous renewal order with no
+    requested quantity change are excluded — see _is_already_renewed. Net-new items
+    are appended after them, each carrying offerId + quantity and no subscriptionId:
+    Adobe creates-and-renews the new subscription in the same order. Their
+    extLineItemNumber continues after the renewing lines so the committed order can
+    be matched back to the payload item (see _get_net_new_line_map).
+    """
+    line_items = []
+    for number, plan in enumerate(_get_renewing_plans(context), start=1):
         line_item = {
             "extLineItemNumber": number,
             "offerId": plan["offer_id"],
@@ -122,16 +184,38 @@ def _build_renewing_line_items(context):
         if plan["flex_discount_codes"]:
             line_item["flexDiscountCodes"] = plan["flex_discount_codes"]
         line_items.append(line_item)
+
+    deployment_id = get_deployment_id(context.order)
+    for number, net_new_item in _iter_net_new_lines(context):
+        line_item = {
+            "extLineItemNumber": number,
+            "offerId": net_new_item["offerId"],
+            "quantity": net_new_item["quantity"],
+        }
+        flex_discount_codes = net_new_item.get("flexDiscountCodes")
+        if flex_discount_codes:
+            line_item["flexDiscountCodes"] = flex_discount_codes
+        if deployment_id:
+            line_item["deploymentId"] = deployment_id
+        line_items.append(line_item)
     return line_items
 
 
 def _get_requested_flex_discount_codes(context):
-    """Map each renewing subscription of the plan to the codes explicitly selected for it."""
-    return {
-        plan["subscription_id"]: plan["flex_discount_codes"]
-        for plan in context.renewal_plan_subscriptions
-        if plan["renew"]
+    """
+    Map each submitted line's extLineItemNumber to the flex codes selected for it.
+
+    Covers both renewing subscriptions and net-new items, keyed by the same
+    extLineItemNumber used to build the request lines, so the committed order can
+    recover the requested codes for a net-new line that has no subscriptionId.
+    """
+    requested = {
+        number: plan["flex_discount_codes"]
+        for number, plan in enumerate(_get_renewing_plans(context), start=1)
     }
+    for number, net_new_item in _iter_net_new_lines(context):
+        requested[number] = net_new_item.get("flexDiscountCodes") or []
+    return requested
 
 
 def _get_committed_flex_discount_codes(preview_line_item, requested_codes):
@@ -179,7 +263,7 @@ def _get_committed_flex_discount_codes(preview_line_item, requested_codes):
     return committed[:1]
 
 
-def _build_committed_line_items(preview_line_items, requested_codes_by_subscription):
+def _build_committed_line_items(preview_line_items, requested_codes_by_line):
     """
     Build RENEWAL order line items from a PREVIEW_RENEWAL response's line items.
 
@@ -189,9 +273,11 @@ def _build_committed_line_items(preview_line_items, requested_codes_by_subscript
     response-shaped (e.g. flexDiscounts is a list of discount result
     objects, not the flexDiscountCodes the create-order request expects) and
     carries pricing fields the create-order request doesn't need, so it is
-    re-shaped into a request line item rather than forwarded as-is. The
-    flex discount codes come from the plan's explicit selection per
-    subscription, confirmed by the preview (see
+    re-shaped into a request line item rather than forwarded as-is. A net-new
+    line carries no subscriptionId (Adobe assigns it on the committed order),
+    so it is only forwarded when present. The flex discount codes come from the
+    plan's explicit selection per line, keyed by extLineItemNumber (stable
+    across preview and commit) and confirmed by the preview (see
     _get_committed_flex_discount_codes).
     """
     line_items = []
@@ -199,10 +285,12 @@ def _build_committed_line_items(preview_line_items, requested_codes_by_subscript
         line_item = {
             "extLineItemNumber": preview_line_item["extLineItemNumber"],
             "offerId": preview_line_item["offerId"],
-            "subscriptionId": preview_line_item["subscriptionId"],
             "quantity": preview_line_item["quantity"],
         }
-        requested_codes = requested_codes_by_subscription.get(preview_line_item["subscriptionId"])
+        subscription_id = preview_line_item.get("subscriptionId")
+        if subscription_id:
+            line_item["subscriptionId"] = subscription_id
+        requested_codes = requested_codes_by_line.get(preview_line_item["extLineItemNumber"])
         flex_discount_codes = _get_committed_flex_discount_codes(
             preview_line_item, requested_codes or []
         )
@@ -267,10 +355,44 @@ class PreviewRenewalNowOrder(Step):
             )
             return False
 
+        if not self._ensure_net_new_previewed(client, context):
+            return False
+
         logger.info(
             "%s: renewal preview validated for %s subscription(s)", context, len(line_items)
         )
         return True
+
+    def _ensure_net_new_previewed(self, client, context):
+        """
+        Fail the order before commit when the preview omitted a requested net-new line.
+
+        The renew-now RENEWAL order is invoiced immediately, so a net-new line the
+        PREVIEW_RENEWAL did not accept must fail the order here — before anything is
+        committed — rather than after commit, leaving nothing to reverse.
+        """
+        previewed = {
+            line_item["extLineItemNumber"]
+            for line_item in context.preview_renewal_order["lineItems"]
+        }
+        missing_offers = _missing_net_new_offers(context, previewed)
+        if not missing_offers:
+            return True
+
+        logger.warning(
+            "%s: renewal preview omitted net-new line(s) for offer(s): %s",
+            context,
+            missing_offers,
+        )
+        switch_order_to_failed(
+            client,
+            context.order,
+            ERR_RENEWAL_NET_NEW_FAILED.to_dict(
+                offer_id=missing_offers,
+                error="line not present on the renewal preview",
+            ),
+        )
+        return False
 
 
 class SubmitRenewalNowOrder(Step):
@@ -283,7 +405,9 @@ class SubmitRenewalNowOrder(Step):
     Adobe RENEWAL order is detected by its external reference id, so a
     retry of this step is idempotent.
 
-    Net-new items are not handled by this step.
+    Net-new lines (offerId + quantity, no subscriptionId) ride this same order;
+    their MPT subscriptions are created afterwards by
+    ResolveNetNewRenewedSubscriptions and CreateNetNewMptSubscriptions.
     """
 
     def __call__(self, client, context, next_step):
@@ -770,6 +894,154 @@ class DisableLapsingSubscriptions(Step):
         return True
 
 
+class ResolveNetNewRenewedSubscriptions(Step):
+    """
+    Resolve the Adobe subscriptions Adobe created for the plan's net-new items.
+
+    A net-new item is submitted as a RENEWAL line with no subscriptionId; Adobe
+    creates-and-renews the subscription in one shot and returns its new
+    subscriptionId on that line of the committed order. This step matches each
+    committed net-new line back to its payload item by extLineItemNumber (offerId
+    can shift between the ordered and the renewal offer variant, so it is not a
+    safe key), fetches the full Adobe subscription, and stores it on the context
+    keyed by the payload offerId so CreateNetNewMptSubscriptions can create the MPT
+    subscription. No-op when the plan has no net-new items or no RENEWAL order was
+    committed. Idempotent: a retry reuses the existing RENEWAL order and re-resolves
+    the same subscriptions.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Resolve the Adobe subscriptions created for the plan's net-new items."""
+        net_new_by_line = _get_net_new_line_map(context)
+        if not net_new_by_line or context.adobe_renewal_order is None:
+            next_step(client, context)
+            return
+
+        adobe_client = get_adobe_client()
+        resolved_lines = set()
+        for line_item in context.adobe_renewal_order.get("lineItems", []):
+            net_new_item = net_new_by_line.get(line_item["extLineItemNumber"])
+            if not net_new_item:
+                continue
+            if not self._resolve(client, adobe_client, context, line_item, net_new_item):
+                return
+            resolved_lines.add(line_item["extLineItemNumber"])
+
+        if not self._ensure_all_resolved(client, context, resolved_lines):
+            return
+
+        next_step(client, context)
+
+    def _ensure_all_resolved(self, client, context, resolved_lines):
+        """Fail the order when the committed order omitted a requested net-new line."""
+        missing_offers = _missing_net_new_offers(context, resolved_lines)
+        if not missing_offers:
+            return True
+
+        logger.warning(
+            "%s: committed renewal order is missing net-new line(s) for offer(s): %s",
+            context,
+            missing_offers,
+        )
+        switch_order_to_failed(
+            client,
+            context.order,
+            ERR_RENEWAL_NET_NEW_FAILED.to_dict(
+                offer_id=missing_offers,
+                error="line not present on the committed renewal order",
+            ),
+        )
+        return False
+
+    def _resolve(self, client, adobe_client, context, line_item, net_new_item):
+        """Fetch and store the Adobe subscription of a committed net-new line, False on failure."""
+        offer_id = net_new_item["offerId"]
+        subscription_id = line_item.get("subscriptionId")
+        if not subscription_id:
+            logger.warning(
+                "%s: committed net-new line for offer %s has no subscriptionId",
+                context,
+                offer_id,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_NET_NEW_FAILED.to_dict(
+                    offer_id=offer_id,
+                    error="committed renewal line has no subscriptionId",
+                ),
+            )
+            return False
+
+        try:
+            subscription = adobe_client.get_subscription(
+                context.authorization_id,
+                context.adobe_customer_id,
+                subscription_id,
+            )
+        except AdobeAPIError as error:
+            logger.warning(
+                "%s: failed to resolve net-new subscription %s for offer %s: %s",
+                context,
+                subscription_id,
+                offer_id,
+                error,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_NET_NEW_FAILED.to_dict(offer_id=offer_id, error=error.message),
+            )
+            return False
+
+        context.renewal_net_new_subscriptions[offer_id] = subscription
+        logger.info(
+            "%s: resolved net-new subscription %s for offer %s",
+            context,
+            subscription["subscriptionId"],
+            offer_id,
+        )
+        return True
+
+
+class ValidateNetNewOrderLines(Step):
+    """
+    Fail the order before any Adobe mutation when a net-new item has no MPT order line.
+
+    CreateNetNewMptSubscriptions matches each net-new item to its MPT order line by SKU
+    and skips an unmatched one. On the renew-now path that would leave Adobe having
+    created-and-invoiced the subscription while the MPT order completes without it, so
+    this step validates the mapping up front — before PREVIEW_RENEWAL — and fails the
+    order with nothing committed instead.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Fail the order when a net-new item has no matching MPT order line."""
+        unmatched = [
+            net_new_item["offerId"]
+            for _, net_new_item in _iter_net_new_lines(context)
+            if not get_order_line_by_sku(context.order, net_new_item["offerId"])
+        ]
+        if unmatched:
+            unmatched_offers = ", ".join(unmatched)
+            logger.warning(
+                "%s: net-new item(s) with no matching order line: %s",
+                context,
+                unmatched_offers,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_NET_NEW_FAILED.to_dict(
+                    offer_id=unmatched_offers,
+                    error="no matching order line for the net-new item",
+                ),
+            )
+            return
+
+        next_step(client, context)
+
+
 def fulfill_renewal_now_order(client, order):
     """
     Fulfills a change order that carries a renew-now renewal payload.
@@ -778,8 +1050,10 @@ def fulfill_renewal_now_order(client, order):
     and committed as an actual Adobe RENEWAL order, invoiced immediately.
     Before that, the previous RENEWAL order lines of the lapsing
     subscriptions already committed are resolved and checked against the
-    return window, so nothing is committed that cannot be undone. Once it
-    completes, those lines are returned, the renewed
+    return window, so nothing is committed that cannot be undone. Net-new
+    items ride the same RENEWAL order as extra lines and their MPT
+    subscriptions are created after it commits. Once it
+    completes, the previous lines are returned, the renewed
     subscriptions (renew = true) have their autoRenewal normalised and the
     plan's lapsing subscriptions (renew = false) have their auto-renewal
     disabled.
@@ -801,11 +1075,14 @@ def fulfill_renewal_now_order(client, order):
         UpdateAgreementParamsVisibility(),
         ValidateRenewalWindow(),
         SetupRenewalPlan(),
-        Validate3YCRenewalFloor(include_net_new_items=False),
+        ValidateNetNewOrderLines(),
+        Validate3YCRenewalFloor(include_net_new_items=True),
         ResolvePreviousRenewalReturns(),
         PreviewRenewalNowOrder(),
         SubmitRenewalNowOrder(),
         ReturnPreviousRenewalOrders(),
+        ResolveNetNewRenewedSubscriptions(),
+        CreateNetNewMptSubscriptions(),
         NormalizeRenewedSubscriptions(),
         DisableLapsingSubscriptions(),
         CompleteOrder(TEMPLATE_NAME_CHANGE),

--- a/adobe_vipm/flows/fulfillment/shared.py
+++ b/adobe_vipm/flows/fulfillment/shared.py
@@ -1771,11 +1771,10 @@ class SetupRenewalPlan(Step):
     def __call__(self, client, context, next_step):
         """Resolve the renewal payload against the customer's Adobe subscriptions."""
         context.renewal_payload = get_renewal_payload(context.order)
-        plan_entries = context.renewal_payload.get("subscriptions", [])
-        for entry in plan_entries:
-            if not self._enforce_one_flex_discount_code(client, context, entry):
-                return
+        if not self._enforce_flex_discount_codes(client, context):
+            return
 
+        plan_entries = context.renewal_payload.get("subscriptions", [])
         adobe_client = get_adobe_client()
         subscriptions = adobe_client.get_subscriptions(
             context.authorization_id,
@@ -1817,13 +1816,30 @@ class SetupRenewalPlan(Step):
         )
         next_step(client, context)
 
+    def _enforce_flex_discount_codes(self, client, context):
+        """
+        Enforce the one-flex-discount-code-per-line rule on every submitted line.
+
+        Covers both existing-subscription entries and net-new items. Returns False as
+        soon as one entry breaches the rule (the entry's handler has failed the order
+        by then); True when every entry is valid.
+        """
+        entries = context.renewal_payload.get("subscriptions", []) + context.renewal_payload.get(
+            "netNewItems", []
+        )
+        return all(
+            self._enforce_one_flex_discount_code(client, context, entry) for entry in entries
+        )
+
     def _enforce_one_flex_discount_code(self, client, context, entry):
         """
         Enforce Adobe's one-flex-discount-code-per-line rule on a renewal plan entry.
 
         The renewal payload is external input: a plan entry carrying more than
         one code would be rejected by Adobe with error 2147 at submission, so
-        the order is failed upfront with a clear message instead. Returns True
+        the order is failed upfront with a clear message instead. Applies to both
+        existing-subscription entries and net-new items; a net-new item has no
+        subscriptionId, so the message falls back to its offerId. Returns True
         when the entry is valid.
         """
         flex_discount_codes = entry.get("flexDiscountCodes") or []
@@ -1831,8 +1847,9 @@ class SetupRenewalPlan(Step):
             return True
 
         joined_codes = ", ".join(flex_discount_codes)
+        line_identifier = entry.get("subscriptionId") or entry.get("offerId")
         error = (
-            f"subscription {entry['subscriptionId']} carries "
+            f"subscription {line_identifier} carries "
             f"{len(flex_discount_codes)} codes ({joined_codes})"
         )
         logger.warning(

--- a/docs/renew-now.md
+++ b/docs/renew-now.md
@@ -9,22 +9,23 @@ at-anniversary path see `renewal.py`. For the surrounding layers and routing see
 ## Flow summary
 
 The resulting renewing aggregate of the plan is first validated against the 3YC
-committed minimum, then the renewing subscriptions are validated with an Adobe
-`PREVIEW_RENEWAL` order and committed as an actual Adobe `RENEWAL` order,
-invoiced immediately. After the commit, previous renewal lines are returned,
-renewed subscriptions have their auto-renewal normalised, lapsing subscriptions
-have their auto-renewal disabled, and the redeemed flex discount codes are
-recorded on the AirTable redemptions table.
+committed minimum, then the renewing subscriptions — and any net-new items — are
+validated with an Adobe `PREVIEW_RENEWAL` order and committed as an actual Adobe
+`RENEWAL` order, invoiced immediately. After the commit, previous renewal lines
+are returned, the MPT subscriptions for net-new items are created, renewed
+subscriptions have their auto-renewal normalised, lapsing subscriptions have
+their auto-renewal disabled, and the redeemed flex discount codes are recorded on
+the AirTable redemptions table.
 
 ## 3YC committed minimum floor (VIPM0034)
 
-`Validate3YCRenewalFloor(include_net_new_items=False)`, shared with the
+`Validate3YCRenewalFloor(include_net_new_items=True)`, shared with the
 at-anniversary flow, runs **before** return resolution and before any Adobe
 preview or commit operation. It projects the plan onto the customer's Adobe
 subscriptions snapshotted by `SetupRenewalPlan` and validates the resulting
 licenses and consumables aggregate with the same 3YC guard used by the other
-order types. Net-new items are excluded here because this flow does not create
-them.
+order types. Net-new items are included in the projection because this flow
+commits them on the same `RENEWAL` order (see [Net-new items](#net-new-items)).
 
 The floor is enforced only for a 3YC renewal, that is a customer with a
 `COMMITTED`/`ACTIVE` commitment that does not end before the coterm date;
@@ -72,6 +73,21 @@ and that the `PREVIEW_RENEWAL` response then **confirmed** with result
 - Adobe accepts at most one code per line and rejects more with error `2147`, so
   a single surviving code is submitted per line.
 
-## Known limitations
+## Net-new items
 
-Net-new items are not handled by this flow yet.
+A net-new item (a product the customer does not yet hold) is submitted as an
+additional line on the same immediate `RENEWAL` order, carrying `offerId` and
+`quantity` and **no** `subscriptionId`: Adobe creates-and-renews the new
+subscription in one shot and returns its assigned `subscriptionId` on the
+committed order. Net-new lines are validated by the same `PREVIEW_RENEWAL` as the
+renewing subscriptions and are numbered after them, so `extLineItemNumber` is the
+join key from the plan item back to the committed line — the committed line's
+`offerId` can differ from the ordered one across the renewal offer-type shift, so
+it is not a safe key. After the order commits,
+`ResolveNetNewRenewedSubscriptions` reads each new `subscriptionId` and
+`CreateNetNewMptSubscriptions` (shared with the at-anniversary flow) creates the
+corresponding MPT subscription. No separate Create Order is placed.
+
+A net-new item may carry a single flexible discount code (`flexDiscountCodes`),
+enforced (one code per line), preview-confirmed, and recorded on the AirTable
+redemptions table exactly like a renewing line.

--- a/tests/adobe/test_client.py
+++ b/tests/adobe/test_client.py
@@ -1961,6 +1961,48 @@ def test_update_subscription_with_flex_discount_codes(
     assert result == {"b": "subscription"}
 
 
+def test_update_subscription_reset_flex_discount_codes(
+    requests_mocker,
+    settings,
+    adobe_client_factory,
+    adobe_authorizations_file,
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    customer_id = "a-customer"
+    sub_id = "a-sub-id"
+    client, _, _ = adobe_client_factory()
+    requests_mocker.patch(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            f"/v3/customers/{customer_id}/subscriptions/{sub_id}",
+        ),
+        status=200,
+        json={"a": "subscription"},
+        match=[
+            matchers.query_param_matcher({"reset-flex-discount-codes": "true"}),
+            matchers.json_params_matcher({"autoRenewal": {"enabled": True}}),
+        ],
+    )
+    requests_mocker.get(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            f"/v3/customers/{customer_id}/subscriptions/{sub_id}",
+        ),
+        status=200,
+        json={"b": "subscription"},
+    )
+
+    result = client.update_subscription(
+        authorization_uk,
+        customer_id,
+        sub_id,
+        auto_renewal=True,
+        reset_flex_discount_codes=True,
+    )
+
+    assert result == {"b": "subscription"}
+
+
 def test_create_customer_subscription(
     requests_mocker,
     settings,
@@ -2046,6 +2088,47 @@ def test_create_customer_subscription_with_deployment(
         "65322651CA01A12",
         5,
         deployment_id="a-deployment-id",
+    )
+
+    assert result == {"subscriptionId": "a-sub-id", "status": "1009"}
+
+
+def test_create_customer_subscription_with_flex_discount_codes(
+    requests_mocker,
+    settings,
+    adobe_client_factory,
+    adobe_authorizations_file,
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    customer_id = "a-customer"
+    client, authorization, _ = adobe_client_factory()
+    body_to_match = {
+        "offerId": "65322651CA01A12",
+        "autoRenewal": {
+            "enabled": True,
+            Param.RENEWAL_QUANTITY.value: 5,
+            "flexDiscountCodes": ["CODE-3"],
+        },
+        "currencyCode": authorization.currency,
+    }
+    requests_mocker.post(
+        urljoin(
+            settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"],
+            f"/v3/customers/{customer_id}/subscriptions",
+        ),
+        status=200,
+        json={"subscriptionId": "a-sub-id", "status": "1009"},
+        match=[
+            matchers.json_params_matcher(body_to_match),
+        ],
+    )
+
+    result = client.create_customer_subscription(
+        authorization_uk,
+        customer_id,
+        "65322651CA01A12",
+        5,
+        flex_discount_codes=["CODE-3"],
     )
 
     assert result == {"subscriptionId": "a-sub-id", "status": "1009"}

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -341,6 +341,7 @@ def test_create_net_new_subscriptions_step(
         5,
         deployment_id="",
         recommendation_tracker_id="8fe13fb6-72a1-451b-901b-d92da956282d",
+        flex_discount_codes=None,
     )
     assert renewal_context.renewal_net_new_subscriptions == {"65322651CA01A12": created_sub}
     assert renewal_context.renewal_created_net_new_subscriptions == {"65322651CA01A12": created_sub}
@@ -402,6 +403,8 @@ def test_create_net_new_subscriptions_step_restores_neutralized_scheduled_subscr
         "net-new-sub-id",
         auto_renewal=True,
         quantity=5,
+        flex_discount_codes=None,
+        reset_flex_discount_codes=False,
     )
     assert renewal_context.renewal_net_new_subscriptions == {"65322651CA01A12": restored_sub}
     assert renewal_context.renewal_created_net_new_subscriptions == {
@@ -1412,3 +1415,128 @@ def test_validate_3yc_renewal_floor_step_ignores_inactive_subscriptions(
         "commitment of 20 licenses for the three-year commitment."
     )
     mocked_next_step.assert_not_called()
+
+
+def test_setup_renewal_plan_step_net_new_multiple_flex_discount_codes(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    order_factory,
+    order_parameters_factory,
+    renewal_payload,
+):
+    """A net-new item carrying more than one flex code fails the order upfront."""
+    renewal_payload["netNewItems"][0]["flexDiscountCodes"] = ["CODE-1", "CODE-2"]
+    order = order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(renewal_payload=renewal_payload),
+    )
+    context = Context(
+        order=order,
+        order_id=order["id"],
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.shared.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SetupRenewalPlan()
+
+    step(mock_mpt_client, context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    message = mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    assert "Only one flexible discount code per line item is allowed" in message
+    mocked_next_step.assert_not_called()
+
+
+def test_create_net_new_subscriptions_step_forwards_flex_discount_codes(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context, adobe_subscription_factory
+):
+    """The net-new item's flex codes are forwarded to create_customer_subscription."""
+    renewal_context.renewal_payload["netNewItems"][0]["flexDiscountCodes"] = ["CODE-3"]
+    created_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=5,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    mock_adobe_client.create_customer_subscription.return_value = created_sub
+    mocked_next_step = mocker.MagicMock()
+    step = CreateNetNewSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.create_customer_subscription.assert_called_once_with(
+        renewal_context.authorization_id,
+        renewal_context.adobe_customer_id,
+        "65322651CA01A12",
+        5,
+        deployment_id="",
+        recommendation_tracker_id="8fe13fb6-72a1-451b-901b-d92da956282d",
+        flex_discount_codes=["CODE-3"],
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+@freeze_time("2026-08-12 10:00:00")
+def test_record_discount_redemptions_step_records_net_new_codes(
+    mocker, mock_mpt_client, renewal_context
+):
+    """Codes on net-new items are recorded as fresh redemptions."""
+    renewal_context.renewal_plan_subscriptions = [plan_entry(flex_discount_codes=["CODE-1"])]
+    renewal_context.renewal_payload["netNewItems"][0]["flexDiscountCodes"] = ["CODE-3"]
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    redeemed_codes = [
+        redemption["code"] for redemption in mocked_create_redemptions.mock_calls[0].args[0]
+    ]
+    assert redeemed_codes == ["CODE-1", "CODE-3"]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_create_net_new_subscriptions_step_resets_stale_flex_discount_codes(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context, adobe_subscription_factory
+):
+    """Reusing a scheduled subscription whose stored code the plan drops resets the code."""
+    renewal_context.renewal_payload["netNewItems"][0].pop("flexDiscountCodes", None)
+    scheduled_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=5,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    scheduled_sub["autoRenewal"]["flexDiscountCodes"] = ["OLD-CODE"]
+    restored_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id",
+        offer_id="65322651CA01A12",
+        current_quantity=0,
+        renewal_quantity=5,
+        status=AdobeSubscriptionStatus.SCHEDULED.value,
+    )
+    renewal_context.adobe_customer_subscriptions = [scheduled_sub]
+    mock_adobe_client.update_subscription.return_value = restored_sub
+    mocked_next_step = mocker.MagicMock()
+    step = CreateNetNewSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        renewal_context.authorization_id,
+        renewal_context.adobe_customer_id,
+        "net-new-sub-id",
+        auto_renewal=True,
+        quantity=5,
+        flex_discount_codes=None,
+        reset_flex_discount_codes=True,
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -14,6 +14,7 @@ from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import TEMPLATE_NAME_CHANGE
 from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.fulfillment.renewal import (
+    CreateNetNewMptSubscriptions,
     RecordDiscountRedemptions,
     Validate3YCRenewalFloor,
 )
@@ -21,9 +22,11 @@ from adobe_vipm.flows.fulfillment.renewal_now import (
     DisableLapsingSubscriptions,
     NormalizeRenewedSubscriptions,
     PreviewRenewalNowOrder,
+    ResolveNetNewRenewedSubscriptions,
     ResolvePreviousRenewalReturns,
     ReturnPreviousRenewalOrders,
     SubmitRenewalNowOrder,
+    ValidateNetNewOrderLines,
     fulfill_renewal_now_order,
 )
 from adobe_vipm.flows.fulfillment.shared import (
@@ -48,7 +51,9 @@ def renewal_now_order(order_factory, order_parameters_factory, lines_factory, re
     lines = lines_factory(
         line_id=1, item_id=1, external_vendor_id="65304578CA", quantity=15
     ) + lines_factory(line_id=2, item_id=2, external_vendor_id="77777777CA", quantity=10)
-    payload = {**renewal_payload, "renewalPath": "now"}
+    # Net-new handling is exercised by dedicated tests that add netNewItems and a
+    # matching order line; the default order carries none.
+    payload = {**renewal_payload, "renewalPath": "now", "netNewItems": []}
     return order_factory(
         order_type="Change",
         order_parameters=order_parameters_factory(renewal_payload=payload),
@@ -64,7 +69,41 @@ def renewal_now_context(renewal_now_order, renewal_payload):
         product_id="PRD-1111-1111",
         authorization_id="authorization-id",
         adobe_customer_id="customer-id",
-        renewal_payload={**renewal_payload, "renewalPath": "now"},
+        renewal_payload={**renewal_payload, "renewalPath": "now", "netNewItems": []},
+    )
+
+
+@pytest.fixture
+def net_new_item():
+    return {"offerId": "65322651CA01A12", "quantity": 5, "flexDiscountCodes": ["CODE-3"]}
+
+
+@pytest.fixture
+def renewal_now_order_net_new(
+    order_factory, order_parameters_factory, lines_factory, renewal_payload, net_new_item
+):
+    lines = (
+        lines_factory(line_id=1, item_id=1, external_vendor_id="65304578CA", quantity=15)
+        + lines_factory(line_id=2, item_id=2, external_vendor_id="77777777CA", quantity=10)
+        + lines_factory(line_id=3, item_id=3, external_vendor_id="65322651CA", quantity=5)
+    )
+    payload = {**renewal_payload, "renewalPath": "now", "netNewItems": [net_new_item]}
+    return order_factory(
+        order_type="Change",
+        order_parameters=order_parameters_factory(renewal_payload=payload),
+        lines=lines,
+    )
+
+
+@pytest.fixture
+def renewal_now_context_net_new(renewal_now_order_net_new, renewal_payload, net_new_item):
+    return Context(
+        order=renewal_now_order_net_new,
+        order_id=renewal_now_order_net_new["id"],
+        product_id="PRD-1111-1111",
+        authorization_id="authorization-id",
+        adobe_customer_id="customer-id",
+        renewal_payload={**renewal_payload, "renewalPath": "now", "netNewItems": [net_new_item]},
     )
 
 
@@ -1360,11 +1399,14 @@ def test_fulfill_renewal_now_order(mocker):
         UpdateAgreementParamsVisibility,
         ValidateRenewalWindow,
         SetupRenewalPlan,
+        ValidateNetNewOrderLines,
         Validate3YCRenewalFloor,
         ResolvePreviousRenewalReturns,
         PreviewRenewalNowOrder,
         SubmitRenewalNowOrder,
         ReturnPreviousRenewalOrders,
+        ResolveNetNewRenewedSubscriptions,
+        CreateNetNewMptSubscriptions,
         NormalizeRenewedSubscriptions,
         DisableLapsingSubscriptions,
         CompleteOrder,
@@ -1377,7 +1419,473 @@ def test_fulfill_renewal_now_order(mocker):
     actual_steps = [type(step) for step in pipeline_args]
     assert actual_steps == expected_steps
     assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
-    assert pipeline_args[8].include_net_new_items is False
-    assert pipeline_args[15].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[9].include_net_new_items is True
+    assert pipeline_args[18].template_name == TEMPLATE_NAME_CHANGE
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)
+
+
+def test_preview_renewal_now_order_step_appends_net_new_line(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    """A net-new item is appended after the renewing lines with no subscriptionId."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["CODE-1"])
+    ]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[
+            {"extLineItemNumber": 1, "offerId": "65304578CA01A12", "quantity": 15},
+            {"extLineItemNumber": 2, "offerId": "65322651CA01A12", "quantity": 5},
+        ],
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    line_items = mock_adobe_client.create_renewal_order.mock_calls[0].args[3]
+    assert line_items == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65304578CA01A12",
+            "subscriptionId": "renewing-sub-id",
+            "quantity": 15,
+            "flexDiscountCodes": ["CODE-1"],
+        },
+        {
+            "extLineItemNumber": 2,
+            "offerId": "65322651CA01A12",
+            "quantity": 5,
+            "flexDiscountCodes": ["CODE-3"],
+        },
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_preview_renewal_now_order_step_net_new_only(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    """A net-new-only plan (no renewing subscriptions) still previews and submits."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = []
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[{"extLineItemNumber": 1, "offerId": "65322651CA01A12", "quantity": 5}],
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    line_items = mock_adobe_client.create_renewal_order.mock_calls[0].args[3]
+    assert line_items == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65322651CA01A12",
+            "quantity": 5,
+            "flexDiscountCodes": ["CODE-3"],
+        },
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_submit_renewal_now_order_step_commits_net_new_line(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    """The committed order carries the net-new line keyed by extLineItemNumber.
+
+    A net-new line has no subscriptionId, and matching by extLineItemNumber keeps the
+    CA->EA offer shift and the confirmed flex code intact.
+    """
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context_net_new.preview_renewal_order = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65322651EA01A12",
+                "quantity": 5,
+                "flexDiscounts": [{"code": "CODE-3", "result": "SUCCESS"}],
+            },
+        ],
+    )
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="RENEWAL", status=AdobeOrderStatus.COMPLETE.value, order_id="ADOBE-RENEWAL-001"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    committed = mock_adobe_client.create_renewal_order.mock_calls[0].args[3]
+    assert committed == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65304578CA01A12",
+            "quantity": 15,
+            "subscriptionId": "renewing-sub-id",
+        },
+        {
+            "extLineItemNumber": 2,
+            "offerId": "65322651EA01A12",
+            "quantity": 5,
+            "flexDiscountCodes": ["CODE-3"],
+        },
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_resolve_net_new_renewed_subscriptions_step(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context_net_new,
+    adobe_order_factory,
+    adobe_subscription_factory,
+):
+    """The committed net-new line is matched by extLineItemNumber and stored by payload offerId."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65322651EA01A12",
+                "subscriptionId": "net-new-sub-id",
+                "quantity": 5,
+            },
+        ],
+    )
+    adobe_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id", offer_id="65322651EA01A12"
+    )
+    mock_adobe_client.get_subscription.return_value = adobe_sub
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_called_once_with(
+        renewal_now_context_net_new.authorization_id,
+        renewal_now_context_net_new.adobe_customer_id,
+        "net-new-sub-id",
+    )
+    assert renewal_now_context_net_new.renewal_net_new_subscriptions == {
+        "65322651CA01A12": adobe_sub
+    }
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_resolve_net_new_renewed_subscriptions_step_no_net_new(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    """No net-new items (or no committed order): the step is a no-op."""
+    renewal_now_context.adobe_renewal_order = None
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_resolve_net_new_renewed_subscriptions_step_adobe_error(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context_net_new,
+    adobe_order_factory,
+    adobe_api_error_factory,
+):
+    """A get_subscription failure fails the order and stops the pipeline."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65322651EA01A12",
+                "subscriptionId": "net-new-sub-id",
+                "quantity": 5,
+            },
+        ],
+    )
+    mock_adobe_client.get_subscription.side_effect = AdobeAPIError(
+        400, adobe_api_error_factory(code="9999", message="boom")
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    mocked_next_step.assert_not_called()
+
+
+def test_preview_renewal_now_order_step_net_new_deployment_and_no_flex(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    """A net-new line with no flex code carries the order's deploymentId when present."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = []
+    renewal_now_context_net_new.renewal_payload["netNewItems"] = [
+        {"offerId": "65322651CA01A12", "quantity": 5},
+    ]
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.get_deployment_id",
+        return_value="deployment-123",
+    )
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[{"extLineItemNumber": 1, "offerId": "65322651CA01A12", "quantity": 5}],
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    line_items = mock_adobe_client.create_renewal_order.mock_calls[0].args[3]
+    assert line_items == [
+        {
+            "extLineItemNumber": 1,
+            "offerId": "65322651CA01A12",
+            "quantity": 5,
+            "deploymentId": "deployment-123",
+        },
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_preview_renewal_now_order_step_fails_when_net_new_missing_from_preview(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    """A preview that omits a requested net-new line fails the order before commit."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    mock_adobe_client.get_orders.return_value = []
+    # The preview echoes only the renewing line; the net-new line (2) is absent.
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = PreviewRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "65322651CA01A12" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_resolve_net_new_renewed_subscriptions_step_missing_line(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context_net_new,
+    adobe_order_factory,
+):
+    """A committed order that omits a requested net-new line fails the MPT order."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    # Committed order carries only the renewing line; the net-new line (extLineItemNumber 2)
+    # is absent.
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+        ],
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_not_called()
+    mocked_switch_to_failed.assert_called_once()
+    assert "65322651CA01A12" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_resolve_net_new_renewed_subscriptions_step_numbering_stable_on_retry(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context_net_new,
+    adobe_order_factory,
+    adobe_subscription_factory,
+):
+    """Net-new numbering counts every renew=True entry so retries keep the line stable."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [
+        plan_entry(),
+        # renew=True but already committed by this order's first attempt (renewedQuantity
+        # populated), so _get_renewing_plans now excludes it — but it still occupied a line.
+        plan_entry(
+            subscription_id="already-renewed-sub-id",
+            offer_id="77777777CA01A12",
+            renewal_quantity=0,
+            snapshot_renewed_quantity=9,
+        ),
+    ]
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "77777777CA01A12",
+                "subscriptionId": "already-renewed-sub-id",
+                "quantity": 9,
+            },
+            {
+                "extLineItemNumber": 3,
+                "offerId": "65322651EA01A12",
+                "subscriptionId": "net-new-sub-id",
+                "quantity": 5,
+            },
+        ],
+    )
+    adobe_sub = adobe_subscription_factory(
+        subscription_id="net-new-sub-id", offer_id="65322651EA01A12"
+    )
+    mock_adobe_client.get_subscription.return_value = adobe_sub
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    # The net-new line is number 3 (two renew=True entries + 1), so the net-new
+    # subscription is resolved — not the already-renewed line 2.
+    mock_adobe_client.get_subscription.assert_called_once_with(
+        renewal_now_context_net_new.authorization_id,
+        renewal_now_context_net_new.adobe_customer_id,
+        "net-new-sub-id",
+    )
+    assert renewal_now_context_net_new.renewal_net_new_subscriptions == {
+        "65322651CA01A12": adobe_sub
+    }
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_resolve_net_new_renewed_subscriptions_step_missing_subscription_id(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context_net_new,
+    adobe_order_factory,
+):
+    """A committed net-new line without a subscriptionId fails the order (no KeyError)."""
+    renewal_now_context_net_new.renewal_plan_subscriptions = [plan_entry()]
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+            },
+            {"extLineItemNumber": 2, "offerId": "65322651EA01A12", "quantity": 5},
+        ],
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolveNetNewRenewedSubscriptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mock_adobe_client.get_subscription.assert_not_called()
+    mocked_switch_to_failed.assert_called_once()
+    assert "65322651CA01A12" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+def test_validate_net_new_order_lines_step_passes_when_all_matched(
+    mocker, mock_mpt_client, renewal_now_context_net_new
+):
+    """Every net-new item has a matching order line, so the step proceeds."""
+    mocked_next_step = mocker.MagicMock()
+    step = ValidateNetNewOrderLines()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
+
+
+def test_validate_net_new_order_lines_step_fails_when_line_missing(
+    mocker, mock_mpt_client, renewal_now_context
+):
+    """A net-new item without a matching MPT order line fails the order before commit."""
+    # The default renewal_now_context order has no line for 65322651CA.
+    renewal_now_context.renewal_payload["netNewItems"] = [
+        {"offerId": "65322651CA01A12", "quantity": 5},
+    ]
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ValidateNetNewOrderLines()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    assert "65322651CA01A12" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Implements the outstanding half of MPT-24772: renew-now early-renewal **net-new additions**, plus full **flexible-discount parity** for net-new items across both renewal paths. (The `x-recommendation-tracker-id` header half was already in place and verified.)

### Renew-now net-new additions (`flows/fulfillment/renewal_now.py`)
- Net-new items (products the customer does not yet hold) are submitted as additional lines on the immediate Adobe `RENEWAL` order (`offerId` + `quantity`, **no** `subscriptionId`); Adobe creates-and-renews them in one shot. No separate Create Order.
- Lines are validated by the same `PREVIEW_RENEWAL` and matched to the committed order by `extLineItemNumber`, which is stable across the CA→EA renewal offer-type shift.
- New `ResolveNetNewRenewedSubscriptions` step resolves each newly assigned Adobe subscription; the **shared** `CreateNetNewMptSubscriptions` then creates the MPT subscription after commit.
- `Validate3YCRenewalFloor` now includes net-new items in the committed-minimum projection (`include_net_new_items=True`).

### Flex-discount parity
- `SetupRenewalPlan` (shared) enforces one flex code per line for net-new items.
- `RecordDiscountRedemptions` records net-new codes as fresh redemptions (both renewal paths).
- At-anniversary `create_customer_subscription` (mixin) now forwards `flexDiscountCodes` into `autoRenewal`, wired through `CreateNetNewSubscriptions`.

### Docs
- `docs/renew-now.md` updated: net-new mechanism and the 3YC floor change.

## Testing
- `make check` equivalent — `ruff format --check`, `ruff check`, `flake8`, `uv lock --check` — clean.
- Full suite: **1084 tests pass, 99% coverage**. New tests cover net-new line emission, net-new-only basket, committed line without `subscriptionId` + CA→EA + flex confirmation, the resolve step (happy / no-op / Adobe error), one-code enforcement on net-new, redemption recording, and at-anniversary flex forwarding (step + mixin).

## Note for reviewers
The net-new-line-on-`RENEWAL` mechanism (no `subscriptionId` for a new offer) is confirmed by Adobe's early-renewals docs (`/vipmp/docs/renewals/manual-renewals`). A sandbox run is still advisable to confirm the committed `RENEWAL` response returns the new `subscriptionId` on the net-new line and echoes `extLineItemNumber` unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds support for net-new products in renew-now orders.
- Validates net-new lines through `PREVIEW_RENEWAL` and matches them with `extLineItemNumber`.
- Creates Adobe and MPT subscriptions after the renewal order commits.
- Includes net-new items in 3YC renewal floor validation.
- Supports flexible-discount codes for net-new subscriptions and both renewal paths.
- Updates renew-now documentation and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->