### PR TITLE
[BACKPORT] MPT-24778 block native orders while an at-anniversary renewal is staged

### DIFF
--- a/adobe_vipm/flows/constants.py
+++ b/adobe_vipm/flows/constants.py
@@ -529,6 +529,13 @@ ERR_EARLY_RENEWAL_IN_PROGRESS = ValidationError(
     "renewal-affecting changes.",
 )
 
+ERR_RENEWAL_STAGED = ValidationError(
+    "VIPM0054",
+    "A renewal has been staged for this agreement, so Change, Configuration and "
+    "Termination orders are locked until it takes effect at the anniversary date. "
+    "Please re-open the renewal wizard to make renewal-affecting changes.",
+)
+
 ERR_FLEX_DISCOUNT_CODE_LIMIT = ValidationError(
     "VIPM0052",
     "Only one flexible discount code per line item is allowed: {error}.",

--- a/adobe_vipm/flows/validation/change.py
+++ b/adobe_vipm/flows/validation/change.py
@@ -29,6 +29,7 @@ from adobe_vipm.flows.validation.shared import (
     GetPreviewOrder,
     ValidateDuplicateLines,
     ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
 )
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,7 @@ def validate_change_order(client, order):
         SetOrUpdateCotermDate(),
         ValidateRenewalWindow(is_validation=True),
         ValidateNoEarlyRenewal(),
+        ValidateNoStagedRenewal(),
         ValidateSkuAvailability(is_validation=True),
         ValidateDownsizes(),
         Validate3YCCommitment(is_validation=True),

--- a/adobe_vipm/flows/validation/configuration.py
+++ b/adobe_vipm/flows/validation/configuration.py
@@ -3,7 +3,10 @@ import logging
 from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.helpers import SetupContext
 from adobe_vipm.flows.pipeline import Pipeline
-from adobe_vipm.flows.validation.shared import ValidateNoEarlyRenewal
+from adobe_vipm.flows.validation.shared import (
+    ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +16,7 @@ def validate_configuration_order(client, order):
     pipeline = Pipeline(
         SetupContext(),
         ValidateNoEarlyRenewal(),
+        ValidateNoStagedRenewal(),
     )
     context = Context(order=order)
     pipeline.run(client, context)

--- a/adobe_vipm/flows/validation/shared.py
+++ b/adobe_vipm/flows/validation/shared.py
@@ -3,7 +3,11 @@ import logging
 from collections import Counter
 
 from adobe_vipm.adobe.client import get_adobe_client
-from adobe_vipm.adobe.constants import ORDER_TYPE_RENEWAL, AdobeOrderStatus
+from adobe_vipm.adobe.constants import (
+    ORDER_TYPE_RENEWAL,
+    AdobeOrderStatus,
+    AdobeSubscriptionStatus,
+)
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeProductNotFoundError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
 from adobe_vipm.flows.constants import (
@@ -12,6 +16,7 @@ from adobe_vipm.flows.constants import (
     ERR_DUPLICATED_ITEMS,
     ERR_EARLY_RENEWAL_IN_PROGRESS,
     ERR_EXISTING_ITEMS,
+    ERR_RENEWAL_STAGED,
 )
 from adobe_vipm.flows.pipeline import Step
 from adobe_vipm.flows.utils import (
@@ -142,6 +147,77 @@ class ValidateNoEarlyRenewal(Step):
             return coterm_date.replace(year=coterm_date.year - 1)
         except ValueError:  # Feb 29 on a non-leap target year
             return coterm_date.replace(year=coterm_date.year - 1, day=LAST_DAY_OF_FEBRUARY_NON_LEAP)
+
+
+class ValidateNoStagedRenewal(Step):
+    """
+    Reject native orders while an at-anniversary renewal is staged for the agreement.
+
+    An at-anniversary ("renew at anniversary") renewal completes its MPT order
+    immediately but places no Adobe order: the plan is applied to Adobe as deferred
+    auto-renewal preferences that only take effect at the coterm date. It therefore
+    leaves no Adobe RENEWAL order for ``ValidateNoEarlyRenewal`` to detect, so a
+    native Change / Configuration / Termination order placed before the anniversary
+    would silently fork the staged renewal.
+
+    The staged state is instead derived live from the customer's Adobe subscriptions,
+    which carry the deferred effect: a net-new item staged for the renewal appears as
+    a SCHEDULED subscription, and a staged quantity increase appears as an existing
+    subscription whose ``autoRenewal.renewalQuantity`` exceeds its ``currentQuantity``.
+    Only staged upsizes and additions are treated as blocking: a staged downsize
+    (``renewalQuantity`` below ``currentQuantity``) is the ordinary renewal-reduction
+    mechanism and does not lock native orders. The divergence self-clears once the
+    renewal takes effect at the anniversary, lifting the block without any bookkeeping.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Reject the order when a renewal is staged and pending effect for the agreement."""
+        if self._is_staged_renewal_pending(context):
+            logger.info(
+                "%s: a renewal is staged and pending effect for the agreement",
+                context,
+            )
+            context.validation_succeeded = False
+            context.order = set_order_error(
+                context.order,
+                ERR_RENEWAL_STAGED.to_dict(),
+            )
+            return
+
+        next_step(client, context)
+
+    def _is_staged_renewal_pending(self, context):
+        if is_renewal_order(context.order):
+            return False
+
+        coterm_date = (context.adobe_customer or {}).get("cotermDate")
+        if not context.adobe_customer_id or not coterm_date:
+            return False
+
+        if dt.datetime.now(tz=dt.UTC).date() > dt.date.fromisoformat(coterm_date):
+            return False
+
+        return self._has_staged_renewal(context)
+
+    def _has_staged_renewal(self, context):
+        adobe_client = get_adobe_client()
+        subscriptions = adobe_client.get_subscriptions(
+            context.authorization_id,
+            context.adobe_customer_id,
+        )
+        for subscription in subscriptions.get("items", []):
+            if subscription.get("status") == AdobeSubscriptionStatus.SCHEDULED:
+                return True
+            auto_renewal = subscription.get("autoRenewal") or {}
+            renewal_quantity = auto_renewal.get("renewalQuantity")
+            current_quantity = subscription.get("currentQuantity")
+            if (
+                renewal_quantity is not None
+                and current_quantity is not None
+                and renewal_quantity > current_quantity
+            ):
+                return True
+        return False
 
 
 class GetPreviewOrder(Step):

--- a/adobe_vipm/flows/validation/termination.py
+++ b/adobe_vipm/flows/validation/termination.py
@@ -14,7 +14,11 @@ from adobe_vipm.flows.utils import (
     validate_subscription_and_returnable_orders,
 )
 from adobe_vipm.flows.utils.subscription import get_subscription_by_line_subs_id
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
+from adobe_vipm.flows.validation.shared import (
+    ValidateDuplicateLines,
+    ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +55,7 @@ def validate_termination_order(client, order):
         SetOrUpdateCotermDate(),
         ValidateRenewalWindow(is_validation=True),
         ValidateNoEarlyRenewal(),
+        ValidateNoStagedRenewal(),
         ValidateDownsizes(),
         Validate3YCCommitment(is_validation=True),
     )

--- a/tests/flows/validation/test_change.py
+++ b/tests/flows/validation/test_change.py
@@ -14,7 +14,11 @@ from adobe_vipm.flows.validation.change import (
     ValidateDownsizes,
     validate_change_order,
 )
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
+from adobe_vipm.flows.validation.shared import (
+    ValidateDuplicateLines,
+    ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
+)
 
 
 @freeze_time("2024-11-09 12:30:00")
@@ -283,19 +287,20 @@ def test_validate_change_order(mocker):
 
     validate_change_order(mocked_client, mocked_order)  # act
 
-    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 10
+    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 11
     expected_steps = [
         SetupContext,
         ValidateDuplicateLines,
         SetOrUpdateCotermDate,
         ValidateRenewalWindow,
         ValidateNoEarlyRenewal,
+        ValidateNoStagedRenewal,
         ValidateSkuAvailability,
         ValidateDownsizes,
         Validate3YCCommitment,
         GetPreviewOrder,
     ]
-    actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args[:9]]
+    actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args[:10]]
     assert actual_steps == expected_steps
     mocked_context_ctor.assert_called_once_with(order=mocked_order)
     mocked_pipeline_instance.run.assert_called_once_with(mocked_client, mocked_context)

--- a/tests/flows/validation/test_configuration.py
+++ b/tests/flows/validation/test_configuration.py
@@ -1,6 +1,9 @@
 from adobe_vipm.flows.helpers import SetupContext
 from adobe_vipm.flows.validation.configuration import validate_configuration_order
-from adobe_vipm.flows.validation.shared import ValidateNoEarlyRenewal
+from adobe_vipm.flows.validation.shared import (
+    ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
+)
 
 
 def test_validate_configuration_order(mocker):
@@ -21,6 +24,7 @@ def test_validate_configuration_order(mocker):
     expected_steps = [
         SetupContext,
         ValidateNoEarlyRenewal,
+        ValidateNoStagedRenewal,
     ]
     actual_steps = [type(step) for step in mocked_pipeline_ctor.mock_calls[0].args]
     assert actual_steps == expected_steps

--- a/tests/flows/validation/test_shared.py
+++ b/tests/flows/validation/test_shared.py
@@ -5,6 +5,7 @@ from adobe_vipm.adobe.constants import (
     ORDER_TYPE_PREVIEW,
     ORDER_TYPE_RENEWAL,
     AdobeOrderStatus,
+    AdobeSubscriptionStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError, AdobeProductNotFoundError
 from adobe_vipm.adobe.mixins.errors import AdobeCreatePreviewError
@@ -13,6 +14,7 @@ from adobe_vipm.flows.constants import (
     ERR_DUPLICATED_ITEMS,
     ERR_EARLY_RENEWAL_IN_PROGRESS,
     ERR_EXISTING_ITEMS,
+    ERR_RENEWAL_STAGED,
     MARKET_SEGMENT_COMMERCIAL,
     MARKET_SEGMENT_EDUCATION,
     MARKET_SEGMENT_GOVERNMENT,
@@ -22,6 +24,7 @@ from adobe_vipm.flows.validation.shared import (
     GetPreviewOrder,
     ValidateDuplicateLines,
     ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
 )
 
 
@@ -399,3 +402,164 @@ def test_validate_no_early_renewal_handles_leap_day_coterm(
     assert early_renewal_context.validation_succeeded is False
     assert early_renewal_context.order["error"] == ERR_EARLY_RENEWAL_IN_PROGRESS.to_dict()
     mock_next_step.assert_not_called()
+
+
+@pytest.fixture
+def staged_renewal_context(order_factory):
+    return Context(
+        order=order_factory(),
+        authorization_id="AUT-1234-5678",
+        adobe_customer_id="a-client-id",
+        adobe_customer={"cotermDate": "2027-09-25"},
+    )
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_staged_renewal_blocks_scheduled_subscription(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    adobe_subscription_factory,
+    staged_renewal_context,
+):
+    mock_adobe_client.get_subscriptions.return_value = {
+        "items": [
+            adobe_subscription_factory(status=AdobeSubscriptionStatus.SCHEDULED.value),
+        ]
+    }
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, staged_renewal_context, mock_next_step)  # act
+
+    assert staged_renewal_context.validation_succeeded is False
+    assert staged_renewal_context.order["error"] == ERR_RENEWAL_STAGED.to_dict()
+    mock_adobe_client.get_subscriptions.assert_called_once_with(
+        "AUT-1234-5678",
+        "a-client-id",
+    )
+    mock_next_step.assert_not_called()
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_staged_renewal_blocks_staged_upsize(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    adobe_subscription_factory,
+    staged_renewal_context,
+):
+    mock_adobe_client.get_subscriptions.return_value = {
+        "items": [
+            adobe_subscription_factory(current_quantity=10, renewal_quantity=15),
+        ]
+    }
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, staged_renewal_context, mock_next_step)  # act
+
+    assert staged_renewal_context.validation_succeeded is False
+    assert staged_renewal_context.order["error"] == ERR_RENEWAL_STAGED.to_dict()
+    mock_next_step.assert_not_called()
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_staged_renewal_ignores_staged_downsize(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    adobe_subscription_factory,
+    staged_renewal_context,
+):
+    mock_adobe_client.get_subscriptions.return_value = {
+        "items": [
+            adobe_subscription_factory(current_quantity=10, renewal_quantity=5),
+        ]
+    }
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, staged_renewal_context, mock_next_step)  # act
+
+    assert staged_renewal_context.validation_succeeded is True
+    mock_next_step.assert_called_once_with(mock_mpt_client, staged_renewal_context)
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_staged_renewal_ignores_unchanged_renewal(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    adobe_subscription_factory,
+    staged_renewal_context,
+):
+    mock_adobe_client.get_subscriptions.return_value = {
+        "items": [
+            adobe_subscription_factory(current_quantity=10, renewal_quantity=10),
+        ]
+    }
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, staged_renewal_context, mock_next_step)  # act
+
+    assert staged_renewal_context.validation_succeeded is True
+    mock_next_step.assert_called_once_with(mock_mpt_client, staged_renewal_context)
+
+
+@freeze_time("2027-09-26 12:30:00")
+def test_validate_no_staged_renewal_unlocks_after_the_anniversary(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    adobe_subscription_factory,
+    staged_renewal_context,
+):
+    mock_adobe_client.get_subscriptions.return_value = {
+        "items": [
+            adobe_subscription_factory(current_quantity=10, renewal_quantity=15),
+        ]
+    }
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, staged_renewal_context, mock_next_step)  # act
+
+    assert staged_renewal_context.validation_succeeded is True
+    mock_adobe_client.get_subscriptions.assert_not_called()
+    mock_next_step.assert_called_once_with(mock_mpt_client, staged_renewal_context)
+
+
+@freeze_time("2026-09-10 12:30:00")
+def test_validate_no_staged_renewal_skips_renewal_orders(
+    mock_adobe_client,
+    mock_mpt_client,
+    mock_next_step,
+    order_factory,
+    order_parameters_factory,
+    renewal_payload,
+):
+    context = Context(
+        order=order_factory(
+            order_parameters=order_parameters_factory(renewal_payload=renewal_payload)
+        ),
+        authorization_id="AUT-1234-5678",
+        adobe_customer_id="a-client-id",
+        adobe_customer={"cotermDate": "2027-09-25"},
+    )
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, context, mock_next_step)  # act
+
+    assert context.validation_succeeded is True
+    mock_adobe_client.get_subscriptions.assert_not_called()
+    mock_next_step.assert_called_once_with(mock_mpt_client, context)
+
+
+def test_validate_no_staged_renewal_skips_without_adobe_customer(
+    mock_adobe_client, mock_mpt_client, mock_next_step, order_factory
+):
+    context = Context(order=order_factory())
+    step = ValidateNoStagedRenewal()
+
+    step(mock_mpt_client, context, mock_next_step)  # act
+
+    assert context.validation_succeeded is True
+    mock_adobe_client.get_subscriptions.assert_not_called()
+    mock_next_step.assert_called_once_with(mock_mpt_client, context)

--- a/tests/flows/validation/test_termination.py
+++ b/tests/flows/validation/test_termination.py
@@ -8,7 +8,11 @@ from adobe_vipm.flows.fulfillment.shared import (
     ValidateRenewalWindow,
 )
 from adobe_vipm.flows.helpers import SetupContext, Validate3YCCommitment
-from adobe_vipm.flows.validation.shared import ValidateDuplicateLines, ValidateNoEarlyRenewal
+from adobe_vipm.flows.validation.shared import (
+    ValidateDuplicateLines,
+    ValidateNoEarlyRenewal,
+    ValidateNoStagedRenewal,
+)
 from adobe_vipm.flows.validation.termination import (
     ValidateDownsizes,
     validate_termination_order,
@@ -234,13 +238,14 @@ def test_validate_termination_order(mocker):
 
     validate_termination_order(mocked_client, mocked_order)  # act
 
-    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 7
+    assert len(mocked_pipeline_ctor.mock_calls[0].args) == 8
     expected_steps = [
         SetupContext,
         ValidateDuplicateLines,
         SetOrUpdateCotermDate,
         ValidateRenewalWindow,
         ValidateNoEarlyRenewal,
+        ValidateNoStagedRenewal,
         ValidateDownsizes,
         Validate3YCCommitment,
     ]


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

Backport of #966 to `release/5`.

## What

Blocks native Change / Configuration / Termination orders while an **at-anniversary** renewal is staged for the agreement (AA9 / RN-7).

## Why

`ValidateNoEarlyRenewal` only detects renew-now renewals (which commit an Adobe `RENEWAL` order). An at-anniversary renewal places no Adobe order and does not roll the coterm date until the anniversary, so a native order placed before the anniversary could silently fork the staged renewal.

## How

New validation step **`ValidateNoStagedRenewal`** (`flows/validation/shared.py`), wired into the change, termination and configuration pipelines beside `ValidateNoEarlyRenewal`. While the renewal is pending effect (today on or before `cotermDate`) it derives the staged state live from Adobe subscriptions and blocks on a staged **upsize / addition**:

* an Adobe subscription in status **SCHEDULED (1009)** — a net-new item staged for the renewal; or
* an existing subscription whose **`autoRenewal.renewalQuantity > currentQuantity`** — a staged quantity increase.

Strictly `>`, not `!=`: a staged **downsize** is the ordinary renewal-reduction mechanism and must not lock. The divergence self-clears at the anniversary. Adds `ERR_RENEWAL_STAGED` (`VIPM0054`), guiding the user to re-open the renewal wizard.

## Backport notes

* Cherry-pick of the single source commit `bd7d5a6` from #966; applied cleanly (auto-merge on `change.py`), no conflicts.
* Source PR is merged to `main`.

## Testing

Validated against `release/5`'s pinned toolchain (ruff 0.15.7, flake8 7.3.0 + wemake 1.6.1, `uv lock --check`) — all clean; full suite **1080 passed**.

Jira: [MPT-24778](https://softwareone.atlassian.net/browse/MPT-24778)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-24778]: https://softwareone.atlassian.net/browse/MPT-24778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-24778](https://softwareone.atlassian.net/browse/MPT-24778)

- Add `ValidateNoStagedRenewal` for native Change, Configuration, and Termination orders.
- Block orders when an at-anniversary renewal stages a net-new subscription or quantity increase.
- Allow staged quantity decreases and orders after the renewal takes effect.
- Add error `ERR_RENEWAL_STAGED` (`VIPM0054`) with renewal wizard guidance.
- Add validation pipeline integration and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->