### PR TITLE
MPT-24862 Flex discounts: typed unknown code not written back into th…

### DIFF
--- a/adobe_vipm/adobe/mixins/order.py
+++ b/adobe_vipm/adobe/mixins/order.py
@@ -684,6 +684,35 @@ class OrderClientMixin:
         )
         return base_offers_with_discounts
 
+    def get_flex_discounts_by_code(
+        self,
+        authorization_id: str,
+        market_segment: str,
+        country: str,
+        flex_discount_code: str,
+    ) -> list:
+        """
+        Fetches the flex discounts matching a single discount code from Adobe.
+
+        Args:
+            authorization_id: Id of the authorization to use.
+            market_segment: Adobe market segment (COM, GOV, EDU).
+            country: Customer country code.
+            flex_discount_code: The flexible discount code to look up.
+
+        Returns:
+            list: The flex discounts Adobe reports for the code.
+        """
+        authorization = self._config.get_authorization(authorization_id)
+        return self._fetch_flex_discounts(
+            authorization,
+            {
+                "market-segment": market_segment,
+                "country": country,
+                "flex-discount-code": flex_discount_code,
+            },
+        )
+
     def _get_fail_discounts_for_cust_not_qualified(self, ex: AdobeError, payload: dict) -> set:
         if ex.code == adobe_constants.AdobeErrorCode.CUSTOMER_NOT_QUALIFIED_FOR_FLEX_DISCOUNT:
             logger.warning("%s", ex)
@@ -879,13 +908,19 @@ class OrderClientMixin:
             and mpt_item["status"] == adobe_constants.AdobeOrderStatus.COMPLETE
         )
 
-    @wrap_http_error
     def _get_flex_discounts(
         self, authorization: Authorization, segment: str, country: str, offer_ids: tuple[str, ...]
     ) -> list:
+        query_params = {
+            "market-segment": segment,
+            "country": country,
+            "offer-ids": ",".join(offer_ids),
+        }
+        return self._fetch_flex_discounts(authorization, query_params)
+
+    @wrap_http_error
+    def _fetch_flex_discounts(self, authorization: Authorization, query_params: dict) -> list:
         headers = self._get_headers(authorization)
-        offer_ids = ",".join(offer_ids)
-        query_params = {"market-segment": {segment}, "country": {country}, "offer-ids": {offer_ids}}
         next_url = "v3/flex-discounts"
         flex_discounts = []
         while next_url:

--- a/adobe_vipm/airtable/models.py
+++ b/adobe_vipm/airtable/models.py
@@ -2,6 +2,7 @@ import datetime as dt
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import cache
+from types import MappingProxyType
 
 from django.conf import settings
 from mpt_extension_sdk.mpt_http.utils import find_first
@@ -24,7 +25,7 @@ from requests import HTTPError
 
 from adobe_vipm.adobe.errors import AdobeProductNotFoundError
 from adobe_vipm.flows.constants import MARKET_SEGMENT_TO_AIRTABLE_SEGMENT
-from adobe_vipm.utils import get_commitment_start_date
+from adobe_vipm.utils import get_commitment_start_date, get_partial_sku
 
 STATUS_INIT = "init"
 STATUS_RUNNING = "running"
@@ -37,6 +38,23 @@ STATUS_GC_PENDING = "pending"
 STATUS_GC_TRANSFERRED = "transferred"
 TYPE_3YC_CONSUMABLE = "Consumable"
 TYPE_3YC_LICENSE = "License"
+
+# Discount Codes store values (shared schema with the ef-extension discount store).
+DISCOUNT_CODE_FIELD = "Code"
+DISCOUNT_SOURCE_CLIENT = "Client"
+DISCOUNT_ENRICHMENT_PENDING = "PENDING"
+DISCOUNT_CATEGORY_INTRO = "INTRO"
+DISCOUNT_ORDER_TYPE_NEW = "NEW"
+DISCOUNT_OFFER_IDS_SEPARATOR = ","
+DISCOUNT_TYPE_PERCENTAGE = "PERCENTAGE"
+
+# Adobe's flex-discount outcome types keyed to the discount types the store uses.
+ADOBE_DISCOUNT_TYPES = MappingProxyType({
+    "PERCENTAGE_DISCOUNT": DISCOUNT_TYPE_PERCENTAGE,
+    "PERCENTAGE": DISCOUNT_TYPE_PERCENTAGE,
+    "FIXED_DISCOUNT": "FIXED_DISCOUNT",
+    "FIXED_PRICE": "FIXED_PRICE",
+})
 
 AIRTABLE_RETRY_STRATEGY = retry_strategy(status_forcelist=(429, 500, 502, 503, 504))
 
@@ -975,6 +993,221 @@ def create_discount_redemptions(redemptions: list):
     """
     redemption_model = get_discount_redemption_model(AirTableBaseInfo.for_discounts())
     redemption_model.batch_save([redemption_model(**redemption) for redemption in redemptions])
+
+
+@cache
+def get_discount_code_model(base_info: AirTableBaseInfo):
+    """
+    Returns the DiscountCode model class connected to the right base.
+
+    The table is the flexible discount store shared with the ef-extension
+    (Discount Management TDR): one row per discount code and market segment.
+
+    Args:
+        base_info: The base info instance.
+
+    Returns:
+        DiscountCode: The AirTable DiscountCode model.
+    """
+
+    class DiscountCode(Model):
+        code = fields.TextField(DISCOUNT_CODE_FIELD)
+        market_segment = fields.TextField("market_segment")
+        source = fields.TextField("source")
+        name = fields.TextField("name")
+        description = fields.TextField("description")
+        adobe_discount_id = fields.TextField("adobe_discount_id")
+        category = fields.TextField("category")
+        status = fields.TextField("status")
+        discount_type = fields.TextField("discount_type")
+        start_date = fields.DatetimeField("start_date")
+        end_date = fields.DatetimeField("end_date")
+        reusable = fields.CheckboxField("reusable")
+        discount_lock_end_date = fields.DatetimeField("discount_lock_end_date")
+        target_offer_ids = fields.TextField("target_offer_ids")
+        qualifying_offer_ids = fields.TextField("qualifying_offer_ids")
+        applicable_order_types = fields.MultipleSelectField("applicable_order_types")
+        enrichment_status = fields.TextField("enrichment_status")
+        synchronized_at = fields.DatetimeField("synchronized_at")
+        created_at = fields.DatetimeField("created_at")
+        updated_at = fields.DatetimeField("updated_at")
+
+        class Meta:
+            table_name = "Discount Codes"
+            api_key = base_info.api_key
+            base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
+
+    return DiscountCode
+
+
+@cache
+def get_discount_value_model(base_info: AirTableBaseInfo):
+    """
+    Returns the DiscountValue model class connected to the right base.
+
+    The table holds the amounts of the codes on the Discount Codes table: one
+    row per country for fixed types, a single country-less row for percentages.
+
+    Args:
+        base_info: The base info instance.
+
+    Returns:
+        DiscountValue: The AirTable DiscountValue model.
+    """
+
+    class DiscountValue(Model):
+        code = fields.TextField("code")
+        market_segment = fields.TextField("market_segment")
+        country = fields.TextField("country")
+        currency = fields.TextField("currency")
+        value = fields.NumberField("value")
+
+        class Meta:
+            table_name = "Discount Values"
+            api_key = base_info.api_key
+            base_id = base_info.base_id
+            retry = AIRTABLE_RETRY_STRATEGY
+
+    return DiscountValue
+
+
+def get_existing_discount_codes(codes: list[str], market_segment: str) -> set[str]:
+    """
+    Returns the subset of codes already stored on the Discount Codes table.
+
+    Args:
+        codes: The discount codes to look up.
+        market_segment: Adobe market segment the codes belong to (COM, GOV, EDU).
+
+    Returns:
+        set[str]: The codes found on the table, whatever their source or state.
+    """
+    discount_code_model = get_discount_code_model(AirTableBaseInfo.for_discounts())
+    rows = discount_code_model.all(
+        formula=AND(
+            EQ(Field("market_segment"), market_segment),
+            OR(*(EQ(Field(DISCOUNT_CODE_FIELD), code) for code in codes)),
+        )
+    )
+    return {row.code for row in rows}
+
+
+def create_client_discount_codes(discounts: list[dict], market_segment: str):
+    """
+    Stores Adobe flex discounts on the Discount Codes table with source "Client".
+
+    Only the attributes GET /v3/flex-discounts reports are written; the
+    enrichment fields stay PENDING for operations to curate, mirroring the
+    rows the ef-extension synchronization first creates. The amounts of each
+    outcome land on the Discount Values table, one row per country for fixed
+    types and a single country-less row for percentages.
+
+    Args:
+        discounts: Adobe flex discount objects, as returned by the flex-discounts API.
+        market_segment: Adobe market segment the codes belong to (COM, GOV, EDU).
+    """
+    now = dt.datetime.now(tz=dt.UTC)
+    base_info = AirTableBaseInfo.for_discounts()
+    discount_code_model = get_discount_code_model(base_info)
+    discount_code_model.batch_save([
+        discount_code_model(**_to_client_discount_code_fields(discount, market_segment, now))
+        for discount in discounts
+    ])
+    discount_value_model = get_discount_value_model(base_info)
+    value_rows = [
+        discount_value_model(**value_fields)
+        for discount in discounts
+        for value_fields in _to_client_discount_value_fields(discount, market_segment)
+    ]
+    if value_rows:
+        discount_value_model.batch_save(value_rows)
+
+
+def _to_client_discount_code_fields(discount: dict, market_segment: str, now: dt.datetime) -> dict:
+    """Maps an Adobe flex discount to the fields of a client-sourced code row."""
+    qualification = discount.get("qualification") or {}
+    lock_end_date = _read_adobe_datetime(discount.get("discountLockEndDate"))
+    fields_map = {
+        "code": str(discount.get("code") or ""),
+        "market_segment": market_segment,
+        "source": DISCOUNT_SOURCE_CLIENT,
+        "name": str(discount.get("name") or ""),
+        "description": str(discount.get("description") or ""),
+        "adobe_discount_id": str(discount.get("id") or ""),
+        "category": str(discount.get("category") or ""),
+        "status": str(discount.get("status") or ""),
+        "discount_type": _get_adobe_discount_type(discount),
+        "start_date": _read_adobe_datetime(discount.get("startDate")),
+        "end_date": _read_adobe_datetime(discount.get("endDate")),
+        # Reusability is derived from the discount lock presence (TDR rule).
+        "reusable": lock_end_date is not None,
+        "discount_lock_end_date": lock_end_date,
+        "target_offer_ids": _to_partial_sku_csv(qualification.get("baseOfferIds")),
+        "qualifying_offer_ids": _to_partial_sku_csv(qualification.get("qualifyingOfferIds")),
+        "enrichment_status": DISCOUNT_ENRICHMENT_PENDING,
+        "synchronized_at": now,
+        "created_at": now,
+        "updated_at": now,
+    }
+    if fields_map["category"] == DISCOUNT_CATEGORY_INTRO:
+        # The only order-type enrichment the TDR fixes: INTRO is net-new only.
+        fields_map["applicable_order_types"] = [DISCOUNT_ORDER_TYPE_NEW]
+    return fields_map
+
+
+def _get_adobe_discount_type(discount: dict) -> str:
+    """Maps the first Adobe outcome type to the discount type the store uses."""
+    outcomes = discount.get("outcomes") or []
+    if not outcomes:
+        return ""
+    adobe_type = str(outcomes[0].get("type") or "")
+    return ADOBE_DISCOUNT_TYPES.get(adobe_type, adobe_type)
+
+
+def _to_client_discount_value_fields(discount: dict, market_segment: str) -> list[dict]:  # noqa: WPS231
+    """
+    Maps the outcomes of an Adobe flex discount to Discount Values rows.
+
+    Fixed-type outcomes carry one value per country; percentage outcomes are
+    country-agnostic, reported by Adobe as a bare value without country or
+    currency. Incomplete values (no amount, or no country on a fixed type)
+    are skipped.
+    """
+    code = str(discount.get("code") or "")
+    rows = []
+    for outcome in discount.get("outcomes") or []:
+        adobe_type = str(outcome.get("type") or "")
+        is_percentage = ADOBE_DISCOUNT_TYPES.get(adobe_type, adobe_type) == DISCOUNT_TYPE_PERCENTAGE
+        for discount_value in outcome.get("discountValues") or []:
+            amount = discount_value.get("value")
+            country = discount_value.get("country")
+            if amount is None or (not is_percentage and not country):
+                continue
+            row = {"code": code, "market_segment": market_segment, "value": amount}
+            if country:
+                row["country"] = str(country)
+            if discount_value.get("currency"):
+                row["currency"] = str(discount_value["currency"])
+            rows.append(row)
+    return rows
+
+
+def _to_partial_sku_csv(offer_ids: list | None) -> str:
+    """Stores Adobe offer ids as their deduplicated 10-char partial SKUs."""
+    skus = (get_partial_sku(str(offer_id)) for offer_id in offer_ids or [])
+    return DISCOUNT_OFFER_IDS_SEPARATOR.join(sku for sku in dict.fromkeys(skus) if sku)
+
+
+def _read_adobe_datetime(raw_date) -> dt.datetime | None:
+    """Reads an Adobe ISO-8601 date string as an aware UTC datetime, or None."""
+    if not isinstance(raw_date, str) or not raw_date:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw_date)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.UTC)
 
 
 @cache

--- a/adobe_vipm/flows/fulfillment/renewal.py
+++ b/adobe_vipm/flows/fulfillment/renewal.py
@@ -28,12 +28,17 @@ from adobe_vipm.adobe.constants import (
     ThreeYearCommitmentStatus,
 )
 from adobe_vipm.adobe.errors import AdobeAPIError
-from adobe_vipm.airtable.models import create_discount_redemptions
+from adobe_vipm.airtable.models import (
+    create_client_discount_codes,
+    create_discount_redemptions,
+    get_existing_discount_codes,
+)
 from adobe_vipm.flows.constants import (
     ERR_COMMITMENT_3YC_VALIDATION,
     ERR_RENEWAL_NET_NEW_FAILED,
     ERR_RENEWAL_PREVIEW_FAILED,
     ERR_RENEWAL_SUBSCRIPTION_UPDATE_FAILED,
+    MARKET_SEGMENTS,
     TEMPLATE_NAME_CHANGE,
     Param,
 )
@@ -760,6 +765,157 @@ class RecordFlexDiscounts(Step):
         next_step(client, context)
 
 
+def get_redeemed_codes(context):
+    """Return the unique codes newly applied by the plan, skipping inherited ones."""
+    confirmed_codes = get_confirmed_codes(context)
+    redeemed_codes, inherited_codes = _split_plan_codes(context)
+    # Net-new items create a brand-new subscription, so they can hold no inherited
+    # code: every code on a net-new item is a fresh redemption by this order.
+    for net_new_item in (context.renewal_payload or {}).get("netNewItems", []):
+        redeemed_codes.extend(net_new_item.get("flexDiscountCodes") or [])
+    if confirmed_codes is not None:
+        redeemed_codes = _drop_unconfirmed_codes(context, redeemed_codes, confirmed_codes)
+    if inherited_codes:
+        logger.info(
+            "%s: skipping inherited flex discount code(s) already held by the "
+            "subscriptions, not redeemed by this order: %s",
+            context,
+            ", ".join(dict.fromkeys(inherited_codes)),
+        )
+    return list(dict.fromkeys(redeemed_codes))
+
+
+def get_confirmed_codes(context):
+    """
+    Return the codes confirmed on the committed RENEWAL order, or None when absent.
+
+    Only the renew-now flow places a RENEWAL order (context.adobe_renewal_order):
+    the confirmed set is the codes Adobe applied (result SUCCESS) on its committed
+    line items, used to drop requested codes the preview did not confirm. The
+    at-anniversary flow places no such order, so this returns None and no
+    committed-order filter applies. A discount object without an explicit SUCCESS
+    result is treated as unconfirmed, so an ambiguous entry never consumes the
+    customer's once-per-customer eligibility.
+    """
+    renewal_order = context.adobe_renewal_order
+    if renewal_order is None:
+        return None
+    return {
+        flex_discount["code"]
+        for line_item in renewal_order.get("lineItems", [])
+        for flex_discount in line_item.get("flexDiscounts") or []
+        if flex_discount.get("result") == "SUCCESS"
+    }
+
+
+def _drop_unconfirmed_codes(context, redeemed_codes, confirmed_codes):
+    """Keep only the plan codes the committed RENEWAL order confirmed (renew-now)."""
+    dropped = [code for code in redeemed_codes if code not in confirmed_codes]
+    if dropped:
+        logger.warning(
+            "%s: skipping flex discount code(s) not confirmed on the committed "
+            "renewal order, not redeemed by this order: %s",
+            context,
+            ", ".join(dict.fromkeys(dropped)),
+        )
+    return [code for code in redeemed_codes if code in confirmed_codes]
+
+
+def _split_plan_codes(context):
+    """Split the renewing plan's codes into (redeemed, inherited)."""
+    redeemed_codes, inherited_codes = [], []
+    for plan in context.renewal_plan_subscriptions:
+        if not plan["renew"]:
+            continue
+        for code in plan["flex_discount_codes"]:
+            is_inherited = code in plan["snapshot"]["flex_discount_codes"]
+            (inherited_codes if is_inherited else redeemed_codes).append(code)
+    return redeemed_codes, inherited_codes
+
+
+class RecordClientDiscountCodes(Step):
+    """
+    Write the redeemed discount codes missing from the AirTable store back to it.
+
+    A code redeemed by the plan that the Discount Codes table does not know
+    yet was typed by the client in the wizard (never offered from the store),
+    and its use just succeeded on Adobe, so on this first successful use it is
+    fetched from Adobe by code and stored with source "Client". Runs after the
+    order has been completed and before RecordDiscountRedemptions, so the
+    redemption rows always point at a known code. The write is best effort:
+    the order is already completed, so a failure is logged and notified for a
+    manual backfill instead of failing the order.
+    """
+
+    def __call__(self, client, context, next_step):
+        """Write the redeemed discount codes missing from the AirTable store back to it."""
+        redeemed_codes = get_redeemed_codes(context)
+        if redeemed_codes:
+            try:
+                self._store_missing_codes(context, redeemed_codes)
+            except Exception:
+                logger.exception(
+                    "%s: failed to write the client discount code(s) back to AirTable",
+                    context,
+                )
+                joined_codes = ", ".join(redeemed_codes)
+                send_exception(
+                    f"Error storing the client discount codes of order {context.order_id}",
+                    "The renewal order has been completed but the discount codes it "
+                    "redeemed could not be checked against or written back to the "
+                    "AirTable Discount Codes table and must be reviewed manually:\n"
+                    f"- Customer ID: {context.adobe_customer_id}\n"
+                    f"- Order ID: {context.order_id}\n"
+                    f"- Codes: {joined_codes}\n",
+                )
+        next_step(client, context)
+
+    def _store_missing_codes(self, context, redeemed_codes):
+        market_segment = MARKET_SEGMENTS[context.market_segment]
+        existing_codes = get_existing_discount_codes(redeemed_codes, market_segment)
+        missing_codes = [code for code in redeemed_codes if code not in existing_codes]
+        if not missing_codes:
+            logger.info(
+                "%s: every redeemed discount code is already on the AirTable store",
+                context,
+            )
+            return
+        discounts = self._fetch_adobe_discounts(context, market_segment, missing_codes)
+        if discounts:
+            create_client_discount_codes(discounts, market_segment)
+            logger.info(
+                "%s: stored %s client discount code(s) on the AirTable store: %s",
+                context,
+                len(discounts),
+                ", ".join(discount["code"] for discount in discounts),
+            )
+
+    def _fetch_adobe_discounts(self, context, market_segment, missing_codes):
+        country = context.adobe_customer["companyProfile"]["address"]["country"]
+        discounts = []
+        for code in missing_codes:
+            discount = self._fetch_adobe_discount(context, market_segment, country, code)
+            if discount:
+                discounts.append(discount)
+            else:
+                logger.warning(
+                    "%s: Adobe returned no flex discount for the redeemed code %s, "
+                    "it cannot be written back to the AirTable store",
+                    context,
+                    code,
+                )
+        return discounts
+
+    def _fetch_adobe_discount(self, context, market_segment, country, code):
+        flex_discounts = get_adobe_client().get_flex_discounts_by_code(
+            context.authorization_id,
+            market_segment,
+            country,
+            code,
+        )
+        return next((fd for fd in flex_discounts if fd.get("code") == code), None)
+
+
 class RecordDiscountRedemptions(Step):
     """
     Record the flex discount codes redeemed by the plan on the AirTable redemptions table.
@@ -787,7 +943,7 @@ class RecordDiscountRedemptions(Step):
 
     def __call__(self, client, context, next_step):
         """Record the redeemed flex discount codes on the AirTable redemptions table."""
-        redeemed_codes = self._get_redeemed_codes(context)
+        redeemed_codes = get_redeemed_codes(context)
         if redeemed_codes:
             self._record_redemptions(context, redeemed_codes)
         else:
@@ -797,70 +953,6 @@ class RecordDiscountRedemptions(Step):
                 context,
             )
         next_step(client, context)
-
-    def _get_redeemed_codes(self, context):
-        """Return the unique codes newly applied by the plan, skipping inherited ones."""
-        confirmed_codes = self._get_confirmed_codes(context)
-        redeemed_codes, inherited_codes = self._split_plan_codes(context)
-        # Net-new items create a brand-new subscription, so they can hold no inherited
-        # code: every code on a net-new item is a fresh redemption by this order.
-        for net_new_item in (context.renewal_payload or {}).get("netNewItems", []):
-            redeemed_codes.extend(net_new_item.get("flexDiscountCodes") or [])
-        if confirmed_codes is not None:
-            redeemed_codes = self._drop_unconfirmed_codes(context, redeemed_codes, confirmed_codes)
-        if inherited_codes:
-            logger.info(
-                "%s: skipping inherited flex discount code(s) already held by the "
-                "subscriptions, not redeemed by this order: %s",
-                context,
-                ", ".join(dict.fromkeys(inherited_codes)),
-            )
-        return list(dict.fromkeys(redeemed_codes))
-
-    def _get_confirmed_codes(self, context):
-        """
-        Return the codes confirmed on the committed RENEWAL order, or None when absent.
-
-        Only the renew-now flow places a RENEWAL order (context.adobe_renewal_order):
-        the confirmed set is the codes Adobe applied (result SUCCESS) on its committed
-        line items, used to drop requested codes the preview did not confirm. The
-        at-anniversary flow places no such order, so this returns None and no
-        committed-order filter applies. A discount object without an explicit SUCCESS
-        result is treated as unconfirmed, so an ambiguous entry never consumes the
-        customer's once-per-customer eligibility.
-        """
-        renewal_order = context.adobe_renewal_order
-        if renewal_order is None:
-            return None
-        return {
-            flex_discount["code"]
-            for line_item in renewal_order.get("lineItems", [])
-            for flex_discount in line_item.get("flexDiscounts") or []
-            if flex_discount.get("result") == "SUCCESS"
-        }
-
-    def _drop_unconfirmed_codes(self, context, redeemed_codes, confirmed_codes):
-        """Keep only the plan codes the committed RENEWAL order confirmed (renew-now)."""
-        dropped = [code for code in redeemed_codes if code not in confirmed_codes]
-        if dropped:
-            logger.warning(
-                "%s: skipping flex discount code(s) not confirmed on the committed "
-                "renewal order, not redeemed by this order: %s",
-                context,
-                ", ".join(dict.fromkeys(dropped)),
-            )
-        return [code for code in redeemed_codes if code in confirmed_codes]
-
-    def _split_plan_codes(self, context):
-        """Split the renewing plan's codes into (redeemed, inherited)."""
-        redeemed_codes, inherited_codes = [], []
-        for plan in context.renewal_plan_subscriptions:
-            if not plan["renew"]:
-                continue
-            for code in plan["flex_discount_codes"]:
-                is_inherited = code in plan["snapshot"]["flex_discount_codes"]
-                (inherited_codes if is_inherited else redeemed_codes).append(code)
-        return redeemed_codes, inherited_codes
 
     def _record_redemptions(self, context, redeemed_codes):
         logger.info(
@@ -939,6 +1031,7 @@ def fulfill_renewal_order(client, order):
         CreateNetNewMptSubscriptions(),
         RecordFlexDiscounts(),
         CompleteOrder(TEMPLATE_NAME_CHANGE),
+        RecordClientDiscountCodes(),
         RecordDiscountRedemptions(),
         SetSubscriptionTemplate(),
         SyncAgreement(),

--- a/adobe_vipm/flows/fulfillment/renewal_now.py
+++ b/adobe_vipm/flows/fulfillment/renewal_now.py
@@ -67,6 +67,7 @@ from adobe_vipm.flows.constants import (
 from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.fulfillment.renewal import (
     CreateNetNewMptSubscriptions,
+    RecordClientDiscountCodes,
     RecordDiscountRedemptions,
     Validate3YCRenewalFloor,
 )
@@ -1086,6 +1087,7 @@ def fulfill_renewal_now_order(client, order):
         NormalizeRenewedSubscriptions(),
         DisableLapsingSubscriptions(),
         CompleteOrder(TEMPLATE_NAME_CHANGE),
+        RecordClientDiscountCodes(),
         RecordDiscountRedemptions(),
         SetSubscriptionTemplate(),
         SyncAgreement(),

--- a/tests/adobe/mixins/test_order.py
+++ b/tests/adobe/mixins/test_order.py
@@ -526,6 +526,62 @@ def test_get_flex_discounts_per_base_offer_collects_all_pages(
     }
 
 
+def test_get_flex_discounts_by_code(
+    adobe_client_factory,
+    adobe_authorizations_file,
+    requests_mocker,
+    settings,
+    flex_discounts_factory,
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    mocked_client, _, _ = adobe_client_factory()
+    response_json = flex_discounts_factory()
+    requests_mocker.get(
+        urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "/v3/flex-discounts"),
+        json=response_json,
+        match=[
+            matchers.query_param_matcher({
+                "market-segment": "COM",
+                "country": "US",
+                "flex-discount-code": "EASTER_26",
+            })
+        ],
+    )
+
+    result = mocked_client.get_flex_discounts_by_code(
+        authorization_uk,
+        "COM",
+        "US",
+        "EASTER_26",
+    )  # act
+
+    assert result == response_json["flexDiscounts"]
+
+
+def test_get_flex_discounts_by_code_error(
+    adobe_client_factory,
+    adobe_authorizations_file,
+    requests_mocker,
+    settings,
+    adobe_api_error_factory,
+):
+    authorization_uk = adobe_authorizations_file["authorizations"][0]["authorization_uk"]
+    mocked_client, _, _ = adobe_client_factory()
+    requests_mocker.get(
+        urljoin(settings.EXTENSION_CONFIG["ADOBE_API_BASE_URL"], "/v3/flex-discounts"),
+        status=400,
+        json=adobe_api_error_factory(AdobeErrorCode.INTERNAL_SERVER_ERROR, "Internal server error"),
+    )
+
+    with pytest.raises(AdobeError):
+        mocked_client.get_flex_discounts_by_code(
+            authorization_uk,
+            "COM",
+            "US",
+            "EASTER_26",
+        )  # act
+
+
 def test_create_switch_preview_order(
     adobe_client_factory,
     adobe_authorizations_file,

--- a/tests/airtable/test_models.py
+++ b/tests/airtable/test_models.py
@@ -20,13 +20,17 @@ from requests import HTTPError
 from adobe_vipm.adobe.errors import AdobeProductNotFoundError
 from adobe_vipm.airtable.models import (
     AirTableBaseInfo,
+    create_client_discount_codes,
     create_discount_redemptions,
     create_gc_agreement_deployments,
     create_gc_main_agreement,
     create_offers,
     get_adobe_product_by_marketplace_sku,
     get_agreement_deployment_view_link,
+    get_discount_code_model,
     get_discount_redemption_model,
+    get_discount_value_model,
+    get_existing_discount_codes,
     get_gc_agreement_deployment_model,
     get_gc_agreement_deployments_by_main_agreement,
     get_gc_agreement_deployments_to_check,
@@ -184,6 +188,217 @@ def test_create_discount_redemptions(mocker, settings):
         order_id=redemptions[0]["order_id"],
         redeemed_at=redemptions[0]["redeemed_at"],
     )
+
+
+def test_get_discount_code_model():
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+
+    result = get_discount_code_model(base_info)
+
+    assert result.meta.api.api_key == base_info.api_key
+    assert result.meta.base.id == base_info.base_id
+
+
+def test_get_discount_value_model():
+    base_info = AirTableBaseInfo(api_key="api-key", base_id="base-id")
+
+    result = get_discount_value_model(base_info)
+
+    assert result.meta.api.api_key == base_info.api_key
+    assert result.meta.base.id == base_info.base_id
+    assert result.meta.table_name == "Discount Values"
+
+
+def test_get_existing_discount_codes(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_DISCOUNTS_ID": "discounts-base-id",
+    }
+    mocked_discount_code_model = mocker.MagicMock()
+    mocked_discount_code_model.all.return_value = [mocker.MagicMock(code="CODE-1")]
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_code_model",
+        return_value=mocked_discount_code_model,
+    )
+
+    result = get_existing_discount_codes(["CODE-1", "CODE-2"], "COM")  # act
+
+    assert result == {"CODE-1"}
+    mocked_discount_code_model.all.assert_called_once_with(
+        formula=AND(
+            EQ(Field("market_segment"), "COM"),
+            OR(EQ(Field("Code"), "CODE-1"), EQ(Field("Code"), "CODE-2")),
+        )
+    )
+
+
+@freeze_time("2026-08-12 10:00:00")
+def test_create_client_discount_codes(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_DISCOUNTS_ID": "discounts-base-id",
+    }
+    mocked_discount_code = mocker.MagicMock()
+    mocked_discount_code_model = mocker.MagicMock(return_value=mocked_discount_code)
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_code_model",
+        return_value=mocked_discount_code_model,
+    )
+    mocked_discount_value = mocker.MagicMock()
+    mocked_discount_value_model = mocker.MagicMock(return_value=mocked_discount_value)
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_value_model",
+        return_value=mocked_discount_value_model,
+    )
+    discount = {
+        "id": "55555555-8768-4e8a-9a2f-fb6a6b08f563",
+        "name": "Easter Flexible Discount",
+        "description": "Exclusive 26 fixed off on Adobe Technical Communication Suite",
+        "code": "EASTER_26",
+        "category": "STANDARD",
+        "startDate": "2025-06-12T10:00:48Z",
+        "endDate": "2026-03-07T10:16Z",
+        "status": "ACTIVE",
+        "qualification": {"baseOfferIds": ["65304769CA01A12"]},
+        "outcomes": [
+            {
+                "type": "FIXED_DISCOUNT",
+                "discountValues": [{"country": "US", "currency": "USD", "value": 26.0}],
+            }
+        ],
+    }
+
+    create_client_discount_codes([discount], "COM")  # act
+
+    now = dt.datetime(2026, 8, 12, 10, 0, tzinfo=dt.UTC)
+    mocked_discount_code_model.batch_save.assert_called_once_with([mocked_discount_code])
+    mocked_discount_code_model.assert_called_once_with(
+        code="EASTER_26",
+        market_segment="COM",
+        source="Client",
+        name="Easter Flexible Discount",
+        description="Exclusive 26 fixed off on Adobe Technical Communication Suite",
+        adobe_discount_id="55555555-8768-4e8a-9a2f-fb6a6b08f563",
+        category="STANDARD",
+        status="ACTIVE",
+        discount_type="FIXED_DISCOUNT",
+        start_date=dt.datetime(2025, 6, 12, 10, 0, 48, tzinfo=dt.UTC),
+        end_date=dt.datetime(2026, 3, 7, 10, 16, tzinfo=dt.UTC),
+        reusable=False,
+        discount_lock_end_date=None,
+        target_offer_ids="65304769CA",
+        qualifying_offer_ids="",
+        enrichment_status="PENDING",
+        synchronized_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    # One Discount Values row per country of the fixed-type outcome.
+    mocked_discount_value_model.batch_save.assert_called_once_with([mocked_discount_value])
+    mocked_discount_value_model.assert_called_once_with(
+        code="EASTER_26",
+        market_segment="COM",
+        value=26.0,
+        country="US",
+        currency="USD",
+    )
+
+
+@freeze_time("2026-08-12 10:00:00")
+def test_create_client_discount_codes_reusable_intro(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_DISCOUNTS_ID": "discounts-base-id",
+    }
+    mocked_discount_code = mocker.MagicMock()
+    mocked_discount_code_model = mocker.MagicMock(return_value=mocked_discount_code)
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_code_model",
+        return_value=mocked_discount_code_model,
+    )
+    mocked_discount_value_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_value_model",
+        return_value=mocked_discount_value_model,
+    )
+    discount = {
+        "code": "INTRO_10",
+        "category": "INTRO",
+        "status": "ACTIVE",
+        "discountLockEndDate": "2027-03-07T10:16Z",
+        "outcomes": [{"type": "PERCENTAGE_DISCOUNT", "discountValues": [{"value": 10.0}]}],
+    }
+
+    create_client_discount_codes([discount], "COM")  # act
+
+    fields = mocked_discount_code_model.mock_calls[0].kwargs
+    assert fields["reusable"] is True
+    assert fields["discount_lock_end_date"] == dt.datetime(2027, 3, 7, 10, 16, tzinfo=dt.UTC)
+    assert fields["discount_type"] == "PERCENTAGE"
+    # The only order-type enrichment the TDR fixes: INTRO is net-new only.
+    assert fields["applicable_order_types"] == ["NEW"]
+    # A percentage is country-agnostic: a single row without country nor currency.
+    mocked_discount_value_model.assert_called_once_with(
+        code="INTRO_10", market_segment="COM", value=10.0
+    )
+    mocked_discount_value_model.batch_save.assert_called_once()
+
+
+def test_create_client_discount_codes_skips_incomplete_values(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_DISCOUNTS_ID": "discounts-base-id",
+    }
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_code_model",
+        return_value=mocker.MagicMock(),
+    )
+    mocked_discount_value_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_value_model",
+        return_value=mocked_discount_value_model,
+    )
+    discount = {
+        "code": "FIXED_199",
+        "outcomes": [
+            {
+                "type": "FIXED_PRICE",
+                "discountValues": [
+                    {"country": "US", "currency": "USD", "value": 199.0},
+                    {"currency": "EUR", "value": 180.0},
+                    {"country": "GB", "currency": "GBP"},
+                ],
+            },
+            {"type": "FIXED_PRICE"},
+        ],
+    }
+
+    create_client_discount_codes([discount], "COM")  # act
+
+    # Fixed-type values without a country or without an amount are skipped.
+    mocked_discount_value_model.assert_called_once_with(
+        code="FIXED_199", market_segment="COM", value=199.0, country="US", currency="USD"
+    )
+
+
+def test_create_client_discount_codes_without_values(mocker, settings):
+    settings.EXTENSION_CONFIG = {
+        "AIRTABLE_API_TOKEN": "api_key",
+        "AIRTABLE_DISCOUNTS_ID": "discounts-base-id",
+    }
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_code_model",
+        return_value=mocker.MagicMock(),
+    )
+    mocked_discount_value_model = mocker.MagicMock()
+    mocker.patch(
+        "adobe_vipm.airtable.models.get_discount_value_model",
+        return_value=mocked_discount_value_model,
+    )
+
+    create_client_discount_codes([{"code": "NO_VALUES", "outcomes": []}], "COM")  # act
+
+    mocked_discount_value_model.batch_save.assert_not_called()
 
 
 def test_get_transfers_to_process(mocker, settings):

--- a/tests/flows/fulfillment/test_renewal.py
+++ b/tests/flows/fulfillment/test_renewal.py
@@ -16,6 +16,7 @@ from adobe_vipm.flows.fulfillment.renewal import (
     CreateNetNewMptSubscriptions,
     CreateNetNewSubscriptions,
     PreviewRenewal,
+    RecordClientDiscountCodes,
     RecordDiscountRedemptions,
     RecordFlexDiscounts,
     SetupRenewalPlan,
@@ -1021,6 +1022,126 @@ def test_record_discount_redemptions_step_airtable_error(mocker, mock_mpt_client
     mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
 
 
+def test_record_client_discount_codes_step(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.market_segment = "COM"
+    renewal_context.adobe_customer = {"companyProfile": {"address": {"country": "US"}}}
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["CODE-1", "CODE-2"]),
+    ]
+    mocked_get_existing_codes = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.get_existing_discount_codes",
+        return_value={"CODE-1"},
+    )
+    adobe_discount = {"code": "CODE-2", "status": "ACTIVE"}
+    mock_adobe_client.get_flex_discounts_by_code.return_value = [adobe_discount]
+    mocked_create_client_codes = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_client_discount_codes",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordClientDiscountCodes()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mocked_get_existing_codes.assert_called_once_with(["CODE-1", "CODE-2"], "COM")
+    mock_adobe_client.get_flex_discounts_by_code.assert_called_once_with(
+        "authorization-id", "COM", "US", "CODE-2"
+    )
+    mocked_create_client_codes.assert_called_once_with([adobe_discount], "COM")
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_record_client_discount_codes_step_all_codes_known(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.market_segment = "COM"
+    renewal_context.adobe_customer = {"companyProfile": {"address": {"country": "US"}}}
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["CODE-1"]),
+    ]
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.get_existing_discount_codes",
+        return_value={"CODE-1"},
+    )
+    mocked_create_client_codes = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_client_discount_codes",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordClientDiscountCodes()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mock_adobe_client.get_flex_discounts_by_code.assert_not_called()
+    mocked_create_client_codes.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_record_client_discount_codes_step_without_codes(mocker, mock_mpt_client, renewal_context):
+    renewal_context.renewal_plan_subscriptions = [plan_entry()]
+    mocked_get_existing_codes = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.get_existing_discount_codes",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordClientDiscountCodes()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mocked_get_existing_codes.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_record_client_discount_codes_step_code_unknown_to_adobe(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.market_segment = "COM"
+    renewal_context.adobe_customer = {"companyProfile": {"address": {"country": "US"}}}
+    renewal_context.renewal_plan_subscriptions = [
+        plan_entry(flex_discount_codes=["CODE-1"]),
+    ]
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.get_existing_discount_codes",
+        return_value=set(),
+    )
+    mock_adobe_client.get_flex_discounts_by_code.return_value = [{"code": "OTHER-CODE"}]
+    mocked_create_client_codes = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.create_client_discount_codes",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordClientDiscountCodes()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mocked_create_client_codes.assert_not_called()
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
+def test_record_client_discount_codes_step_airtable_error(
+    mocker, mock_adobe_client, mock_mpt_client, renewal_context
+):
+    renewal_context.market_segment = "COM"
+    renewal_context.adobe_customer = {"companyProfile": {"address": {"country": "US"}}}
+    renewal_context.renewal_plan_subscriptions = [plan_entry(flex_discount_codes=["CODE-1"])]
+    mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.get_existing_discount_codes",
+        side_effect=Exception("airtable is down"),
+    )
+    mocked_send_exception = mocker.patch(
+        "adobe_vipm.flows.fulfillment.renewal.send_exception",
+    )
+    mocked_next_step = mocker.MagicMock()
+    step = RecordClientDiscountCodes()
+
+    step(mock_mpt_client, renewal_context, mocked_next_step)  # act
+
+    mocked_send_exception.assert_called_once()
+    notification_text = mocked_send_exception.mock_calls[0].args[1]
+    assert "customer-id" in notification_text
+    assert renewal_context.order_id in notification_text
+    assert "CODE-1" in notification_text
+    mocked_next_step.assert_called_once_with(mock_mpt_client, renewal_context)
+
+
 def test_fulfill_renewal_order(mocker):
     mocked_pipeline_instance = mocker.MagicMock()
     mocked_pipeline_ctor = mocker.patch(
@@ -1051,6 +1172,7 @@ def test_fulfill_renewal_order(mocker):
         CreateNetNewMptSubscriptions,
         RecordFlexDiscounts,
         CompleteOrder,
+        RecordClientDiscountCodes,
         RecordDiscountRedemptions,
         SetSubscriptionTemplate,
         SyncAgreement,

--- a/tests/flows/fulfillment/test_renewal_now.py
+++ b/tests/flows/fulfillment/test_renewal_now.py
@@ -15,6 +15,7 @@ from adobe_vipm.flows.constants import TEMPLATE_NAME_CHANGE
 from adobe_vipm.flows.context import Context
 from adobe_vipm.flows.fulfillment.renewal import (
     CreateNetNewMptSubscriptions,
+    RecordClientDiscountCodes,
     RecordDiscountRedemptions,
     Validate3YCRenewalFloor,
 )
@@ -1571,6 +1572,7 @@ def test_fulfill_renewal_now_order(mocker):
         NormalizeRenewedSubscriptions,
         DisableLapsingSubscriptions,
         CompleteOrder,
+        RecordClientDiscountCodes,
         RecordDiscountRedemptions,
         SetSubscriptionTemplate,
         SyncAgreement,


### PR DESCRIPTION
…e store on first successful use (W2.13)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds `RecordClientDiscountCodes` to store previously unknown, successfully redeemed Adobe flex discount codes in Airtable.
- Adds Adobe flex discount lookup by discount code.
- Updates renewal and renewal-now fulfillment flows to persist client discount codes before recording redemptions.
- Adds Airtable discount model helpers, mappings, filtering, and value creation logic.
- Adds tests for Adobe lookup, Airtable persistence, and fulfillment flow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->