### PR TITLE
MPT-24838 record only committed flex discount codes on renew-now redemptions

### DIFF
--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -769,9 +769,20 @@ class RecordDiscountRedemptions(Step):
     applied by the plan. A code the subscription already carried before this
     order (inherited discount snapshotted by SetupRenewalPlan) was not
     redeemed by it, so it is skipped: an auto-applied reusable is never
-    recorded as a fresh once-per-customer redemption. The write is best
-    effort: the order is already completed, so an AirTable failure is logged
-    and notified for a manual backfill instead of failing the order.
+    recorded as a fresh once-per-customer redemption.
+
+    On the renew-now flow a code is recorded only once the committed RENEWAL
+    order confirmed it: that flow drops a requested code the preview did not
+    confirm (result != SUCCESS) from the order without failing it, so
+    recording it would wrongly consume the customer's once-per-customer
+    eligibility. The at-anniversary flow places no RENEWAL order — its codes
+    ride create_customer_subscription / update_subscription, which Adobe
+    validates on the spot (a rejected code fails the order) — so its requested
+    codes are the applied ones and no committed-order filter applies.
+
+    The write is best effort: the order is already completed, so an AirTable
+    failure is logged and notified for a manual backfill instead of failing
+    the order.
     """
 
     def __call__(self, client, context, next_step):
@@ -789,11 +800,14 @@ class RecordDiscountRedemptions(Step):
 
     def _get_redeemed_codes(self, context):
         """Return the unique codes newly applied by the plan, skipping inherited ones."""
+        confirmed_codes = self._get_confirmed_codes(context)
         redeemed_codes, inherited_codes = self._split_plan_codes(context)
         # Net-new items create a brand-new subscription, so they can hold no inherited
         # code: every code on a net-new item is a fresh redemption by this order.
         for net_new_item in (context.renewal_payload or {}).get("netNewItems", []):
             redeemed_codes.extend(net_new_item.get("flexDiscountCodes") or [])
+        if confirmed_codes is not None:
+            redeemed_codes = self._drop_unconfirmed_codes(context, redeemed_codes, confirmed_codes)
         if inherited_codes:
             logger.info(
                 "%s: skipping inherited flex discount code(s) already held by the "
@@ -802,6 +816,40 @@ class RecordDiscountRedemptions(Step):
                 ", ".join(dict.fromkeys(inherited_codes)),
             )
         return list(dict.fromkeys(redeemed_codes))
+
+    def _get_confirmed_codes(self, context):
+        """
+        Return the codes confirmed on the committed RENEWAL order, or None when absent.
+
+        Only the renew-now flow places a RENEWAL order (context.adobe_renewal_order):
+        the confirmed set is the codes Adobe applied (result SUCCESS) on its committed
+        line items, used to drop requested codes the preview did not confirm. The
+        at-anniversary flow places no such order, so this returns None and no
+        committed-order filter applies. A discount object without an explicit SUCCESS
+        result is treated as unconfirmed, so an ambiguous entry never consumes the
+        customer's once-per-customer eligibility.
+        """
+        renewal_order = context.adobe_renewal_order
+        if renewal_order is None:
+            return None
+        return {
+            flex_discount["code"]
+            for line_item in renewal_order.get("lineItems", [])
+            for flex_discount in line_item.get("flexDiscounts") or []
+            if flex_discount.get("result") == "SUCCESS"
+        }
+
+    def _drop_unconfirmed_codes(self, context, redeemed_codes, confirmed_codes):
+        """Keep only the plan codes the committed RENEWAL order confirmed (renew-now)."""
+        dropped = [code for code in redeemed_codes if code not in confirmed_codes]
+        if dropped:
+            logger.warning(
+                "%s: skipping flex discount code(s) not confirmed on the committed "
+                "renewal order, not redeemed by this order: %s",
+                context,
+                ", ".join(dict.fromkeys(dropped)),
+            )
+        return [code for code in redeemed_codes if code in confirmed_codes]
 
     def _split_plan_codes(self, context):
         """Split the renewing plan's codes into (redeemed, inherited)."""

--- a/docs/renew-now.md
+++ b/docs/renew-now.md
@@ -73,6 +73,14 @@ and that the `PREVIEW_RENEWAL` response then **confirmed** with result
 - Adobe accepts at most one code per line and rejects more with error `2147`, so
   a single surviving code is submitted per line.
 
+The redemptions written to the AirTable table mirror this committed set:
+`RecordDiscountRedemptions` records only the codes confirmed (result `SUCCESS`)
+on the committed `RENEWAL` order, for both renewing and net-new lines. A
+requested code the preview dropped is not recorded, so it does not wrongly
+consume the customer's once-per-customer eligibility. (The at-anniversary flow
+places no `RENEWAL` order and records its requested codes directly, since Adobe
+validates them at subscription create/update time.)
+
 ## Net-new items
 
 A net-new item (a product the customer does not yet hold) is submitted as an

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -1328,7 +1328,9 @@ def test_return_previous_renewal_orders_step_return_failed(
 
 
 @freeze_time("2026-08-28 10:00:00")
-def test_record_discount_redemptions_step_renew_now(mocker, mock_mpt_client, renewal_now_context):
+def test_record_discount_redemptions_step_renew_now(
+    mocker, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
     renewal_now_context.renewal_plan_subscriptions = [
         plan_entry(
             subscription_id="9d6f8c818d4ae8807910f889cbab8fNA",
@@ -1349,6 +1351,27 @@ def test_record_discount_redemptions_step_renew_now(mocker, mock_mpt_client, ren
             renewal_quantity=0,
         ),
     ]
+    # Both requested codes were confirmed on the committed RENEWAL order, so both
+    # are recorded.
+    renewal_now_context.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304520CA01A12",
+                "quantity": 5,
+                "flexDiscounts": [{"code": "SB7U6WLG8R4N0IGODRZ191ZD", "result": "SUCCESS"}],
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65324861CA01A12",
+                "quantity": 7,
+                "flexDiscounts": [{"code": "HOU3BNCONXV7WOTAQ4032KSM", "result": "SUCCESS"}],
+            },
+        ],
+    )
     mocked_create_redemptions = mocker.patch(
         "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
     )
@@ -1373,6 +1396,144 @@ def test_record_discount_redemptions_step_renew_now(mocker, mock_mpt_client, ren
         },
     ])
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+@freeze_time("2026-08-28 10:00:00")
+def test_record_discount_redemptions_step_renew_now_skips_unconfirmed_code(
+    mocker, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(
+            subscription_id="9d6f8c818d4ae8807910f889cbab8fNA",
+            offer_id="65304520CA01A12",
+            renewal_quantity=5,
+            flex_discount_codes=["CONFIRMED-CODE"],
+        ),
+        # The preview did not confirm this code, so the renew-now flow dropped it from
+        # the committed order (result != SUCCESS): it must not be recorded as redeemed.
+        plan_entry(
+            subscription_id="424d33184346eabbdd0dfce7294cf2NA",
+            offer_id="65324861CA01A12",
+            renewal_quantity=7,
+            flex_discount_codes=["DROPPED-CODE"],
+        ),
+    ]
+    renewal_now_context.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304520CA01A12",
+                "quantity": 5,
+                "flexDiscounts": [{"code": "CONFIRMED-CODE", "result": "SUCCESS"}],
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65324861CA01A12",
+                "quantity": 7,
+                "flexDiscounts": [{"code": "DROPPED-CODE", "result": "FAILURE"}],
+            },
+        ],
+    )
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_create_redemptions.assert_called_once_with([
+        {
+            "code": "CONFIRMED-CODE",
+            "customer_id": "customer-id",
+            "order_id": renewal_now_context.order_id,
+            "redeemed_at": dt.datetime(2026, 8, 28, 10, 0, tzinfo=dt.UTC),
+        },
+    ])
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_record_discount_redemptions_step_renew_now_requires_explicit_success(
+    mocker, mock_mpt_client, renewal_now_context, adobe_order_factory
+):
+    renewal_now_context.renewal_plan_subscriptions = [
+        plan_entry(
+            subscription_id="9d6f8c818d4ae8807910f889cbab8fNA",
+            offer_id="65304520CA01A12",
+            renewal_quantity=5,
+            flex_discount_codes=["AMBIGUOUS-CODE"],
+        ),
+    ]
+    # A discount object carrying a code but no result is not an explicit confirmation, so
+    # it must not be recorded (and must not consume once-per-customer eligibility).
+    renewal_now_context.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304520CA01A12",
+                "quantity": 5,
+                "flexDiscounts": [{"code": "AMBIGUOUS-CODE"}],
+            },
+        ],
+    )
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_now_context, mocked_next_step)  # act
+
+    mocked_create_redemptions.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context)
+
+
+def test_record_discount_redemptions_step_renew_now_skips_unconfirmed_net_new_code(
+    mocker, mock_mpt_client, renewal_now_context_net_new, adobe_order_factory
+):
+    renewal_now_context_net_new.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["CONFIRMED-CODE"]),
+    ]
+    # The net-new item's code (CODE-3, from the net_new_item fixture) was omitted from
+    # the committed order (the line carries no flexDiscounts at all), so it must not be
+    # recorded as redeemed.
+    renewal_now_context_net_new.adobe_renewal_order = adobe_order_factory(
+        order_type="RENEWAL",
+        status=AdobeOrderStatus.COMPLETE.value,
+        order_id="ADOBE-RENEWAL-001",
+        items=[
+            {
+                "extLineItemNumber": 1,
+                "offerId": "65304578CA01A12",
+                "quantity": 15,
+                "flexDiscounts": [{"code": "CONFIRMED-CODE", "result": "SUCCESS"}],
+            },
+            {
+                "extLineItemNumber": 2,
+                "offerId": "65322651CA01A12",
+                "quantity": 5,
+            },
+        ],
+    )
+    mocked_create_redemptions = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_discount_redemptions",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordDiscountRedemptions()
+
+    step(mock_mpt_client, renewal_now_context_net_new, mocked_next_step)  # act
+
+    recorded_codes = {
+        redemption["code"] for redemption in mocked_create_redemptions.mock_calls[0].args[0]
+    }
+    assert recorded_codes == {"CONFIRMED-CODE"}
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_now_context_net_new)
 
 
 def test_fulfill_renewal_now_order(mocker):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fixes a redemption-recording bug on the **renew-now** early-renewal flow: `RecordDiscountRedemptions` recorded the flex discount codes **requested** in the renewal plan rather than the ones Adobe actually **confirmed/applied** on the committed `RENEWAL` order.

On renew-now, a requested code the `PREVIEW_RENEWAL` did not confirm (result `!= SUCCESS`) is dropped from the committed order without failing it — but the redemption was still written to the AirTable Discount Redemptions table. Because redemptions are once-per-customer, recording a code that was never applied wrongly consumed the customer's eligibility. This affected **both renewing subscriptions and net-new items**.

## How

- `RecordDiscountRedemptions._get_redeemed_codes` now intersects the plan's redeemed candidate codes with the set actually confirmed on the committed `RENEWAL` order.
  - `_get_confirmed_codes` reads `context.adobe_renewal_order` and returns the codes with `result == SUCCESS` on its committed line items. This is authoritative and survives idempotent retries (the `existing_order` reuse path, where the preview is not rebuilt).
  - `_drop_unconfirmed_codes` removes any candidate code not in that confirmed set and logs what it dropped.
- The intersection only **removes** unconfirmed requested codes; it never adds auto-applied reusables (those are not in the requested set).
- The **at-anniversary** path is left intact: it never sets `context.adobe_renewal_order`, so `_get_confirmed_codes` returns `None` and no committed-order filter applies. Its codes ride `create_customer_subscription` / `update_subscription`, which Adobe validates on the spot.
- Docs: `docs/renew-now.md` now states that renew-now redemptions record only the committed/confirmed set.

## Testing

- Updated `test_record_discount_redemptions_step_renew_now` to source from the committed order.
- Added coverage for a **rejected** (FAILURE) code and an **omitted** net-new code — both are dropped from redemptions.
- Full local validation passes: `ruff format --check`, `ruff check`, `flake8`, `uv lock --check`, and `pytest` (1101 passed, 99% coverage).

Fixes MPT-24838. Fast-follow from the CodeRabbit review of MPT-24772 (#964).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-24838](https://softwareone.atlassian.net/browse/MPT-24838)

- Record only flex discount codes with `result == SUCCESS` on the committed `RENEWAL` order.
- Exclude unconfirmed and omitted codes from redemption records.
- Apply the filter to renewing subscriptions and net-new items.
- Preserve the at-anniversary flow behavior.
- Update documentation and add tests for rejected and omitted codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-24838]: https://softwareone.atlassian.net/browse/MPT-24838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ