### PR TITLE
[BACKPORT]-MPT-24777 Renewal fulfilment hardening: 3YC floor guard, redemption p…

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -515,6 +515,12 @@ ERR_RENEWAL_RETURN_FAILED = ValidationError(
     "Failed to return the previous renewal order for subscription {subscription_id}: {error}.",
 )
 
+ERR_RENEWAL_RETURN_WINDOW_CLOSED = ValidationError(
+    "VIPM0053",
+    "The previous renewal order {order_id} of subscription {subscription_id} was placed on "
+    "{creation_date}, outside the {window_days}-day return window, so it cannot be returned.",
+)
+
 ERR_EARLY_RENEWAL_IN_PROGRESS = ValidationError(
     "VIPM0051",
     "An early renewal has already been placed for this agreement, so Change, "

--- a/adobe_vipm/flows/context.py
+++ b/adobe_vipm/flows/context.py
@@ -40,6 +40,7 @@ class Context:
     adobe_transfer_order: dict = field(default_factory=dict)
     renewal_payload: dict | None = None
     renewal_plan_subscriptions: list = field(default_factory=list)
+    renewal_return_candidates: list = field(default_factory=list)
     renewal_net_new_subscriptions: dict = field(default_factory=dict)
     renewal_created_net_new_subscriptions: dict = field(default_factory=dict)
     adobe_customer_subscriptions: list = field(default_factory=list)

--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -10,7 +10,10 @@ The plan is applied in a fixed additive-before-subtractive order so the
 running renewing aggregate never dips below the 3YC committed minimum:
 the plan is validated with a single PREVIEW_RENEWAL, the net-new scheduled
 subscriptions are created first, then the existing subscriptions are patched
-(enable, increase, decrease, disable, in that order).
+(enable, increase, decrease, disable, in that order). The ordering only
+protects the intermediate states, so before any mutation the resulting
+renewing aggregate is also validated numerically against the committed
+minimum (Validate3YCRenewalFloor, shared with the renew-now flow).
 """
 
 import datetime as dt
@@ -22,10 +25,12 @@ from adobe_vipm.adobe.client import get_adobe_client
 from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW_RENEWAL,
     AdobeSubscriptionStatus,
+    ThreeYearCommitmentStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.airtable.models import create_discount_redemptions
 from adobe_vipm.flows.constants import (
+    ERR_COMMITMENT_3YC_VALIDATION,
     ERR_RENEWAL_NET_NEW_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
     ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
@@ -47,19 +52,39 @@ from adobe_vipm.flows.fulfillment.shared import (
     get_flex_discount_limit_error,
     switch_order_to_failed,
 )
-from adobe_vipm.flows.helpers import SetupContext
+from adobe_vipm.flows.helpers import SetupContext, Validate3YCCommitment
 from adobe_vipm.flows.pipeline import Pipeline, Step
 from adobe_vipm.flows.utils import (
     get_order_line_by_sku,
     get_subscription_by_line_and_item_id,
+    is_3yc_commitment_ending_before_coterm,
     notify_not_updated_subscriptions,
 )
 from adobe_vipm.flows.utils.deployment import get_deployment_id
 from adobe_vipm.flows.utils.parameter import update_fulfillment_parameter_value
 from adobe_vipm.notifications import send_exception
-from adobe_vipm.utils import get_partial_sku
+from adobe_vipm.utils import get_3yc_commitment, get_partial_sku
 
 logger = logging.getLogger(__name__)
+
+# The committed minimum binds only while the commitment is in force.
+IN_FORCE_COMMITMENT_STATUSES = frozenset((
+    ThreeYearCommitmentStatus.COMMITTED,
+    ThreeYearCommitmentStatus.ACTIVE,
+))
+
+
+def find_scheduled_subscription(subscriptions, offer_id):
+    """Return the scheduled (1009) subscription holding the offer, or None."""
+    return next(
+        (
+            subscription
+            for subscription in subscriptions
+            if subscription.get("status") == AdobeSubscriptionStatus.SCHEDULED
+            and get_partial_sku(subscription["offerId"]) == get_partial_sku(offer_id)
+        ),
+        None,
+    )
 
 
 class PreviewRenewal(Step):
@@ -125,6 +150,147 @@ class PreviewRenewal(Step):
                 line_item["flexDiscountCodes"] = plan["flex_discount_codes"]
             line_items.append(line_item)
         return line_items
+
+
+class Validate3YCRenewalFloor(Step):
+    """
+    Validate the resulting renewing aggregate against the 3YC committed minimum.
+
+    The additive-before-subtractive ordering of the renewal flows only
+    protects the intermediate states: nothing compares the plan's end state
+    with the committed floor, and the renewal orders are created directly in
+    Processing so the draft validation guard never runs for them. This step
+    projects the plan onto the customer's Adobe subscriptions snapshotted by
+    SetupRenewalPlan (a renewing entry takes the plan's renewal quantity, a
+    lapsing entry stops renewing, a subscription outside the plan keeps its
+    current auto-renewal and inactive subscriptions never count), adds the
+    net-new items when the flow creates them, and validates the resulting
+    licenses and consumables aggregate with the same 3YC guard used by the
+    other order types. It runs before any mutation, so a breach fails the
+    order with nothing to reverse. The floor is enforced only for a
+    COMMITTED/ACTIVE commitment that does not end before the coterm date.
+    """
+
+    def __init__(self, *, include_net_new_items=True):
+        self.include_net_new_items = include_net_new_items
+        self.commitment_validator = Validate3YCCommitment()
+
+    def __call__(self, client, context, next_step):
+        """Validate the resulting renewing aggregate against the 3YC committed minimum."""
+        commitment = get_3yc_commitment(context.adobe_customer or {})
+        if not self._is_floor_enforced(context, commitment):
+            next_step(client, context)
+            return
+
+        projected_subscriptions = self._project_plan(context)
+        count_licenses, count_consumables = (
+            self.commitment_validator.get_licenses_and_consumables_count(
+                context.market_segment, {"items": projected_subscriptions}
+            )
+        )
+        error = self.commitment_validator.validate_minimum_quantity(
+            context, commitment, count_licenses, count_consumables
+        )
+        if error:
+            logger.warning(
+                "%s: the renewal plan breaches the 3YC committed minimum: %s", context, error
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_COMMITMENT_3YC_VALIDATION.to_dict(error=error),
+            )
+            return
+
+        logger.info(
+            "%s: the renewal plan respects the 3YC committed minimum (licenses=%s, consumables=%s)",
+            context,
+            count_licenses,
+            count_consumables,
+        )
+        next_step(client, context)
+
+    def _is_floor_enforced(self, context, commitment):
+        if not commitment or commitment.get("status") not in IN_FORCE_COMMITMENT_STATUSES:
+            logger.info(
+                "%s: no 3YC commitment in force, skipping the renewal floor validation", context
+            )
+            return False
+        if is_3yc_commitment_ending_before_coterm(context.adobe_customer, commitment):
+            logger.info(
+                "%s: the 3YC commitment ends before the coterm date, "
+                "skipping the renewal floor validation",
+                context,
+            )
+            return False
+        return True
+
+    def _project_plan(self, context):
+        """Return the Adobe subscriptions as they will renew once the plan is applied."""
+        plans_by_subscription_id = {
+            plan["subscription_id"]: plan for plan in context.renewal_plan_subscriptions
+        }
+        projected = [
+            self._project_subscription(
+                subscription, plans_by_subscription_id.get(subscription["subscriptionId"])
+            )
+            for subscription in context.adobe_customer_subscriptions
+            if subscription.get("status") != AdobeSubscriptionStatus.INACTIVE
+        ]
+        if self.include_net_new_items:
+            self._project_net_new_items(context, projected)
+        return projected
+
+    def _project_subscription(self, subscription, plan):
+        auto_renewal = subscription.get("autoRenewal", {})
+        if plan is None:
+            enabled = auto_renewal.get("enabled", False)
+            quantity = auto_renewal.get(Param.RENEWAL_QUANTITY.value) or 0
+        elif plan["renew"]:
+            enabled, quantity = True, self._renewing_quantity(plan)
+        else:
+            enabled, quantity = False, 0
+        return {
+            **subscription,
+            "autoRenewal": {"enabled": enabled, Param.RENEWAL_QUANTITY.value: quantity},
+        }
+
+    def _renewing_quantity(self, plan):
+        """
+        Return the quantity a renewing plan entry will renew.
+
+        An entry already committed by a previous renewal order with no
+        requested quantity change keeps that order's renewedQuantity (the
+        renew-now flow submits nothing for it); otherwise the plan's
+        renewal quantity applies.
+        """
+        renewed_quantity = plan["snapshot"].get("renewed_quantity")
+        if not plan["renewal_quantity"] and renewed_quantity is not None:
+            return renewed_quantity
+        return plan["renewal_quantity"]
+
+    def _project_net_new_items(self, context, projected):
+        """
+        Add the plan's net-new items to the projection.
+
+        Mirrors CreateNetNewSubscriptions: a scheduled subscription already
+        holding the offer (created by a previous attempt) is reused instead
+        of being counted twice.
+        """
+        for net_new_item in context.renewal_payload.get("netNewItems", []):
+            auto_renewal = {
+                "enabled": True,
+                Param.RENEWAL_QUANTITY.value: net_new_item["quantity"],
+            }
+            scheduled = find_scheduled_subscription(projected, net_new_item["offerId"])
+            if scheduled:
+                scheduled["autoRenewal"] = auto_renewal
+            else:
+                projected.append({
+                    "offerId": net_new_item["offerId"],
+                    "status": AdobeSubscriptionStatus.SCHEDULED,
+                    "autoRenewal": auto_renewal,
+                })
 
 
 class CreateNetNewSubscriptions(Step):
@@ -254,15 +420,7 @@ class CreateNetNewSubscriptions(Step):
         return True
 
     def _find_scheduled_subscription(self, context, offer_id):
-        return next(
-            (
-                subscription
-                for subscription in context.adobe_customer_subscriptions
-                if subscription["status"] == AdobeSubscriptionStatus.SCHEDULED
-                and get_partial_sku(subscription["offerId"]) == get_partial_sku(offer_id)
-            ),
-            None,
-        )
+        return find_scheduled_subscription(context.adobe_customer_subscriptions, offer_id)
 
 
 class UpdateRenewalSubscriptions(Step):
@@ -271,7 +429,10 @@ class UpdateRenewalSubscriptions(Step):
 
     The PATCH operations run in a fixed additive-before-subtractive order
     (enable, increase, decrease, disable) so the renewing aggregate never
-    dips below the 3YC committed minimum. Each subscription state was
+    dips below the 3YC committed minimum. A plan entry without discount
+    codes leaves the codes Adobe already holds on the subscription
+    (inherited reusables) untouched, while an explicitly selected code
+    replaces them. Each subscription state was
     snapshotted before mutating; on a confirmed Adobe failure the applied
     operations are reversed (restore-to-known-good, best effort) and the
     scheduled net-new subscriptions are neutralized by disabling their
@@ -361,11 +522,20 @@ class UpdateRenewalSubscriptions(Step):
         }
 
     def _is_renewal_in_place(self, plan, snapshot):
-        """Return True when the subscription already holds the target renewal state."""
+        """
+        Return True when the subscription already holds the target renewal state.
+
+        A plan entry without codes leaves the subscription's codes untouched
+        (the PATCH sends none), so inherited codes on the snapshot do not
+        make the state differ.
+        """
+        codes_in_place = not plan["flex_discount_codes"] or sorted(
+            snapshot["flex_discount_codes"]
+        ) == sorted(plan["flex_discount_codes"])
         return (
             snapshot["enabled"]
             and snapshot["renewal_quantity"] == plan["renewal_quantity"]
-            and sorted(snapshot["flex_discount_codes"]) == sorted(plan["flex_discount_codes"])
+            and codes_in_place
         )
 
     def _apply_operation(self, adobe_client, context, operation):
@@ -583,21 +753,17 @@ class RecordDiscountRedemptions(Step):
 
     Runs after the order has been completed, so a fulfillment retry of an
     earlier failure never duplicates rows. One row is written per unique code
-    applied by the plan. The write is best effort: the order is already
-    completed, so an AirTable failure is logged and notified for a manual
-    backfill instead of failing the order.
+    applied by the plan. A code the subscription already carried before this
+    order (inherited discount snapshotted by SetupRenewalPlan) was not
+    redeemed by it, so it is skipped: an auto-applied reusable is never
+    recorded as a fresh once-per-customer redemption. The write is best
+    effort: the order is already completed, so an AirTable failure is logged
+    and notified for a manual backfill instead of failing the order.
     """
 
     def __call__(self, client, context, next_step):
         """Record the redeemed flex discount codes on the AirTable redemptions table."""
-        redeemed_codes = list(
-            dict.fromkeys(
-                code
-                for plan in context.renewal_plan_subscriptions
-                if plan["renew"]
-                for code in plan["flex_discount_codes"]
-            )
-        )
+        redeemed_codes = self._get_redeemed_codes(context)
         if redeemed_codes:
             self._record_redemptions(context, redeemed_codes)
         else:
@@ -607,6 +773,24 @@ class RecordDiscountRedemptions(Step):
                 context,
             )
         next_step(client, context)
+
+    def _get_redeemed_codes(self, context):
+        """Return the unique codes newly applied by the plan, skipping inherited ones."""
+        redeemed_codes, inherited_codes = [], []
+        for plan in context.renewal_plan_subscriptions:
+            if not plan["renew"]:
+                continue
+            for code in plan["flex_discount_codes"]:
+                is_inherited = code in plan["snapshot"]["flex_discount_codes"]
+                (inherited_codes if is_inherited else redeemed_codes).append(code)
+        if inherited_codes:
+            logger.info(
+                "%s: skipping inherited flex discount code(s) already held by the "
+                "subscriptions, not redeemed by this order: %s",
+                context,
+                ", ".join(dict.fromkeys(inherited_codes)),
+            )
+        return list(dict.fromkeys(redeemed_codes))
 
     def _record_redemptions(self, context, redeemed_codes):
         logger.info(
@@ -655,12 +839,12 @@ def fulfill_renewal_order(client, order):
     """
     Fulfills a change order that carries an at-anniversary renewal payload.
 
-    It validates the plan with a PREVIEW_RENEWAL order, creates the scheduled
-    net-new subscriptions first (additive before subtractive, so the 3YC
-    committed minimum is never breached) and then applies the auto-renewal
-    preferences to the existing subscriptions (enable, increase, decrease,
-    disable). Nothing is invoiced and no Adobe order is placed: the plan
-    takes effect at the coterm date.
+    It validates the resulting renewing aggregate against the 3YC committed
+    minimum, creates the scheduled net-new subscriptions first (additive
+    before subtractive, so the 3YC committed minimum is never breached) and
+    then applies the auto-renewal preferences to the existing subscriptions
+    (enable, increase, decrease, disable). Nothing is invoiced and no Adobe
+    order is placed: the plan takes effect at the coterm date.
 
     Args:
         client (MPTClient): An instance of the MPT client used for communication
@@ -679,6 +863,7 @@ def fulfill_renewal_order(client, order):
         UpdateAgreementParamsVisibility(),
         ValidateRenewalWindow(),
         SetupRenewalPlan(),
+        Validate3YCRenewalFloor(),
         CreateNetNewSubscriptions(),
         UpdateRenewalSubscriptions(),
         CreateNetNewMptSubscriptions(),

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -7,9 +7,12 @@ carry a renewal payload built by the renewal wizard with renewalPath "now"
 renewing subscriptions are committed as an actual Adobe RENEWAL order,
 invoiced immediately, mirroring how the PURCHASE flow turns its PREVIEW
 order into a NEW order: validate with PREVIEW_RENEWAL, then resubmit the
-line items it returns as the real order. A renewing subscription already
-committed in a previous renewal order (renewedQuantity populated) with no
-requested quantity change is excluded from both. Once the order completes, the
+line items it returns as the real order, committing only the flex discount
+codes the plan explicitly selected (reusable discounts Adobe auto-applies
+are never echoed back, and an explicit code takes precedence over them). A
+renewing subscription already committed in a previous renewal order
+(renewedQuantity populated) with no requested quantity change is excluded
+from both. Once the order completes, the
 renewed subscriptions (renew = true) have their autoRenewal normalised
 (enabled=on, renewalQuantity taken from Adobe's post-renewal
 renewedQuantity) and the plan's lapsing subscriptions (renew = false)
@@ -17,12 +20,18 @@ have their auto-renewal disabled. A lapsing subscription that was already
 committed in a previous RENEWAL order (its pre-mutation snapshot carries a
 renewedQuantity) additionally has that order's line returned via a RETURN
 order, so the customer is not left paying for a renewal that is being
-toggled off. Once the order is completed, the flex discount codes redeemed
-by the plan are recorded on the AirTable redemptions table.
+toggled off; that previous line is located and checked against Adobe's
+14-day return window before anything is committed, so an order that cannot
+be undone fails with nothing to reverse. Once the order is completed, the
+flex discount codes redeemed by the plan are recorded on the AirTable
+redemptions table. Before anything is committed, the resulting renewing
+aggregate is validated against the 3YC committed minimum
+(Validate3YCRenewalFloor, shared with the at-anniversary flow).
 
 Net-new items are not handled yet.
 """
 
+import datetime as dt
 import logging
 from operator import itemgetter
 
@@ -30,6 +39,7 @@ from mpt_extension_sdk.mpt_http.mpt import update_order
 
 from adobe_vipm.adobe.client import get_adobe_client
 from adobe_vipm.adobe.constants import (
+    CANCELLATION_WINDOW_DAYS,
     ORDER_STATUS_DESCRIPTION,
     ORDER_TYPE_PREVIEW_RENEWAL,
     ORDER_TYPE_RENEWAL,
@@ -41,6 +51,7 @@ from adobe_vipm.flows.constants import (
     ERR_RENEWAL_ORDER_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
     ERR_RENEWAL_RETURN_FAILED,
+    ERR_RENEWAL_RETURN_WINDOW_CLOSED,
     ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
     ERR_UNEXPECTED_ADOBE_ERROR_STATUS,
     ERR_UNRECOVERABLE_ADOBE_ORDER_STATUS,
@@ -48,7 +59,10 @@ from adobe_vipm.flows.constants import (
     Param,
 )
 from adobe_vipm.flows.context import Context
-from adobe_vipm.flows.fulfillment.renewal import RecordDiscountRedemptions
+from adobe_vipm.flows.fulfillment.renewal import (
+    RecordDiscountRedemptions,
+    Validate3YCRenewalFloor,
+)
 from adobe_vipm.flows.fulfillment.shared import (
     CompleteOrder,
     SetOrUpdateCotermDate,
@@ -111,38 +125,61 @@ def _build_renewing_line_items(context):
     return line_items
 
 
-def _get_committed_flex_discount_codes(preview_line_item):
-    """
-    Extract the flex discount code to commit from a PREVIEW_RENEWAL response line item.
+def _get_requested_flex_discount_codes(context):
+    """Map each renewing subscription of the plan to the codes explicitly selected for it."""
+    return {
+        plan["subscription_id"]: plan["flex_discount_codes"]
+        for plan in context.renewal_plan_subscriptions
+        if plan["renew"]
+    }
 
-    Adobe accepts at most one flexible discount code per line item (it rejects
-    more with error 2147), so instead of blindly taking the first element the
-    discounts the preview did not apply successfully are dropped and only one
-    surviving code is submitted, logging what is being discarded.
+
+def _get_committed_flex_discount_codes(preview_line_item, requested_codes):
+    """
+    Pick the flex discount code to commit for a PREVIEW_RENEWAL response line item.
+
+    Only a code the plan explicitly selected for the line is committed, and
+    only once the preview confirmed it (result SUCCESS). Reusable discounts
+    the customer already holds are auto-applied by Adobe at renewal without
+    any opt-in: the preview reports them alongside the requested ones, but
+    they are never echoed back, so the commit does not double-apply them and
+    an explicitly selected code takes precedence over them. Adobe accepts at
+    most one code per line (it rejects more with error 2147), so a single
+    surviving code is submitted.
     """
     flex_discounts = preview_line_item.get("flexDiscounts") or []
+    line_number = preview_line_item.get("extLineItemNumber")
     successful = (fd for fd in flex_discounts if fd.get("result", "SUCCESS") == "SUCCESS")
-    codes = [fd["code"] for fd in successful]
-    discarded = [fd["code"] for fd in flex_discounts if fd["code"] not in codes]
-    if discarded:
+    confirmed = {fd["code"] for fd in successful}
+    committed = [code for code in requested_codes if code in confirmed]
+    dropped = [code for code in requested_codes if code not in confirmed]
+    if dropped:
         logger.warning(
             "Dropping flex discount code(s) not applied successfully by the renewal "
             "preview for line %s: %s",
-            preview_line_item.get("extLineItemNumber"),
-            ", ".join(discarded),
+            line_number,
+            ", ".join(dropped),
         )
-    if len(codes) > 1:
+    auto_applied = sorted(confirmed.difference(requested_codes))
+    if auto_applied:
+        logger.info(
+            "Leaving the discount(s) auto-applied by Adobe for line %s out of the renewal "
+            "order, they apply without opt-in: %s",
+            line_number,
+            ", ".join(auto_applied),
+        )
+    if len(committed) > 1:
         logger.warning(
-            "Renewal preview returned %s flex discounts for line %s, submitting only "
+            "Renewal plan selected %s flex discounts for line %s, submitting only "
             "the first one (%s) to honour Adobe's one-code-per-line rule",
-            len(codes),
-            preview_line_item.get("extLineItemNumber"),
-            codes[0],
+            len(committed),
+            line_number,
+            committed[0],
         )
-    return codes[:1]
+    return committed[:1]
 
 
-def _build_committed_line_items(preview_line_items):
+def _build_committed_line_items(preview_line_items, requested_codes_by_subscription):
     """
     Build RENEWAL order line items from a PREVIEW_RENEWAL response's line items.
 
@@ -152,7 +189,10 @@ def _build_committed_line_items(preview_line_items):
     response-shaped (e.g. flexDiscounts is a list of discount result
     objects, not the flexDiscountCodes the create-order request expects) and
     carries pricing fields the create-order request doesn't need, so it is
-    re-shaped into a request line item rather than forwarded as-is.
+    re-shaped into a request line item rather than forwarded as-is. The
+    flex discount codes come from the plan's explicit selection per
+    subscription, confirmed by the preview (see
+    _get_committed_flex_discount_codes).
     """
     line_items = []
     for preview_line_item in preview_line_items:
@@ -162,7 +202,10 @@ def _build_committed_line_items(preview_line_items):
             "subscriptionId": preview_line_item["subscriptionId"],
             "quantity": preview_line_item["quantity"],
         }
-        flex_discount_codes = _get_committed_flex_discount_codes(preview_line_item)
+        requested_codes = requested_codes_by_subscription.get(preview_line_item["subscriptionId"])
+        flex_discount_codes = _get_committed_flex_discount_codes(
+            preview_line_item, requested_codes or []
+        )
         if flex_discount_codes:
             line_item["flexDiscountCodes"] = flex_discount_codes
         if preview_line_item.get("deploymentId"):
@@ -273,7 +316,10 @@ class SubmitRenewalNowOrder(Step):
                 context.authorization_id,
                 context.adobe_customer_id,
                 context.order_id,
-                _build_committed_line_items(context.preview_renewal_order["lineItems"]),
+                _build_committed_line_items(
+                    context.preview_renewal_order["lineItems"],
+                    _get_requested_flex_discount_codes(context),
+                ),
                 recommendation_tracker_id=(
                     context.renewal_payload.get("recommendationTrackerId") or None
                 ),
@@ -323,28 +369,41 @@ class SubmitRenewalNowOrder(Step):
         )
 
 
-class ReturnPreviousRenewalOrders(Step):
+def _get_creation_date(order):
+    creation_date = dt.datetime.fromisoformat(order["creationDate"])
+    return creation_date.replace(tzinfo=dt.UTC).date()
+
+
+def _is_within_return_window(order):
+    """Return True when the Adobe order was placed within the return window (inclusive)."""
+    today = dt.datetime.now(tz=dt.UTC).date()
+    window_start = today - dt.timedelta(days=CANCELLATION_WINDOW_DAYS)
+    return _get_creation_date(order) >= window_start
+
+
+class ResolvePreviousRenewalReturns(Step):
     """
-    Return the previous RENEWAL order lines of the plan's lapsing subscriptions.
+    Resolve, before anything is committed, the previous RENEWAL order lines to return.
 
     A lapsing subscription (renew = false) whose pre-mutation snapshot
-    (taken by SetupRenewalPlan, before this order commits anything) carries
-    a renewedQuantity was already committed in a previous RENEWAL order
-    placed within the renewal window. Disabling its auto-renewal is not
-    enough — the already-paid renewal must be undone, so this step submits
-    a RETURN order referencing that previous RENEWAL order, returning only
-    the lapsing subscription's line (other lines of that order stay
-    renewed). Runs after SubmitRenewalNowOrder so the additive operation
-    always precedes the subtractive one.
-
-    Idempotent: RETURN orders created by this MPT order are detected by
-    their external reference prefix and reused instead of re-submitted. A
-    RETURN order still pending on Adobe's side keeps the MPT order in
-    Processing to be retried on the next fulfillment attempt.
+    (taken by SetupRenewalPlan) carries a renewedQuantity was already
+    committed in a previous RENEWAL order, so ReturnPreviousRenewalOrders
+    has to return that order's line once this order's RENEWAL commits.
+    Adobe only accepts a RETURN within CANCELLATION_WINDOW_DAYS of the order
+    placement, so the previous order is located here and its creation date
+    checked against the window while nothing has been committed yet: a line
+    outside the window, or a previous order that cannot be found, fails the
+    MPT order with nothing to reverse instead of leaving a committed and
+    invoiced RENEWAL behind a Failed order. A RETURN already created by a
+    previous attempt of this MPT order (detected by its external reference
+    prefix) is reused as-is, whatever the window says today, so retries stay
+    idempotent. The resolved candidates are stored on the context for
+    ReturnPreviousRenewalOrders.
     """
 
     def __call__(self, client, context, next_step):
-        """Return the previous RENEWAL order lines of the plan's lapsing subscriptions."""
+        """Resolve the previous RENEWAL order lines of the plan's lapsing subscriptions."""
+        context.renewal_return_candidates = []
         lapsing_renewed = [
             plan
             for plan in context.renewal_plan_subscriptions
@@ -355,25 +414,25 @@ class ReturnPreviousRenewalOrders(Step):
             return
 
         adobe_client = get_adobe_client()
-        renewal_orders = self._get_completed_renewal_orders(adobe_client, context)
         existing_return_orders = adobe_client.get_return_orders_by_external_reference(
             context.authorization_id,
             context.adobe_customer_id,
             context.order_id,
         )
-
-        return_orders = []
+        renewal_orders = self._get_completed_renewal_orders(adobe_client, context)
         for plan in lapsing_renewed:
-            return_order = self._return_previous_renewal(
-                client, adobe_client, context, plan, renewal_orders, existing_return_orders
+            candidate = self._resolve_candidate(
+                client, context, plan, renewal_orders, existing_return_orders
             )
-            if return_order is None:
+            if candidate is None:
                 return
-            return_orders.append(return_order)
+            context.renewal_return_candidates.append(candidate)
 
-        if not self._ensure_not_pending_return_orders(context, return_orders):
-            return
-
+        logger.info(
+            "%s: %s previous renewal line(s) resolved for return",
+            context,
+            len(context.renewal_return_candidates),
+        )
         next_step(client, context)
 
     def _get_completed_renewal_orders(self, adobe_client, context):
@@ -387,10 +446,16 @@ class ReturnPreviousRenewalOrders(Step):
         )
         return sorted(orders, key=itemgetter("creationDate"), reverse=True)
 
-    def _return_previous_renewal(  # noqa: WPS211
-        self, client, adobe_client, context, plan, renewal_orders, existing_return_orders
+    def _resolve_candidate(  # noqa: WPS211
+        self, client, context, plan, renewal_orders, existing_return_orders
     ):
         subscription_id = plan["subscription_id"]
+        candidate = {
+            "subscription_id": subscription_id,
+            "return_order": None,
+            "returning_order": None,
+            "returning_line": None,
+        }
         existing_returns = existing_return_orders.get(get_partial_sku(plan["offer_id"]))
         if existing_returns:
             logger.info(
@@ -399,7 +464,7 @@ class ReturnPreviousRenewalOrders(Step):
                 existing_returns[0]["orderId"],
                 subscription_id,
             )
-            return existing_returns[0]
+            return {**candidate, "return_order": existing_returns[0]}
 
         returning_order, returning_line = self._find_previous_renewal_line(
             context, renewal_orders, subscription_id
@@ -420,9 +485,34 @@ class ReturnPreviousRenewalOrders(Step):
             )
             return None
 
-        return self._create_return_order(
-            client, adobe_client, context, subscription_id, returning_order, returning_line
-        )
+        if not _is_within_return_window(returning_order):
+            creation_date = _get_creation_date(returning_order).isoformat()
+            logger.warning(
+                "%s: previous renewal order %s for subscription %s was placed on %s, "
+                "outside the %s-day return window",
+                context,
+                returning_order["orderId"],
+                subscription_id,
+                creation_date,
+                CANCELLATION_WINDOW_DAYS,
+            )
+            switch_order_to_failed(
+                client,
+                context.order,
+                ERR_RENEWAL_RETURN_WINDOW_CLOSED.to_dict(
+                    order_id=returning_order["orderId"],
+                    subscription_id=subscription_id,
+                    creation_date=creation_date,
+                    window_days=CANCELLATION_WINDOW_DAYS,
+                ),
+            )
+            return None
+
+        return {
+            **candidate,
+            "returning_order": returning_order,
+            "returning_line": returning_line,
+        }
 
     def _find_previous_renewal_line(self, context, renewal_orders, subscription_id):
         for order in renewal_orders:
@@ -433,9 +523,50 @@ class ReturnPreviousRenewalOrders(Step):
                     return order, line_item
         return None, None
 
-    def _create_return_order(  # noqa: WPS211
-        self, client, adobe_client, context, subscription_id, returning_order, returning_line
-    ):
+
+class ReturnPreviousRenewalOrders(Step):
+    """
+    Return the previous RENEWAL order lines resolved by ResolvePreviousRenewalReturns.
+
+    Each candidate is a lapsing subscription (renew = false) already
+    committed in a previous RENEWAL order placed within the return window.
+    Disabling its auto-renewal is not enough — the already-paid renewal must
+    be undone, so this step submits a RETURN order referencing that previous
+    RENEWAL order, returning only the lapsing subscription's line (other
+    lines of that order stay renewed). Runs after SubmitRenewalNowOrder so
+    the additive operation always precedes the subtractive one.
+
+    Idempotent: a RETURN order already created by this MPT order is carried
+    by the candidate and reused instead of re-submitted. A RETURN order
+    still pending on Adobe's side keeps the MPT order in Processing to be
+    retried on the next fulfillment attempt.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Return the previous RENEWAL order lines of the plan's lapsing subscriptions."""
+        if not context.renewal_return_candidates:
+            next_step(client, context)
+            return
+
+        adobe_client = get_adobe_client()
+        return_orders = []
+        for candidate in context.renewal_return_candidates:
+            return_order = candidate["return_order"] or self._create_return_order(
+                client, adobe_client, context, candidate
+            )
+            if return_order is None:
+                return
+            return_orders.append(return_order)
+
+        if not self._ensure_not_pending_return_orders(context, return_orders):
+            return
+
+        next_step(client, context)
+
+    def _create_return_order(self, client, adobe_client, context, candidate):
+        subscription_id = candidate["subscription_id"]
+        returning_order = candidate["returning_order"]
+        returning_line = candidate["returning_line"]
         try:
             return_order = adobe_client.create_return_order(
                 context.authorization_id,
@@ -645,8 +776,10 @@ def fulfill_renewal_now_order(client, order):
 
     The plan's renewing subscriptions are validated with a PREVIEW_RENEWAL
     and committed as an actual Adobe RENEWAL order, invoiced immediately.
-    Once it completes, lapsing subscriptions that were already committed in
-    a previous RENEWAL order have that order's line returned, the renewed
+    Before that, the previous RENEWAL order lines of the lapsing
+    subscriptions already committed are resolved and checked against the
+    return window, so nothing is committed that cannot be undone. Once it
+    completes, those lines are returned, the renewed
     subscriptions (renew = true) have their autoRenewal normalised and the
     plan's lapsing subscriptions (renew = false) have their auto-renewal
     disabled.
@@ -668,6 +801,8 @@ def fulfill_renewal_now_order(client, order):
         UpdateAgreementParamsVisibility(),
         ValidateRenewalWindow(),
         SetupRenewalPlan(),
+        Validate3YCRenewalFloor(include_net_new_items=False),
+        ResolvePreviousRenewalReturns(),
         PreviewRenewalNowOrder(),
         SubmitRenewalNowOrder(),
         ReturnPreviousRenewalOrders(),

--- a/adobe_vipm/flows/helpers.py
+++ b/adobe_vipm/flows/helpers.py
@@ -57,6 +57,7 @@ from adobe_vipm.flows.utils import (
     get_ordering_parameter,
     get_price_item_by_line_sku,
     get_retry_count,
+    is_3yc_commitment_ending_before_coterm,
     reset_order_error,
     reset_ordering_parameters_error,
     set_customer_data,
@@ -333,28 +334,7 @@ class Validate3YCCommitment(Step):
         return False
 
     def _validate_3yc_commitment_date_before_coterm_date(self, context, commitment):
-        if not context.adobe_customer["cotermDate"]:
-            return False
-
-        threeyc_end_date = (
-            dt.datetime
-            .strptime(
-                commitment["endDate"],
-                "%Y-%m-%d",
-            )
-            .replace(tzinfo=dt.UTC)
-            .date()
-        )
-        coterm_date = (
-            dt.datetime
-            .strptime(
-                context.adobe_customer["cotermDate"],
-                "%Y-%m-%d",
-            )
-            .replace(tzinfo=dt.UTC)
-            .date()
-        )
-        return threeyc_end_date < coterm_date
+        return is_3yc_commitment_ending_before_coterm(context.adobe_customer, commitment)
 
     def get_quantities(self, context, subscriptions) -> tuple[float, float]:
         """Calculates licensees and consumables quantities of subscriptions."""

--- a/adobe_vipm/flows/utils/__init__.py
+++ b/adobe_vipm/flows/utils/__init__.py
@@ -92,6 +92,7 @@ from .subscription import (
 )
 from .three_yc import (
     get_3yc_fulfillment_parameters,
+    is_3yc_commitment_ending_before_coterm,
     set_adobe_3yc_commitment_request_status,
     set_adobe_3yc_end_date,
     set_adobe_3yc_enroll_status,

--- a/adobe_vipm/flows/utils/three_yc.py
+++ b/adobe_vipm/flows/utils/three_yc.py
@@ -1,4 +1,5 @@
 import copy
+import datetime as dt
 
 from adobe_vipm.flows.constants import Param
 from adobe_vipm.flows.utils.parameter import get_fulfillment_parameter, get_ordering_parameter
@@ -129,3 +130,24 @@ def get_3yc_fulfillment_parameters(order_or_agreement: dict) -> list[str]:
         get_fulfillment_parameter(order_or_agreement, param_external_id)
         for param_external_id in three_yc_fulfillment_parameters
     ]
+
+
+def is_3yc_commitment_ending_before_coterm(adobe_customer: dict, commitment: dict) -> bool:
+    """
+    Check whether the 3YC commitment ends before the customer's coterm date.
+
+    A commitment that expires before the next anniversary no longer binds the
+    quantities renewing at that anniversary, so its committed minimum is not
+    enforced. Without a coterm date the check is not applicable.
+
+    Args:
+        adobe_customer: Adobe customer.
+        commitment: 3YC commitment (or commitment request) object.
+
+    Returns:
+        True when the commitment end date is strictly before the coterm date.
+    """
+    coterm_date = adobe_customer.get("cotermDate")
+    if not coterm_date:
+        return False
+    return dt.date.fromisoformat(commitment["endDate"]) < dt.date.fromisoformat(coterm_date)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,9 +32,13 @@ extension (`pyproject.toml` `[project.entry-points."swo.mpt.ext"]` ->
    order type to `purchase.py`, `change.py`, `transfer.py`, `reseller_transfer.py`,
    `termination.py`, and `configuration.py`; change orders carrying a
    `switchPayload` or `renewalPayload` ordering parameter are routed to
-   `switch.py` (mid-term upgrades) and `renewal.py` (at-anniversary renewals);
-   `shared.py` holds common utilities and the flexible-discount-code-per-line
-   validation used by switch/renewal fulfillment.
+   `switch.py` (mid-term upgrades), `renewal.py` (at-anniversary renewals) and
+   `renewal_now.py` (renew-now renewals, `renewalPath: "now"`, documented in
+   [renew-now.md](renew-now.md)); `renewal.py` also hosts the 3YC
+   committed-minimum floor guard (`Validate3YCRenewalFloor`)
+   that both renewal flows run before mutating Adobe; `shared.py` holds common
+   utilities and the flexible-discount-code-per-line validation used by
+   switch/renewal fulfillment.
 3. **Validation** (`flows/validation/`) — `validate_order()` in `base.py` routes to
    per-type validators (`purchase.py`, `change.py`, `transfer.py`, `termination.py`).
 4. **Sync** (`flows/sync/`) — Adobe-to-MPT synchronisation for `agreement.py`,
@@ -94,4 +98,6 @@ started via `swoext run`. See [deployment.md](deployment.md) for configuration.
 - [testing.md](testing.md) — test strategy and execution
 - [deployment.md](deployment.md) — configuration and deployment model
 - [external-integrations.md](external-integrations.md) — external systems
+- [renew-now.md](renew-now.md) — renew-now fulfilment flow: return window and
+  committed flex discount codes
 - [migrations.md](migrations.md) — migration workflow

--- a/docs/renew-now.md
+++ b/docs/renew-now.md
@@ -1,0 +1,77 @@
+# Renew-now renewals
+
+This document describes the renew-now fulfilment flow
+(`adobe_vipm/flows/fulfillment/renewal_now.py`). It covers change orders that
+carry a `renewalPayload` ordering parameter with `renewalPath: "now"`. For the
+at-anniversary path see `renewal.py`. For the surrounding layers and routing see
+[architecture.md](architecture.md).
+
+## Flow summary
+
+The resulting renewing aggregate of the plan is first validated against the 3YC
+committed minimum, then the renewing subscriptions are validated with an Adobe
+`PREVIEW_RENEWAL` order and committed as an actual Adobe `RENEWAL` order,
+invoiced immediately. After the commit, previous renewal lines are returned,
+renewed subscriptions have their auto-renewal normalised, lapsing subscriptions
+have their auto-renewal disabled, and the redeemed flex discount codes are
+recorded on the AirTable redemptions table.
+
+## 3YC committed minimum floor (VIPM0034)
+
+`Validate3YCRenewalFloor(include_net_new_items=False)`, shared with the
+at-anniversary flow, runs **before** return resolution and before any Adobe
+preview or commit operation. It projects the plan onto the customer's Adobe
+subscriptions snapshotted by `SetupRenewalPlan` and validates the resulting
+licenses and consumables aggregate with the same 3YC guard used by the other
+order types. Net-new items are excluded here because this flow does not create
+them.
+
+The floor is enforced only for a 3YC renewal, that is a customer with a
+`COMMITTED`/`ACTIVE` commitment that does not end before the coterm date;
+otherwise the step is a no-op. A breach fails the MPT order with
+`ERR_COMMITMENT_3YC_VALIDATION` (`VIPM0034`) and processing stops before any
+mutation has been made in Adobe, so there is nothing to reverse.
+
+## 14-day return window (VIPM0053)
+
+A lapsing subscription (`renew = false`) whose pre-mutation snapshot carries a
+`renewedQuantity` was already committed in a previous `RENEWAL` order. That
+order's line has to be returned, so the customer is not left paying for a
+renewal that is being toggled off.
+
+Adobe only accepts a `RETURN` within `CANCELLATION_WINDOW_DAYS` (14 days) of the
+original order placement. The `ResolvePreviousRenewalReturns` step therefore
+locates the previous renewal line and checks its creation date against that
+window **before anything is committed**. Two outcomes fail the MPT order at that
+point, while nothing has been mutated in Adobe:
+
+- the previous renewal order cannot be found, which fails with
+  `ERR_RENEWAL_RETURN_FAILED` (`VIPM0050`);
+- the previous renewal order was placed outside the 14-day window, which fails
+  with `ERR_RENEWAL_RETURN_WINDOW_CLOSED` (`VIPM0053`).
+
+Failing up front is deliberate. Committing the new `RENEWAL` first and only then
+discovering that the old one cannot be returned would leave a committed and
+invoiced Adobe order behind a Failed MPT order, with no way to reverse it.
+
+A `RETURN` order created by an earlier attempt of the same MPT order is detected
+by its external reference prefix and reused as-is, whatever the window says
+today, so retries stay idempotent.
+
+## Flex discount codes committed
+
+Only a discount code that the renewal plan **explicitly selected** for a line,
+and that the `PREVIEW_RENEWAL` response then **confirmed** with result
+`SUCCESS`, is submitted on the real `RENEWAL` order.
+
+- Requested codes the preview did not apply successfully are dropped and logged.
+- Reusable discounts the customer already holds are auto-applied by Adobe at
+  renewal without any opt-in. The preview reports them alongside the requested
+  ones, but they are never echoed back on the commit, so they are not
+  double-applied. An explicitly selected code takes precedence over them.
+- Adobe accepts at most one code per line and rejects more with error `2147`, so
+  a single surviving code is submitted per line.
+
+## Known limitations
+
+Net-new items are not handled by this flow yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ per-file-ignores = [
   "adobe_vipm/flows/fulfillment/configuration.py: WPS229 WPS338 WPS235",
   "adobe_vipm/flows/fulfillment/purchase.py: WPS110 WPS114 WPS203 WPS204 WPS229 WPS231 WPS235 WPS338",
   "adobe_vipm/flows/fulfillment/shared.py: WPS110 WPS201 WPS202 WPS203 WPS204 WPS210 WPS213 WPS214 WPS220 WPS221 WPS229 WPS231 WPS235 WPS237 WPS336 WPS426 WPS441 WPS504",
-  "adobe_vipm/flows/fulfillment/renewal.py: WPS202 WPS235",
+  "adobe_vipm/flows/fulfillment/renewal.py: WPS202 WPS204 WPS235",
   "adobe_vipm/flows/fulfillment/renewal_now.py: WPS202 WPS204 WPS210 WPS235",
   "adobe_vipm/flows/fulfillment/switch.py: WPS235",
   "adobe_vipm/flows/fulfillment/termination.py: WPS210 WPS220 WPS229 WPS231 WPS235",

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -7,6 +7,7 @@ from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW_RENEWAL,
     AdobeErrorCode,
     AdobeSubscriptionStatus,
+    ThreeYearCommitmentStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import TEMPLATE_NAME_CHANGE, Param
@@ -19,6 +20,7 @@ from adobe_vipm.flows.fulfillment.renewal import (
     RecordFlexDiscounts,
     SetupRenewalPlan,
     UpdateRenewalSubscriptions,
+    Validate3YCRenewalFloor,
     fulfill_renewal_order,
 )
 from adobe_vipm.flows.fulfillment.shared import (
@@ -586,6 +588,13 @@ def test_update_renewal_subscriptions_step_skips_operations_already_in_place(
 ):
     renewal_context.renewal_plan_subscriptions = [
         plan_entry(renewal_quantity=10, snapshot_quantity=10),
+        # No explicit code selected: the inherited code Adobe holds stays as it is.
+        plan_entry(
+            subscription_id="inherited-sub-id",
+            renewal_quantity=10,
+            snapshot_quantity=10,
+            snapshot_codes=["INHERITED"],
+        ),
         plan_entry(
             subscription_id="lapsed-sub-id",
             renew=False,
@@ -599,6 +608,56 @@ def test_update_renewal_subscriptions_step_skips_operations_already_in_place(
     step(mock_mpt_client, renewal_context, mocked_next_step)  # act
 
     mock_adobe_client.update_subscription.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_update_renewal_subscriptions_step_explicit_code_replaces_inherited_code(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(
+            renewal_quantity=10,
+            snapshot_quantity=10,
+            flex_discount_codes=["CODE-1"],
+            snapshot_codes=["INHERITED"],
+        ),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = UpdateRenewalSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        "authorization-id",
+        "customer-id",
+        "renewing-sub-id",
+        auto_renewal=True,
+        quantity=10,
+        flex_discount_codes=["CODE-1"],
+    )
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_update_renewal_subscriptions_step_keeps_inherited_code_without_explicit_selection(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(renewal_quantity=15, snapshot_quantity=10, snapshot_codes=["INHERITED"]),
+    ]
+    mocked_next_step = mocker.MagicMock()
+    step = UpdateRenewalSubscriptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    # flex_discount_codes=None leaves the inherited code untouched on Adobe's side.
+    mock_adobe_client.update_subscription.assert_called_once_with(
+        "authorization-id",
+        "customer-id",
+        "renewing-sub-id",
+        auto_renewal=True,
+        quantity=15,
+        flex_discount_codes=None,
+    )
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
 
 
@@ -861,6 +920,69 @@ def test_record_discount_redemptions_step(mocker, mock_mpt_client, renewal_conte
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
 
 
+@freeze_time("2026-08-12 10:00:00")
+def test_record_discount_redemptions_step_skips_inherited_codes(
+    mocker, mock_mpt_client, renewal_context
+):
+    renewal_context.renewal_plan_subscriptions = [
+        # Already held by the subscription before this order: auto-applied, not redeemed.
+        plan_entry(flex_discount_codes=["INHERITED"], snapshot_codes=["INHERITED"]),
+        plan_entry(
+            subscription_id="another-renewing-sub-id",
+            offer_id="65322651CA01A12",
+            flex_discount_codes=["CODE-2"],
+        ),
+        # The same code newly selected on a subscription that did not hold it: redeemed.
+        plan_entry(
+            subscription_id="third-renewing-sub-id",
+            offer_id="65322651CA01A12",
+            flex_discount_codes=["INHERITED"],
+        ),
+    ]
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    redeemed_at = dt.datetime(2026, 8, 12, 10, 0, tzinfo=dt.UTC)
+    mocked_create_redemptions.assert_called_once_with([
+        {
+            "code": "CODE-2",
+            "customer_id": "customer-id",
+            "order_id": renewal_context.order_id,
+            "redeemed_at": redeemed_at,
+        },
+        {
+            "code": "INHERITED",
+            "customer_id": "customer-id",
+            "order_id": renewal_context.order_id,
+            "redeemed_at": redeemed_at,
+        },
+    ])
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_record_discount_redemptions_step_only_inherited_codes(
+    mocker, mock_mpt_client, renewal_context
+):
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["INHERITED"], snapshot_codes=["INHERITED"]),
+    ]
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mocked_create_redemptions.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
 def test_record_discount_redemptions_step_without_codes(mocker, mock_mpt_client, renewal_context):
     renewal_context.renewal_plan_subscriptions = [plan_entry()]
     mocked_create_redemptions = mocker.patch(
@@ -921,6 +1043,7 @@ def test_fulfill_renewal_order(mocker):
         UpdateAgreementParamsVisibility,
         ValidateRenewalWindow,
         SetupRenewalPlan,
+        Validate3YCRenewalFloor,
         CreateNetNewSubscriptions,
         UpdateRenewalSubscriptions,
         CreateNetNewMptSubscriptions,
@@ -935,6 +1058,358 @@ def test_fulfill_renewal_order(mocker):
     actual_steps = [type(step) for step in pipeline_args]
     assert actual_steps == expected_steps
     assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
-    assert pipeline_args[12].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[8].include_net_new_items is True
+    assert pipeline_args[13].template_name == TEMPLATE_NAME_CHANGE
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)
+
+
+@pytest.fixture
+def floor_context(
+    mocker,
+    renewal_context,
+    renewal_payload,
+    adobe_subscription_factory,
+    mock_get_sku_adobe_mapping_model,
+):
+    """
+    Renewal context ready for the 3YC floor guard.
+
+    Adobe subscriptions: a renewing license (10 -> 15 per the plan), a lapsing
+    consumable (10 -> stops renewing) and a license outside the plan renewing
+    3. Projected aggregate: 18 licenses, 0 consumables.
+    """
+    mocker.patch(
+        "adobe_vipm.flows.helpers.get_adobe_product_by_marketplace_sku",
+        side_effect=mock_get_sku_adobe_mapping_model.from_id,
+    )
+    renewal_context.market_segment = "COM"
+    renewal_context.renewal_payload = {**renewal_payload, "netNewItems": []}
+    renewal_context.adobe_customer_subscriptions = [
+        adobe_subscription_factory(
+            subscription_id="renewing-sub-id", offer_id="65304578CA01A12", renewal_quantity=10
+        ),
+        adobe_subscription_factory(
+            subscription_id="lapsing-sub-id", offer_id="77777777CA01A12", renewal_quantity=10
+        ),
+        adobe_subscription_factory(
+            subscription_id="other-sub-id", offer_id="65304578CA01A12", renewal_quantity=3
+        ),
+    ]
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(renewal_quantity=15),
+        plan_entry(
+            subscription_id="lapsing-sub-id",
+            offer_id="77777777CA01A12",
+            renew=False,
+            renewal_quantity=0,
+        ),
+    ]
+    return renewal_context
+
+
+def set_3yc_customer(
+    context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    *,
+    licenses=None,
+    consumables=None,
+    status=ThreeYearCommitmentStatus.COMMITTED.value,
+    end_date="2027-06-01",
+    coterm_date="2026-12-01",
+):
+    commitment = adobe_commitment_factory(
+        licenses=licenses, consumables=consumables, status=status, end_date=end_date
+    )
+    context.adobe_customer = adobe_customer_factory(commitment=commitment, coterm_date=coterm_date)
+
+
+def test_validate_3yc_renewal_floor_step_without_adobe_customer(
+    mocker, mock_mpt_client, floor_context
+):
+    floor_context.adobe_customer = None
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+def test_validate_3yc_renewal_floor_step_without_commitment(
+    mocker, mock_mpt_client, floor_context, adobe_customer_factory
+):
+    floor_context.adobe_customer = adobe_customer_factory(coterm_date="2026-12-01")
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ThreeYearCommitmentStatus.REQUESTED.value,
+        ThreeYearCommitmentStatus.ACCEPTED.value,
+        ThreeYearCommitmentStatus.EXPIRED.value,
+        ThreeYearCommitmentStatus.NONCOMPLIANT.value,
+        ThreeYearCommitmentStatus.DECLINED.value,
+    ],
+)
+def test_validate_3yc_renewal_floor_step_commitment_not_in_force(
+    mocker,
+    mock_mpt_client,
+    floor_context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    status,
+):
+    # The floor would be breached (18 licenses < 100) if the commitment were in force.
+    set_3yc_customer(
+        floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=100, status=status
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+def test_validate_3yc_renewal_floor_step_commitment_ending_before_coterm(
+    mocker, mock_mpt_client, floor_context, adobe_customer_factory, adobe_commitment_factory
+):
+    set_3yc_customer(
+        floor_context,
+        adobe_customer_factory,
+        adobe_commitment_factory,
+        licenses=100,
+        end_date="2026-11-30",
+        coterm_date="2026-12-01",
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [ThreeYearCommitmentStatus.COMMITTED.value, ThreeYearCommitmentStatus.ACTIVE.value],
+)
+def test_validate_3yc_renewal_floor_step_plan_respects_floor(
+    mocker,
+    mock_mpt_client,
+    floor_context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    status,
+):
+    # Exactly at the floor: 15 (renewing) + 3 (outside the plan) = 18 licenses.
+    set_3yc_customer(
+        floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=18, status=status
+    )
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+def test_validate_3yc_renewal_floor_step_lapsing_breaches_floor(
+    mocker, mock_mpt_client, floor_context, adobe_customer_factory, adobe_commitment_factory
+):
+    # The lapsing consumable stops renewing: 0 consumables < 5.
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, consumables=5)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    error = mocked_switch_to_failed.mock_calls[0].args[2]
+    # Consumables-only breaches reuse the downsize wording of the shared 3YC guard.
+    assert error["message"] == (
+        "The order has failed. The reduction in quantity would place the account below "
+        "the minimum commitment of 5 consumables for the three-year commitment."
+    )
+    mocked_next_step.assert_not_called()
+
+
+def test_validate_3yc_renewal_floor_step_decrease_breaches_floor(
+    mocker, mock_mpt_client, floor_context, adobe_customer_factory, adobe_commitment_factory
+):
+    # The plan decreases the renewing license from 25 to 15: 15 + 3 = 18 < 20.
+    floor_context.adobe_customer_subscriptions[0]["autoRenewal"]["renewalQuantity"] = 25
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=20)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    error = mocked_switch_to_failed.mock_calls[0].args[2]
+    assert error["message"] == (
+        "The quantity selected of 18 would place the account below the minimum "
+        "commitment of 20 licenses for the three-year commitment."
+    )
+    mocked_next_step.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("include_net_new_items", "expected_failure"),
+    [(True, False), (False, True)],
+)
+def test_validate_3yc_renewal_floor_step_net_new_items(
+    mocker,
+    mock_mpt_client,
+    floor_context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    include_net_new_items,
+    expected_failure,
+):
+    # 18 licenses + 2 net-new licenses reach the floor of 20 only when net-new items count.
+    floor_context.renewal_payload["netNewItems"] = [{"offerId": "65304578CA01A12", "quantity": 2}]
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=20)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor(include_net_new_items=include_net_new_items)
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    assert mocked_switch_to_failed.called is expected_failure
+    assert mocked_next_step.called is not expected_failure
+
+
+def test_validate_3yc_renewal_floor_step_net_new_reuses_scheduled_subscription(
+    mocker,
+    mock_mpt_client,
+    floor_context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    adobe_subscription_factory,
+):
+    # A scheduled subscription created by a previous attempt already holds the
+    # net-new offer: it is counted once (18 + 2 = 20 < 21), not twice.
+    floor_context.adobe_customer_subscriptions.append(
+        adobe_subscription_factory(
+            subscription_id="scheduled-sub-id",
+            offer_id="65304578CA01A12",
+            renewal_quantity=2,
+            status=AdobeSubscriptionStatus.SCHEDULED.value,
+        )
+    )
+    floor_context.renewal_payload["netNewItems"] = [{"offerId": "65304578CA01A12", "quantity": 2}]
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=21)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    error = mocked_switch_to_failed.mock_calls[0].args[2]
+    assert error["message"] == (
+        "The quantity selected of 20 would place the account below the minimum "
+        "commitment of 21 licenses for the three-year commitment."
+    )
+    mocked_next_step.assert_not_called()
+
+
+def test_validate_3yc_renewal_floor_step_already_renewed_entry_keeps_renewed_quantity(
+    mocker, mock_mpt_client, floor_context, adobe_customer_factory, adobe_commitment_factory
+):
+    # renew=true with no requested quantity and a renewedQuantity snapshot: the
+    # previous renewal order's 8 seats count (8 + 3 = 11 >= 11), not zero.
+    floor_context.renewal_plan_subscriptions[0] = {
+        **plan_entry(renewal_quantity=0),
+        "snapshot": {
+            "enabled": True,
+            "renewal_quantity": 10,
+            "flex_discount_codes": [],
+            "renewed_quantity": 8,
+        },
+    }
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=11)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, floor_context)
+
+
+def test_validate_3yc_renewal_floor_step_ignores_inactive_subscriptions(
+    mocker,
+    mock_mpt_client,
+    floor_context,
+    adobe_customer_factory,
+    adobe_commitment_factory,
+    adobe_subscription_factory,
+):
+    # An inactive subscription never renews, whatever its auto-renewal says.
+    floor_context.adobe_customer_subscriptions.append(
+        adobe_subscription_factory(
+            subscription_id="inactive-sub-id",
+            offer_id="65304578CA01A12",
+            renewal_quantity=100,
+            status=AdobeSubscriptionStatus.INACTIVE.value,
+        )
+    )
+    set_3yc_customer(floor_context, adobe_customer_factory, adobe_commitment_factory, licenses=20)
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = Validate3YCRenewalFloor()
+
+    step(mock_mpt_client, floor_context, mocked_next_step)  # act
+
+    mocked_switch_to_failed.assert_called_once()
+    error = mocked_switch_to_failed.mock_calls[0].args[2]
+    assert error["message"] == (
+        "The quantity selected of 18 would place the account below the minimum "
+        "commitment of 20 licenses for the three-year commitment."
+    )
+    mocked_next_step.assert_not_called()

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -4,6 +4,7 @@ import pytest
 from freezegun import freeze_time
 
 from adobe_vipm.adobe.constants import (
+    CANCELLATION_WINDOW_DAYS,
     ORDER_TYPE_PREVIEW_RENEWAL,
     ORDER_TYPE_RENEWAL,
     AdobeErrorCode,
@@ -12,11 +13,15 @@ from adobe_vipm.adobe.constants import (
 from adobe_vipm.adobe.errors import AdobeAPIError
 from adobe_vipm.flows.constants import TEMPLATE_NAME_CHANGE
 from adobe_vipm.flows.context import Context
-from adobe_vipm.flows.fulfillment.renewal import RecordDiscountRedemptions
+from adobe_vipm.flows.fulfillment.renewal import (
+    RecordDiscountRedemptions,
+    Validate3YCRenewalFloor,
+)
 from adobe_vipm.flows.fulfillment.renewal_now import (
     DisableLapsingSubscriptions,
     NormalizeRenewedSubscriptions,
     PreviewRenewalNowOrder,
+    ResolvePreviousRenewalReturns,
     ReturnPreviousRenewalOrders,
     SubmitRenewalNowOrder,
     fulfill_renewal_now_order,
@@ -417,9 +422,10 @@ def test_submit_renewal_now_order_step_commits_only_one_successful_flex_discount
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
 ):
     renewal_now_context.renewal_plan_subscriptions = [plan_entry(flex_discount_codes=["CODE-1"])]
-    # The preview can report discounts Adobe did not apply (result != SUCCESS) and,
-    # defensively, more than one entry: only one successful code may be committed
-    # (Adobe rejects more than one code per line with error 2147).
+    # The preview can report discounts Adobe did not apply (result != SUCCESS) and
+    # reusable discounts Adobe auto-applied on its own: only the code the plan
+    # explicitly selected, confirmed by the preview, is committed (Adobe rejects
+    # more than one code per line with error 2147).
     renewal_now_context.preview_renewal_order = adobe_order_factory(
         order_type="PREVIEW_RENEWAL",
         status=AdobeOrderStatus.COMPLETE.value,
@@ -460,6 +466,95 @@ def test_submit_renewal_now_order_step_commits_only_one_successful_flex_discount
             "flexDiscountCodes": ["CODE-1"],
         },
     ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@pytest.mark.parametrize(
+    ("requested_codes", "preview_flex_discounts", "expected_codes"),
+    [
+        pytest.param(
+            ["CODE-1"],
+            [{"code": "INHERITED", "result": "SUCCESS"}, {"code": "CODE-1", "result": "SUCCESS"}],
+            ["CODE-1"],
+            id="explicit-code-takes-precedence-over-auto-applied",
+        ),
+        pytest.param(
+            [],
+            [{"code": "INHERITED", "result": "SUCCESS"}],
+            None,
+            id="auto-applied-reusable-is-not-echoed-back",
+        ),
+        pytest.param(
+            ["CODE-1"],
+            [{"code": "CODE-1", "result": "FAILURE"}, {"code": "INHERITED", "result": "SUCCESS"}],
+            None,
+            id="rejected-explicit-code-is-dropped-without-falling-back",
+        ),
+        pytest.param(
+            ["CODE-1"],
+            [],
+            None,
+            id="explicit-code-missing-from-preview-is-dropped",
+        ),
+        # Defensive: SetupRenewalPlan already rejects plan entries with more than one
+        # code, but should two reach the commit only the first confirmed one is
+        # submitted, honouring Adobe's one-code-per-line rule.
+        pytest.param(
+            ["CODE-1", "CODE-2"],
+            [{"code": "CODE-1", "result": "SUCCESS"}, {"code": "CODE-2", "result": "SUCCESS"}],
+            ["CODE-1"],
+            id="only-one-explicit-code-is-submitted",
+        ),
+    ],
+)
+def test_submit_renewal_now_order_step_flex_discount_code_precedence(
+    mocker,
+    mock_adobe_client,
+    mock_mpt_client,
+    renewal_now_context,
+    adobe_order_factory,
+    requested_codes,
+    preview_flex_discounts,
+    expected_codes,
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=requested_codes)
+    ]
+    renewal_now_context.preview_renewal_order = adobe_order_factory(
+        order_type="PREVIEW_RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "subscriptionId": "renewing-sub-id",
+                "quantity": 15,
+                "flexDiscounts": preview_flex_discounts,
+            },
+        ],
+    )
+    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.create_renewal_order.return_value = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = SubmitRenewalNowOrder()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    expected_line_item = {
+        "extLineItemNumber": 1,
+        "offerId": "65304578CA01A12",
+        "subscriptionId": "renewing-sub-id",
+        "quantity": 15,
+    }
+    if expected_codes is not None:
+        expected_line_item["flexDiscountCodes"] = expected_codes
+    committed_line_items = mock_adobe_client.create_renewal_order.mock_calls[0].args[3]
+    assert committed_line_items == [expected_line_item]
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
 
@@ -834,7 +929,21 @@ def previous_renewal_order_factory(
     )
 
 
-def test_return_previous_renewal_orders_step_no_candidates(
+def return_candidate(
+    returning_order=None,
+    returning_line=None,
+    return_order=None,
+    subscription_id="lapsing-sub-id",
+):
+    return {
+        "subscription_id": subscription_id,
+        "return_order": return_order,
+        "returning_order": returning_order,
+        "returning_line": returning_line,
+    }
+
+
+def test_resolve_previous_renewal_returns_step_no_candidates(
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
 ):
     renewal_now_context.renewal_plan_subscriptions = [
@@ -844,12 +953,222 @@ def test_return_previous_renewal_orders_step_no_candidates(
         plan_entry(subscription_id="lapsing-sub-id", renew=False, renewal_quantity=0),
     ]
     mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.renewal_return_candidates == []
+    mock_adobe_client.get_orders.assert_not_called()
+    mock_adobe_client.get_return_orders_by_external_reference.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@freeze_time("2026-08-10 10:00:00")
+def test_resolve_previous_renewal_returns_step_resolves_line(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    previous_renewal = previous_renewal_order_factory(adobe_order_factory)
+    mock_adobe_client.get_orders.return_value = [previous_renewal]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_return_orders_by_external_reference.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        renewal_now_context.order_id,
+    )
+    mock_adobe_client.get_orders.assert_called_once_with(
+        renewal_now_context.authorization_id,
+        renewal_now_context.adobe_customer_id,
+        filters={
+            "order-type": ORDER_TYPE_RENEWAL,
+            "status": AdobeOrderStatus.COMPLETE,
+        },
+    )
+    assert renewal_now_context.renewal_return_candidates == [
+        return_candidate(
+            returning_order=previous_renewal,
+            returning_line=previous_renewal["lineItems"][0],
+        )
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@freeze_time("2026-09-30 10:00:00")
+def test_resolve_previous_renewal_returns_step_existing_return_reused(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    # The previous renewal order is outside the return window by now, but the
+    # RETURN was already created by a previous attempt of this order: reused as-is.
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [
+        previous_renewal_order_factory(adobe_order_factory)
+    ]
+    existing_return = adobe_order_factory(
+        order_type="RETURN",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RETURN-EXISTING",
+    )
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {
+        "77777777CA": [existing_return],
+    }
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.renewal_return_candidates == [
+        return_candidate(return_order=existing_return)
+    ]
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_resolve_previous_renewal_returns_step_previous_order_not_found(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = []
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.renewal_return_candidates == []
+    mocked_switch_to_failed.assert_called_once()
+    assert "lapsing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
+    mocked_next_step.assert_not_called()
+
+
+@freeze_time("2026-08-10 10:00:00")
+def test_resolve_previous_renewal_returns_step_picks_most_recent_order(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    older_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-OLDER",
+        external_id="ORD-OLDER",
+        creation_date="2026-07-30T10:00:00Z",
+    )
+    newer_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-NEWER",
+        external_id="ORD-NEWER",
+        creation_date="2026-08-01T10:00:00Z",
+    )
+    # The renewal order committed by this very MPT order never contains lapsing
+    # subscriptions, but it is excluded defensively even if it did.
+    own_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-OWN",
+        external_id=renewal_now_context.order_id,
+        creation_date="2026-08-09T10:00:00Z",
+    )
+    unrelated_renewal = previous_renewal_order_factory(
+        adobe_order_factory,
+        order_id="ADOBE-RENEWAL-UNRELATED",
+        external_id="ORD-UNRELATED",
+        creation_date="2026-08-05T10:00:00Z",
+        subscription_id="other-sub-id",
+    )
+    mock_adobe_client.get_orders.return_value = [
+        older_renewal,
+        own_renewal,
+        unrelated_renewal,
+        newer_renewal,
+    ]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.renewal_return_candidates == [
+        return_candidate(
+            returning_order=newer_renewal,
+            returning_line=newer_renewal["lineItems"][0],
+        )
+    ]
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@freeze_time("2026-08-15 23:00:00")
+def test_resolve_previous_renewal_returns_step_last_day_of_return_window(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    # Placed exactly CANCELLATION_WINDOW_DAYS ago: still returnable (inclusive window).
+    previous_renewal = previous_renewal_order_factory(
+        adobe_order_factory, creation_date="2026-08-01T10:00:00Z"
+    )
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [previous_renewal]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert CANCELLATION_WINDOW_DAYS == 14
+    assert len(renewal_now_context.renewal_return_candidates) == 1
+    mocked_switch_to_failed.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@freeze_time("2026-08-16 10:00:00")
+def test_resolve_previous_renewal_returns_step_outside_return_window(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    # Placed 15 days ago: Adobe would reject the RETURN, so the order fails
+    # before the RENEWAL is committed.
+    previous_renewal = previous_renewal_order_factory(
+        adobe_order_factory, creation_date="2026-08-01T10:00:00Z"
+    )
+    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
+    mock_adobe_client.get_orders.return_value = [previous_renewal]
+    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    mocked_switch_to_failed = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = ResolvePreviousRenewalReturns()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    assert renewal_now_context.renewal_return_candidates == []
+    mocked_switch_to_failed.assert_called_once()
+    error = mocked_switch_to_failed.mock_calls[0].args[2]
+    assert error["id"] == "VIPM0053"
+    assert error["message"] == (
+        "The previous renewal order ADOBE-RENEWAL-PREV of subscription lapsing-sub-id was "
+        "placed on 2026-08-01, outside the 14-day return window, so it cannot be returned."
+    )
+    mocked_next_step.assert_not_called()
+
+
+def test_return_previous_renewal_orders_step_no_candidates(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
+):
+    renewal_now_context.renewal_return_candidates = []
+    mocked_next_step = mocker.MagicMock()
     step = ReturnPreviousRenewalOrders()
 
     step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
 
-    mock_adobe_client.get_orders.assert_not_called()
-    mock_adobe_client.get_return_orders_by_external_reference.assert_not_called()
     mock_adobe_client.create_return_order.assert_not_called()
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
@@ -857,10 +1176,13 @@ def test_return_previous_renewal_orders_step_no_candidates(
 def test_return_previous_renewal_orders_step_creates_return(
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
 ):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
     previous_renewal = previous_renewal_order_factory(adobe_order_factory)
-    mock_adobe_client.get_orders.return_value = [previous_renewal]
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
+    renewal_now_context.renewal_return_candidates = [
+        return_candidate(
+            returning_order=previous_renewal,
+            returning_line=previous_renewal["lineItems"][0],
+        )
+    ]
     return_order = adobe_order_factory(
         order_type="RETURN",
         status=AdobeOrderStatus.COMPLETE.value,
@@ -874,19 +1196,6 @@ def test_return_previous_renewal_orders_step_creates_return(
 
     step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
 
-    mock_adobe_client.get_orders.assert_called_once_with(
-        renewal_now_context.authorization_id,
-        renewal_now_context.adobe_customer_id,
-        filters={
-            "order-type": ORDER_TYPE_RENEWAL,
-            "status": AdobeOrderStatus.COMPLETE,
-        },
-    )
-    mock_adobe_client.get_return_orders_by_external_reference.assert_called_once_with(
-        renewal_now_context.authorization_id,
-        renewal_now_context.adobe_customer_id,
-        renewal_now_context.order_id,
-    )
     mock_adobe_client.create_return_order.assert_called_once_with(
         renewal_now_context.authorization_id,
         renewal_now_context.adobe_customer_id,
@@ -906,18 +1215,12 @@ def test_return_previous_renewal_orders_step_creates_return(
 def test_return_previous_renewal_orders_step_existing_return_reused(
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
 ):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
-    mock_adobe_client.get_orders.return_value = [
-        previous_renewal_order_factory(adobe_order_factory)
-    ]
     existing_return = adobe_order_factory(
         order_type="RETURN",
         status=AdobeOrderStatus.COMPLETE.value,
         order_id="ADOBE-RETURN-EXISTING",
     )
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {
-        "77777777CA": [existing_return],
-    }
+    renewal_now_context.renewal_return_candidates = [return_candidate(return_order=existing_return)]
     mocked_next_step = mocker.MagicMock()
     step = ReturnPreviousRenewalOrders()
 
@@ -930,11 +1233,13 @@ def test_return_previous_renewal_orders_step_existing_return_reused(
 def test_return_previous_renewal_orders_step_pending_return(
     mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
 ):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
-    mock_adobe_client.get_orders.return_value = [
-        previous_renewal_order_factory(adobe_order_factory)
+    previous_renewal = previous_renewal_order_factory(adobe_order_factory)
+    renewal_now_context.renewal_return_candidates = [
+        return_candidate(
+            returning_order=previous_renewal,
+            returning_line=previous_renewal["lineItems"][0],
+        )
     ]
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
     mock_adobe_client.create_return_order.return_value = adobe_order_factory(
         order_type="RETURN",
         status=AdobeOrderStatus.OPEN.value,
@@ -953,26 +1258,6 @@ def test_return_previous_renewal_orders_step_pending_return(
     mocked_next_step.assert_not_called()
 
 
-def test_return_previous_renewal_orders_step_previous_order_not_found(
-    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context
-):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
-    mock_adobe_client.get_orders.return_value = []
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
-    mocked_switch_to_failed = mocker.patch(
-        "adobe_vipm.flows.fulfillment.renewal_now.switch_order_to_failed"
-    )
-    mocked_next_step = mocker.MagicMock()
-    step = ReturnPreviousRenewalOrders()
-
-    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
-
-    mock_adobe_client.create_return_order.assert_not_called()
-    mocked_switch_to_failed.assert_called_once()
-    assert "lapsing-sub-id" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
-    mocked_next_step.assert_not_called()
-
-
 def test_return_previous_renewal_orders_step_return_failed(
     mocker,
     mock_adobe_client,
@@ -981,11 +1266,13 @@ def test_return_previous_renewal_orders_step_return_failed(
     adobe_order_factory,
     adobe_api_error_factory,
 ):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
-    mock_adobe_client.get_orders.return_value = [
-        previous_renewal_order_factory(adobe_order_factory)
+    previous_renewal = previous_renewal_order_factory(adobe_order_factory)
+    renewal_now_context.renewal_return_candidates = [
+        return_candidate(
+            returning_order=previous_renewal,
+            returning_line=previous_renewal["lineItems"][0],
+        )
     ]
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
     mock_adobe_client.create_return_order.side_effect = AdobeAPIError(
         400, adobe_api_error_factory("9999", "cannot return")
     )
@@ -1000,66 +1287,6 @@ def test_return_previous_renewal_orders_step_return_failed(
     mocked_switch_to_failed.assert_called_once()
     assert "cannot return" in mocked_switch_to_failed.mock_calls[0].args[2]["message"]
     mocked_next_step.assert_not_called()
-
-
-def test_return_previous_renewal_orders_step_picks_most_recent_order(
-    mocker, mock_adobe_client, mock_mpt_client, renewal_now_context, adobe_order_factory
-):
-    renewal_now_context.renewal_plan_subscriptions = [lapsing_renewed_plan_entry()]
-    older_renewal = previous_renewal_order_factory(
-        adobe_order_factory,
-        order_id="ADOBE-RENEWAL-OLDER",
-        external_id="ORD-OLDER",
-        creation_date="2026-07-01T10:00:00Z",
-    )
-    newer_renewal = previous_renewal_order_factory(
-        adobe_order_factory,
-        order_id="ADOBE-RENEWAL-NEWER",
-        external_id="ORD-NEWER",
-        creation_date="2026-08-01T10:00:00Z",
-    )
-    # The renewal order committed by this very MPT order never contains lapsing
-    # subscriptions, but it is excluded defensively even if it did.
-    own_renewal = previous_renewal_order_factory(
-        adobe_order_factory,
-        order_id="ADOBE-RENEWAL-OWN",
-        external_id=renewal_now_context.order_id,
-        creation_date="2026-08-10T10:00:00Z",
-    )
-    unrelated_renewal = previous_renewal_order_factory(
-        adobe_order_factory,
-        order_id="ADOBE-RENEWAL-UNRELATED",
-        external_id="ORD-UNRELATED",
-        creation_date="2026-08-05T10:00:00Z",
-        subscription_id="other-sub-id",
-    )
-    mock_adobe_client.get_orders.return_value = [
-        older_renewal,
-        own_renewal,
-        unrelated_renewal,
-        newer_renewal,
-    ]
-    mock_adobe_client.get_return_orders_by_external_reference.return_value = {}
-    mock_adobe_client.create_return_order.return_value = adobe_order_factory(
-        order_type="RETURN",
-        status=AdobeOrderStatus.COMPLETE.value,
-        order_id="ADOBE-RETURN-001",
-    )
-    mocker.patch("adobe_vipm.flows.fulfillment.renewal_now.update_order")
-    mocked_next_step = mocker.MagicMock()
-    step = ReturnPreviousRenewalOrders()
-
-    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
-
-    mock_adobe_client.create_return_order.assert_called_once_with(
-        renewal_now_context.authorization_id,
-        renewal_now_context.adobe_customer_id,
-        newer_renewal,
-        newer_renewal["lineItems"][0],
-        renewal_now_context.order_id,
-        None,
-    )
-    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
 
 
 @freeze_time("2026-08-28 10:00:00")
@@ -1134,6 +1361,8 @@ def test_fulfill_renewal_now_order(mocker):
         UpdateAgreementParamsVisibility,
         ValidateRenewalWindow,
         SetupRenewalPlan,
+        Validate3YCRenewalFloor,
+        ResolvePreviousRenewalReturns,
         PreviewRenewalNowOrder,
         SubmitRenewalNowOrder,
         ReturnPreviousRenewalOrders,
@@ -1149,6 +1378,7 @@ def test_fulfill_renewal_now_order(mocker):
     actual_steps = [type(step) for step in pipeline_args]
     assert actual_steps == expected_steps
     assert pipeline_args[1].template_name == TEMPLATE_NAME_CHANGE
-    assert pipeline_args[13].template_name == TEMPLATE_NAME_CHANGE
+    assert pipeline_args[8].include_net_new_items is False
+    assert pipeline_args[15].template_name == TEMPLATE_NAME_CHANGE
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)

--- a/tests/flows/utils/test_three_yc.py
+++ b/tests/flows/utils/test_three_yc.py
@@ -1,0 +1,33 @@
+import pytest
+
+from adobe_vipm.flows.utils.three_yc import is_3yc_commitment_ending_before_coterm
+
+
+@pytest.mark.parametrize(
+    ("end_date", "coterm_date", "expected"),
+    [
+        ("2026-06-30", "2026-07-01", True),
+        ("2026-07-01", "2026-07-01", False),
+        ("2027-01-01", "2026-07-01", False),
+    ],
+)
+def test_is_3yc_commitment_ending_before_coterm(
+    adobe_customer_factory, adobe_commitment_factory, end_date, coterm_date, expected
+):
+    customer = adobe_customer_factory(coterm_date=coterm_date)
+    commitment = adobe_commitment_factory(end_date=end_date)
+
+    result = is_3yc_commitment_ending_before_coterm(customer, commitment)  # act
+
+    assert result is expected
+
+
+def test_is_3yc_commitment_ending_before_coterm_without_coterm_date(
+    adobe_customer_factory, adobe_commitment_factory
+):
+    customer = adobe_customer_factory(coterm_date=None)
+    commitment = adobe_commitment_factory(end_date="2020-01-01")
+
+    result = is_3yc_commitment_ending_before_coterm(customer, commitment)  # act
+
+    assert result is False


### PR DESCRIPTION
…… (#963)

…aram name, 14-day return window, reusable de-dupe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-24777](https://softwareone.atlassian.net/browse/MPT-24777)

- Enforce the 3YC committed-minimum floor during renewal fulfilment.
- Correct flex discount handling and redemption recording.
- Support inclusive 14-day renewal return windows.
- Reuse scheduled subscriptions and return orders during retries.
- Add shared 3YC date validation and update fulfilment documentation.
- Expand tests for renewal floors, returns, discounts, and 3YC date checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24777]:
https://softwareone.atlassian.net/browse/MPT-24777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MPT-24777]: https://softwareone.atlassian.net/browse/MPT-24777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MPT-24777]: https://softwareone.atlassian.net/browse/MPT-24777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ